### PR TITLE
canton: bind NTT custody to guardianGovernance (unlock needs its fresh authority)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,5 @@ node_modules
 .wormhole
 
 # Claude code
+.claude/
 .claude/settings.local.json

--- a/canton/ntt-cip56/daml/Wormhole/Ntt/TokenCip56.daml
+++ b/canton/ntt-cip56/daml/Wormhole/Ntt/TokenCip56.daml
@@ -53,18 +53,35 @@ requireRegistryCid msg = \case
 -- lock / unlock via the transfer factory
 ----------------------------------------------------------------------
 
+-- | The unlock (lock/unlock) hook. @custody@ is the party that holds locked
+-- funds between send and receive; the unlock moves them @custody -> recipient@.
+--
+-- @custody@ is NOT a signatory of this token. That is the security property:
+-- 'TransferFactory_Transfer' is @controller transfer.sender@ and the unlock's
+-- @sender = custody@, so moving custody funds needs @custody@'s authority IN the
+-- transaction. By keeping @custody@ out of the signatories, that authority can
+-- only be supplied FRESH at submission (as a 'MintOrUnlock' co-controller, via
+-- the view's @custodian@), never delegated by this contract. In production
+-- @custody@ is the guardian-governance party, whose external quorum-gated signer
+-- only co-signs a valid-VAA 'NttManager.Receive'; so the operator/manager alone
+-- cannot move custody funds through any choice.
+--
+-- Residual (follow-up, not fixed here): a participant that actually holds
+-- @custody@'s raw @actAs@ could co-sign a bare drain, or submit a direct Amulet
+-- transfer outside NTT. Full trustlessness requires @custody@ to be an external
+-- party whose off-ledger signer only co-signs VAA-verified transactions.
 template Cip56CustodyToken
   with
     admin              : Party                        -- token registry admin (backs transfers)
     manager            : Party                        -- NTT operator that drives the seam
-    custody            : Party                        -- holds locked funds between send/receive
+    custody            : Party                        -- holds locked funds between send/receive; supplies fresh unlock authority
     instrumentId       : InstrumentId
   where
     signatory admin
     observer manager
 
     interface instance NttToken for Cip56CustodyToken where
-      view = NttTokenView with admin, manager, mode = LockUnlock
+      view = NttTokenView with admin, manager, mode = LockUnlock, custodian = Some custody
 
       -- Lock: sender -> custody. Must settle synchronously (Completed); a
       -- Pending/Failed result means the tokens never reached custody.
@@ -138,7 +155,7 @@ template Cip56BurnMintToken
     observer manager
 
     interface instance NttToken for Cip56BurnMintToken where
-      view = NttTokenView with admin, manager, mode = BurnMint
+      view = NttTokenView with admin, manager, mode = BurnMint, custodian = None
 
       -- Burn: spend the sender's holdings for exactly the wire amount, returning change.
       lockOrBurnImpl sender amount inputHoldingCids registryCid extraArgs = do

--- a/canton/ntt-token/daml/Wormhole/Ntt/Token.daml
+++ b/canton/ntt-token/daml/Wormhole/Ntt/Token.daml
@@ -19,6 +19,7 @@
 -- per call, the same as every other cid here; never a Daml contract key).
 module Wormhole.Ntt.Token where
 
+import DA.Optional (optionalToList)
 import Splice.Api.Token.HoldingV1 (Holding, InstrumentId)
 import Splice.Api.Token.MetadataV1 (AnyContractId, ExtraArgs (..), emptyChoiceContext, emptyMetadata)
 
@@ -63,11 +64,21 @@ untrimAmount ta toDecimals =
     else ta.amount / tenPow (ta.decimals - toDecimals)
 
 -- | The view of an 'NttToken' hook: the token admin (whose authority it carries),
--- the manager party that drives it, and the mode.
+-- the manager party that drives it, the mode, and — for custody (lock/unlock)
+-- kinds — the @custodian@ that holds locked funds.
+--
+-- @custodian@ is a required co-controller of 'MintOrUnlock' (see below). It is
+-- deliberately NOT a signatory of the token: the unlock spends the custodian's
+-- own holdings ('TransferFactory_Transfer' is @controller transfer.sender@, and
+-- @sender = custodian@), so the custodian's authority must be supplied FRESH at
+-- submission rather than delegated by the token contract. A delegated custodian
+-- authority is exactly what would let the manager drain custody without a VAA.
+-- 'None' for kinds that mint fresh holdings (burn/mint) and so have no custodian.
 data NttTokenView = NttTokenView with
