### PR TITLE
fix: use u64::MAX as default Solana outbound limit

### DIFF
--- a/cli/src/constants.ts
+++ b/cli/src/constants.ts
@@ -1,0 +1,2 @@
+/** u64::MAX -- effectively unlimited, consistent with EVM and Sui defaults. */
+export const U64_MAX = 2n ** 64n - 1n;

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -18,6 +18,7 @@ import { AddressLookupTableAccount, Connection, Keypair, PublicKey, SendTransact
 import * as spl from "@solana/spl-token";
 import fs from "fs";
 import path from "path";
+import { U64_MAX } from "./constants.js";
 import readline from "readline";
 import { ChainContext, UniversalAddress, Wormhole, assertChain, canonicalAddress, chainToPlatform, chains, isNetwork, networks, platforms, signSendWait, toUniversal, type AccountAddress, type Chain, type ChainAddress, type Network, type Platform } from "@wormhole-foundation/sdk";
 import { Transaction } from "@mysten/sui/transactions";
@@ -2827,7 +2828,7 @@ async function deploySolana<N extends Network, C extends SolanaChains>(
             {
                 mint: new PublicKey(token),
                 mode,
-                outboundLimit: 100000000n,
+                outboundLimit: U64_MAX,
                 ...(mode === "burning" && !mint.mintAuthority!.equals(tokenAuthority) && {
                     multisigTokenAuthority: mint.mintAuthority!,
                 }),


### PR DESCRIPTION
## Summary

- Aligns the Solana NTT deploy outbound limit with EVM and Sui which both default to `u64::MAX` (effectively unlimited)
- Previously Solana hardcoded `100000000n` (~1 token for 8-decimal SPL tokens), while EVM and Sui used `u64::MAX`
- Extracts `U64_MAX` constant into `cli/src/constants.ts` for reuse and testability

## Context

When running `ntt add-chain` for a Solana chain, the outbound rate limit was set to `100000000n` (1 token with 8 decimals), whereas EVM sets `type(uint64).max * scale` in the forge deploy script and Sui sets `u64::MAX` in `state.move`. This inconsistency caused unexpectedly restrictive rate limits on Solana deployments.

The Solana rate limiter Rust code already handles `u64::MAX` safely via `u128` intermediate calculations (`rate_limit.rs:61-86`).

## Test plan

- [x] Added `cli/__tests__/solanaDefaults.test.ts` validating `U64_MAX == 2^64 - 1`
- [ ] Verify existing CLI tests still pass
- [ ] Manual verification: deploy a Solana NTT and confirm outbound limit is set to `u64::MAX`