-    admin   : Party
-    manager : Party
-    mode    : TokenMode
+    admin     : Party
+    manager   : Party
+    mode      : TokenMode
+    custodian : Optional Party
   deriving (Eq, Show)
 
 -- | Empty 'ExtraArgs', for callers/impls that need no registry context.
@@ -153,9 +164,15 @@ interface NttToken where
     controller (view this).manager, sender
     do lockOrBurnImpl this sender amount inputHoldingCids registryCid extraArgs
 
-  -- Manager-only, so a relayer can drive a receive while the recipient is
-  -- offline. The recipient's signature is not supplied here — for owner-signed
-  -- kinds it comes from the standing 'DepositPreapproval' passed in.
+  -- Controlled by the manager and, for custody kinds, the @custodian@ (from the
+  -- view). Burn/mint kinds have no custodian, so the controller is just the
+  -- manager and a relayer can drive the mint while the recipient is offline (the
+  -- recipient's signature comes from the standing 'DepositPreapproval' passed
+  -- in). Custody kinds additionally require the custodian's FRESH authority: the
+  -- unlock spends the custodian's holdings, so its authority cannot be delegated
+  -- by the token contract (that would let the manager drain custody without a
+  -- VAA). In production the custodian is the guardian-governance party, whose
+  -- external quorum-gated signer only co-signs a valid-VAA 'NttManager.Receive'.
   nonconsuming choice MintOrUnlock : ()
     with
       recipient             : Party
@@ -164,7 +181,7 @@ interface NttToken where
       depositPreapprovalCid : Optional (ContractId DepositPreapproval)
       registryCid           : Optional AnyContractId
       extraArgs             : ExtraArgs
-    controller (view this).manager
+    controller (view this).manager :: optionalToList (view this).custodian
     do mintOrUnlockImpl this recipient amount inputHoldingCids depositPreapprovalCid registryCid extraArgs
 
   -- | Recipient opt-in, done once before the first inbound transfer. @user@

--- a/canton/ntt/daml/Wormhole/Ntt/Manager.daml
+++ b/canton/ntt/daml/Wormhole/Ntt/Manager.daml
@@ -239,6 +239,17 @@ template NttManager
     -- signed). This permanently binds the VAA to that Party id; a recipient needing
     -- a different party requires a re-send.
     --
+    -- Controller: the @executor@ (any relayer) and, for the custody
+    -- ('LockUnlock') mode, the @guardianGovernance@ custodian. Burn/mint mints
+    -- fresh holdings and stays fully permissionless. A custody unlock moves the
+    -- custodian's own holdings, so 'MintOrUnlock' requires the custodian's fresh
+    -- authority (it is not a signatory anywhere); requiring @guardianGovernance@
+    -- here is what threads that authority into the VAA-gated body. In production
+    -- @guardianGovernance@ is an external, quorum-gated signer that only co-signs
+    -- a valid-VAA receive — so the operator alone can never move custody funds.
+    -- (Residual: a participant holding @guardianGovernance@'s raw @actAs@ could
+    -- co-sign; the external-signer requirement is the follow-up.)
+    --
     -- @pubKeys@ are untrusted hints (hint-free verification is a follow-up, §11).
     nonconsuming choice Receive : NativeTokenTransfer
       with
@@ -252,7 +263,7 @@ template NttManager
         depositPreapprovalCid : Optional (ContractId DepositPreapproval)  -- recipient consent (owner-signed kinds)
         registryCid           : Optional AnyContractId -- registry's current factory, resolved off-ledger
         extraArgs             : ExtraArgs             -- CIP-56 choice context
-      controller executor
+      controller executor :: (if mode == LockUnlock then [guardianGovernance] else [])
       do
         -- Authenticate the guardian trust root before verifying against it.
         csGg <- exercise coreStateCid GetGuardianGovernance with reader = executor

--- a/canton/test/daml/Test/TestNtt.daml
+++ b/canton/test/daml/Test/TestNtt.daml
@@ -268,6 +268,97 @@ testCustodyLockPendingRejected = do
     Left err -> abort ("expected a synchronous-settle failure, got: " <> show err)
     Right _ -> abort "pending lock succeeded: tokens were never moved to custody"
 
+----------------------------------------------------------------------
+-- Guardian-governance custody: the unlock moves the custodian's funds and
+-- therefore needs the custodian's FRESH authority (it is not a signatory of
+-- the token). These tests use custody = a dedicated 'guardianGovernance' party.
+--
+-- The locked custody funds are pre-created directly (mkHolding, which needs
+-- the custodian's one-time authority) to represent the resting state a real
+-- lock produces. A real lock TO a third-party custody can't be driven through
+-- the owner-signed 'Cip56MockHolding' mock (creating the custodian's holding
+-- would need its authority at lock time; production supplies that via the
+-- custodian's registry-level TransferPreapproval, unmodeled here) — the same
+-- reason 'testCustodyLockCompletedSucceeds' keeps custody = admin.
+----------------------------------------------------------------------
+
+-- | Disclose the (admin-signed, observer manager) custody token so a non-admin
+-- submitter can exercise 'MintOrUnlock' on it.
+discloseCustodyToken : Party -> Script Disclosure
+discloseCustodyToken admin = do
+  [(cid, _)] <- query @Cip56CustodyToken admin
+  fromSome <$> queryDisclosure admin cid
+
+-- | Positive: an unlock submitted WITH the guardianGovernance custodian's
+-- authority moves custody funds to the recipient while the recipient is offline.
+-- Submitted as @manager <> guardianGovernance@ (no admin actAs — the admin's
+-- authority is delegated by the admin-signed token/factory), so the ONLY fresh
+-- signature is the custodian's. @recipient = admin@ keeps the recipient offline:
+-- its owner-signed holding is created under the factory's admin authority (a
+-- distinct third-party recipient would need its own registry pre-approval, as
+-- noted above).
+testCustodyUnlockWithGuardianGovernanceSucceeds : Script ()
+testCustodyUnlockWithGuardianGovernanceSucceeds = do
+  admin <- allocateParty "CustodyUnlockAdmin"
+  manager <- allocateParty "CustodyUnlockManager"
+  guardianGovernance <- allocateParty "CustodyUnlockGg"
+  let custody = guardianGovernance
+      recipient = admin
+      instrumentId = InstrumentId with admin, id = "LOCK"
+  (tokenCid, factoryCid) <- mkCustodyToken admin manager custody instrumentId False
+  custodyHolding <- mkHolding admin custody instrumentId 0.01
+  dTok <- discloseCustodyToken admin
+  dFactory <- discloseTransferFactory admin
+
+  _ <- submit (actAs manager <> actAs guardianGovernance <> disclose dTok <> disclose dFactory) do
+    exerciseCmd tokenCid MintOrUnlock with
+      recipient
+      amount = TrimmedAmount with decimals = 8, amount = 1_000_000
+      inputHoldingCids = [custodyHolding]
+      depositPreapprovalCid = None
+      registryCid = someRegistryCid factoryCid
+      extraArgs = emptyExtraArgs
+
+  custodyRemaining <- cip56HoldingsOwnedBy admin custody
+  custodyRemaining === []
+  recipientHoldings <- cip56HoldingsOwnedBy admin recipient
+  case recipientHoldings of
+    [(_, h)] -> h.amount === 0.01
+    _ -> abort ("expected exactly one holding unlocked to the recipient, got: " <> show recipientHoldings)
+
+-- | NEGATIVE (the key one): the manager (== operator) alone CANNOT unlock custody
+-- funds. 'MintOrUnlock' on a custody token requires the guardianGovernance
+-- custodian as a co-controller, and the custodian is not a signatory anywhere,
+-- so there is no delegated authority for the manager to ride on. Everything else
+-- is disclosed (token, factory, and the custody holding), so the submission fails
+-- for exactly one reason: the missing custodian authority. This closes the
+-- operator-as-custodian hole at the contract level.
+testCustodyUnlockWithoutGuardianGovernanceFails : Script ()
+testCustodyUnlockWithoutGuardianGovernanceFails = do
+  admin <- allocateParty "CustodyDrainAdmin"
+  manager <- allocateParty "CustodyDrainManager"
+  guardianGovernance <- allocateParty "CustodyDrainGg"
+  let custody = guardianGovernance
+      recipient = admin
+      instrumentId = InstrumentId with admin, id = "LOCK"
+  (tokenCid, factoryCid) <- mkCustodyToken admin manager custody instrumentId False
+  custodyHolding <- mkHolding admin custody instrumentId 0.01
+  dTok <- discloseCustodyToken admin
+  dFactory <- discloseTransferFactory admin
+  -- Disclose the custody holding to the manager too, so visibility is not the
+  -- reason this fails — only the missing custodian authority is.
+  [(concreteHolding, _)] <- cip56HoldingsOwnedBy admin custody
+  dHolding <- fromSome <$> queryDisclosure admin concreteHolding
+
+  submitMustFail (actAs manager <> disclose dTok <> disclose dFactory <> disclose dHolding) do
+    exerciseCmd tokenCid MintOrUnlock with
+      recipient
+      amount = TrimmedAmount with decimals = 8, amount = 1_000_000
+      inputHoldingCids = [custodyHolding]
+      depositPreapprovalCid = None
+      registryCid = someRegistryCid factoryCid
+      extraArgs = emptyExtraArgs
+
 -- | Fix 1: a genuinely owner-signed sender ('alice', distinct from admin and
 -- manager) drives a real burn. 'Cip56MockHolding' is signatory @admin, owner@,
 -- so archiving alice's holding needs her live authority; that authority only
@@ -860,6 +951,74 @@ testNttReceivePinsGuardianGovernance = do
         ("committed guardian trust anchor" `isInfixOf` fs.message)
     Left err -> abort ("expected a guardian-governance pin failure, got: " <> show err)
     Right _ -> abort "Receive accepted a forged CoreState under a throwaway gg"
+
+-- | Stand up a custody ('LockUnlock') deployment whose @managerAddress@ is the
+-- fixture's recipientManager (0x..aa), so a relay gets past the manager/peer
+-- checks to the recipient-binding step. custody = @guardianGovernance@.
+setupCustodyReceiveManager : Party -> Party -> Party -> Script (ContractId NttManager)
+setupCustodyReceiveManager operator guardianGovernance admin = do
+  let instrumentId = bridgedInstrument admin
+  _ <- submit admin do createCmd MockTransferFactory with admin, pending = False
+  tokenConcrete <- submit admin do
+    createCmd Cip56CustodyToken with admin, manager = operator, custody = guardianGovernance, instrumentId
+  let tokenCid = toInterfaceContractId @NttToken tokenConcrete
+  mgrId <- submit (actAs operator <> actAs admin) do
+    createCmd NttManager with
+      operator
+      admin
+      guardianGovernance
+      managerId = 998
+      managerAddress = b32 "aa"
+      transceiverEmitterId = 998
+      tokenCid
+      mode = LockUnlock
+      tokenDecimals = 8
+      peers = Map.empty
+      outboundSequence = 0
+  mgrId <- submit admin do
+    exerciseCmd mgrId SetPeer with
+      chainId = 2
+      peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc"
+  _ <- registerReplayRoot operator admin defaultSplitThreshold
+  pure mgrId
+
+-- | NEGATIVE at the Receive layer: a custody ('LockUnlock') 'Receive' requires
+-- @guardianGovernance@'s fresh co-signature. The operator (== executor here)
+-- alone cannot drive it — even with a valid VAA. Adding @guardianGovernance@
+-- clears that controller gate, and the same relay then fails only on the
+-- recipient binding (a fresh party can't match the fixture VAA), proving the
+-- one thing operator-alone lacked was the custodian's authority.
+testCustodyReceiveRequiresGuardianGovernance : Script ()
+testCustodyReceiveRequiresGuardianGovernance = do
+  (operator, guardianGovernance, csId) <- nttSetup
+  admin <- allocateParty "CustodyRecvAdmin"
+  wrongRecipient <- allocateParty "CustodyRecvWrong"
+  mgrId <- setupCustodyReceiveManager operator guardianGovernance admin
+  (nodeCid, _) <- coveringDisclosure operator admin nttTransferDigest
+
+  let doReceive = exerciseCmd mgrId Receive with
+        executor = operator
+        coreStateCid = csId
+        replayNodeCid = nodeCid
+        vaaBytes = nttTransferVAA
+        pubKeys = [(0, devnetGuardianPubKey)]
+        recipient = wrongRecipient
+        inputHoldingCids = []
+        depositPreapprovalCid = None
+        registryCid = None
+        extraArgs = emptyExtraArgs
+
+  -- Operator alone: rejected — the custody Receive requires gg as a controller.
+  submitMustFail operator do doReceive
+
+  -- With gg co-signing: clears the gate, fails only on the recipient binding.
+  res <- trySubmit (actAs operator <> actAs guardianGovernance) do doReceive
+  case res of
+    Left (FailureStatusError fs) ->
+      assertMsg ("expected a recipient-binding failure, got: " <> fs.message)
+        ("recipient does not match" `isInfixOf` fs.message)
+    Left err -> abort ("expected a recipient-binding failure, got: " <> show err)
+    Right _ -> abort "custody Receive succeeded with a mismatched recipient"
 
 ----------------------------------------------------------------------
 -- Receive (matching recipient), live two-step harness


### PR DESCRIPTION
## Security fix: custody moves only with the guardian-governance party's fresh authority

Today the CIP-56 custody party is effectively the operator/admin, so the operator can move the locked funds. This binds custody to the `guardianGovernance` party and enforces, at the contract level, that **no operator-drivable choice can move custody funds** — the custodian's authority must be supplied fresh in the transaction.

### What is now contract-enforced
- **`NttToken`** gains a `custodian` view field. `MintOrUnlock` is now controlled by `manager :: optionalToList custodian` — for custody kinds that is `[manager, custodian]`, so the unlock requires the custodian's authority as a co-controller. Burn/mint kinds have `custodian = None` and are unchanged (`[manager]`).
- **`Cip56CustodyToken`** stays `signatory admin`. The custodian is **deliberately not a signatory** of the token (or of anything). The unlock spends the custodian's own holdings (`TransferFactory_Transfer` is `controller transfer.sender`, and `sender = custody`), so the custodian's authority must come **fresh at submission** and can never be *delegated* by the token contract. A delegated custodian authority is exactly what would let the manager exercise `MintOrUnlock` directly and drain custody with no VAA.
- **`NttManager.Receive`** additionally requires `guardianGovernance` as a controller when `mode == LockUnlock`. Burn/mint `Receive` stays fully permissionless (executor only). This threads the custodian's fresh authority into the VAA-gated body, so the only on-ledger NTT path that moves custody funds is `Receive` (which already runs `VerifyAndConsumeVAA` + the recipient-binding check before `MintOrUnlock`).

The net effect: the operator (== manager) alone cannot move custody funds through any manager choice. Release requires the guardian-governance party's co-signature, whose external, quorum-gated signer only co-signs a valid-VAA `Receive`.

### Why this is the right shape (a note on Daml authority)
Submitter `actAs` authority does **not** propagate into nested exercise bodies — a choice body's authorizers are exactly `signatories(contract) ∪ actors(choice)`. So requiring the custodian only "in the submitting party set" would not authorize the unlock, and making the custodian a *signatory* would re-open the drain (the manager could ride the delegated authority via a direct `MintOrUnlock`). Requiring the custodian as a fresh **controller** of the unlock path — and keeping it out of every signatory set — is what makes "release only via a valid guardian-signed VAA" true at the contract level.

### Residual / follow-up (NOT fixed here)
This binds the on-ledger NTT path, but it does not stop a participant that actually holds `guardianGovernance`'s raw `actAs` from co-signing a bare drain, or from submitting a direct Amulet transfer outside the NTT manager. Full trustlessness requires `guardianGovernance` to be an **external party whose off-ledger signer only co-signs VAA-verified transactions**. That external-signer work is the remaining follow-up and is called out in the module docs.

### Tests (`Test.TestNtt`, Daml Script)
- `testCustodyUnlockWithGuardianGovernanceSucceeds` — an unlock submitted with the custodian's fresh authority moves custody funds to the recipient with the recipient offline.
- `testCustodyUnlockWithoutGuardianGovernanceFails` — the manager (== operator) alone cannot `MintOrUnlock`; it fails for the missing custodian authority (token, factory, and holding all disclosed, so authority is the only variable).
- `testCustodyReceiveRequiresGuardianGovernance` — the operator alone cannot drive a custody-mode `Receive`; adding `guardianGovernance` clears the controller gate and the same relay then fails only on the recipient binding, proving the custodian's authority was the only missing ingredient.

`dpm build --all` and `dpm test` are green (51 scripts pass).

### Note on the test mock
The CIP-56 test mock (`Cip56MockHolding`, `signatory admin, owner`) requires the receiver's authority to *create* a holding, so a real lock to a third-party custody can't be driven through it (production supplies the receiver's authority via a registry-level `TransferPreapproval`). The shared send/flow deploy therefore keeps `custody = admin`; the custody-party separation and the unlock authority model are proven directly by the dedicated tests above, which pre-fund the guardian-governance custody holding (the resting locked state).

> Note: a sibling PR (#41) also edits the custody token; merge conflicts there are expected.
