### PR TITLE
canton: Claude NTT standard compliance audit

### DIFF
--- a/audits/canton/2026-07-23-internal-canton-ntt-compliance-evaluation.md
+++ b/audits/canton/2026-07-23-internal-canton-ntt-compliance-evaluation.md
@@ -1,0 +1,295 @@
+# NTT Canton Implementation — Compliance Evaluation
+
+Date: 2026-07-23. Audited commit: `c41edbf6cb97499fd39933a542c798a0981492f4`
+("canton: enforce reserve coverage on admin handoff and exact registry delivery"),
+the tip of branch `canton/ntt-cip56-rework` at the time of evaluation. All file and
+line references are as of that commit.
+
+Scope: functional wire/mesh compatibility with
+the NTT standard, the 29 security invariants in `docs/INVARIANTS.md`, and access
+control. Method: six parallel deep-readers mapped the Canton code, the EVM/Solana/Sui
+reference, the wire formats and their test vectors, and the mesh-integration surface;
+each load-bearing claim was then adversarially re-verified against the actual code
+(13 verifiers, each trying to refute its finding), and the wire codec was checked
+empirically by porting the reference deserialization vectors into Daml
+(`canton/test/daml/Test/TestNttVectors.daml`, 66/66 tests pass).
+
+## Bottom line
+
+The implementation is a faithful, security-sound port of NTT to Canton's model. The
+wire codec is byte-identical to the reference for the canonical cross-runtime message,
+so a Canton deployment can join an existing EVM/Solana NTT mesh at the protocol level.
+No fund-theft, inflation, forgery, or double-spend path was found. The gaps are three
+substantive ones (all medium) and a set of low/cosmetic divergences; none is a
+correctness hole, but two affect real deployments.
+
+The three that matter:
+
+1. **No Wormhole chain id for Canton** — a launch-coordination prerequisite, not a code
+   defect. Nothing in the contracts hardcodes a chain id; the tooling and guardian
+   watcher need an assignment before a real mesh connection is possible.
+2. **Outbound amount trimming ignores the peer's decimals** — sends to a peer whose
+   token has fewer than 8 decimals silently lose the sender's dust at the destination.
+   Deflationary only (never inflation or theft), but real value loss.
+3. **No pause / emergency-halt, and burn/mint mint has no cap** — the reference treats
+   pause as a core safety feature; Canton has no first-class halt, and a compromised
+   peer chain plus a guardian-signed VAA can mint unboundedly in burn/mint mode.
+
+Everything else is either subsumed by another mechanism, an intended design tradeoff, or
+informational.
+
+---
+
+## 1. Functional compatibility and mesh integration
+
+### Wire format: compatible (empirically verified)
+
+Canton encodes the three nested NTT structures exactly as the spec and the reference
+implementations do:
+
+- `NativeTokenTransfer`: `0x994E5454 ‖ decimals(1) ‖ amount(8) ‖ sourceToken(32) ‖
+  recipientAddress(32) ‖ recipientChain(2) [‖ additionalPayloadLen(2) ‖ payload]`
+- `NttManagerMessage`: `id(32) ‖ sender(32) ‖ payloadLen(2) ‖ payload`
+- `WormholeTransceiverMessage`: `0x9945FF10 ‖ sourceManager(32) ‖ recipientManager(32)
+  ‖ mgrPayloadLen(2) ‖ mgrPayload ‖ xcvrPayloadLen(2) ‖ xcvrPayload`
+
+The ported test `testVectorTransceiverMessage1` proves Canton's encoder produces
+byte-for-byte the shared 217-byte `evm/test/payloads/transceiver_message_1.txt` vector
+(the one EVM, Solana, and the TS SDK all consume) and its decoder round-trips it. The
+optional `additionalPayload` extension and the non-canonical explicit-zero-length form
+both behave exactly as the reference: accepted on decode, never emitted on encode.
+
+Two encoder/decoder divergences, both benign (details in §5): decoders tolerate trailing
+bytes where EVM enforces exact length (not reachable as an exploit because the VAA is
+guardian-signed and replay keys on the VAA hash), and the `sender` field carries the
+manager address rather than the originating user.
+
+### The transceiver is a core Emitter
+
+The "Wormhole transceiver" on Canton is a core Wormhole `Emitter`. A send is an ordinary
+`Emitter.PublishMessage`; the guardian watcher observes a normal core message, so there
+is no NTT-specific watcher code. Inbound, Canton consumes standard VAAs via the core
+`VerifyAndConsumeVAA`. This is the cleanest possible fit with the existing guardian
+infrastructure.
+
+### How to connect Canton to an existing mesh
+
+Per peer chain, four data cross the boundary:
+
+- **On the EVM peer** (`onlyOwner`): `NttManager.setPeer(cantonChainId,
+  cantonManagerAddress, cantonTokenDecimals, inboundLimit)` and
+  `WormholeTransceiver.setWormholePeer(cantonChainId, cantonTransceiverAddress)`.
+- **On the Canton side** (`controller admin`): `SetPeer{chainId, Peer{managerAddress,
+  transceiverAddress}}` — one choice registers both the peer manager and peer
+  transceiver (EVM splits these across two contracts).
+
+Canton's two 32-byte identities are keccak hashes bound to the stable `namespace` party
+(so they survive admin handoff):
+
+- `managerAddress = keccak256("wormhole:ntt-manager:v1" ‖ operator ‖ namespace ‖ managerId)`
+  — stored on-ledger, this is the peer address EVM registers and checks as `sourceManager`.
+- `transceiverAddress = keccak256("wormhole:emitter:v1" ‖ operator ‖ namespace ‖ emitterId)`
+  — derived off-ledger by the watcher, this is the VAA `emitterAddress` EVM checks.
+
+### What does not fit the standard model
+
+- **No assigned Wormhole chain id** (Finding F3, medium). Grep of `sdk/` and `cli/` finds
+  zero Canton references; `@wormhole-foundation/sdk-base` has no Canton entry; tests use
+  `72` as a placeholder. Without an assignment, guardians cannot stamp `emitterChain`,
+  peers cannot be registered, and the SDK cannot represent the chain. The contracts
+  themselves are chain-id-agnostic (no hardcoded id), so no contract change is needed once
+  an id is assigned — only test vectors that bake in `72` would need regeneration.
+- **No SDK / CLI / Connect / executor support.** No Canton platform module exists;
+  the CLI switches cover only Evm/Solana/Sui. Canton's submission model (Ledger API
+  `actAs` parties + explicit disclosed contracts) matches none of the existing signer
+  abstractions. Inbound delivery is permissionless but operationally heavy: a relayer
+  needs an off-ledger disclosure index (manager, CoreState, replay node; ledger + custody
+  pot for lock/unlock; deposit pre-approval + factory for burn/mint).
+- **Single transceiver vs manager-global threshold** (F4, low). Canton has exactly one
+  transceiver (implicit 1-of-1). Because the EVM threshold is manager-global, an existing
+  multi-transceiver EVM deployment cannot add Canton without dropping global threshold to
+  1 — a real deployment constraint, liveness only, no theft. Canton's attestation security
+  equals the guardian set, the same trust as a threshold-1 Wormhole-only EVM deployment.
+- **No `TransceiverInit` / `TransceiverRegistration` broadcasts** (F5, low). Canton emits
+  neither. These are consumed only by off-chain NTT Global Accountant bookkeeping; the
+  standard treats them as opt-in (Solana/Sui do not emit them automatically). Transfers
+  work without them; only accountant discovery is affected, and the namespace can publish
+  the payloads manually via its Emitter if needed.
+- **Recipient binding is a one-way hash of the party id.** A Canton `Party` has no
+  fixed-size form, so the sender hashes it into the 32-byte `recipientAddress`. The binding
+  is permanent: a recipient who loses the party (key loss, custodial migration) needs a
+  re-send. Mint additionally requires a standing self-signed `DepositPreapproval`.
+- **`additionalPayload` is always empty outbound and ignored inbound** — no integrator
+  additional-payload hook.
+
+---
+
+## 2. Security invariants (INV-001 .. INV-029)
+
+### Supply conservation and double-spend
+
+- **INV-001 (supply conservation)** — Held, with one caveat. Lock/unlock is capped by the
+  per-deployment `LockedLedger` (`Debit` rejects amounts above balance), so a deployment
+  can release at most what it locked. Burn/mint burns exactly the wire amount and mints the
+  received amount. Caveat: the decimals divergence (F2) makes cross-decimal transfers
+  strictly deflationary — the destination can credit less than the source removed — never
+  inflationary.
+- **INV-002 (no double-spend)** — Held. Each VAA digest is consumed atomically in the
+  replay trie. Scope is per-namespace, not per-manager (F8); adversarial analysis confirms
+  no cross-manager double-spend, because the digest is bound to a unique `recipientManager`
+  and a mismatch aborts and rolls back the consumption in the same Daml transaction.
+
+### Message integrity
+
+- **INV-003 (authentication)** — Held. Every inbound movement first pins the `CoreState`
+  to the committed `guardianGovernance` (a compromised operator cannot forge the real gg's
+  signature), then verifies guardian signatures via the core.
+- **INV-004/005 (ordering / sequence reuse)** — Held via the Emitter sequence (message id =
+  the transceiver's next sequence, unique per transceiver).
+- **INV-006 (hash integrity)** — Held. Replay keys on the VAA hash over the exact signed
+  bytes. Decoder trailing-byte tolerance (F7) does not weaken this: appending bytes breaks
+  the guardian signature, and Canton re-derives no digest from decoded content.
+- **INV-019 (chain id validation)** — Outbound half held (peer lookup by `recipientChain`).
+  Inbound half absent (F1): `verifyInboundTransfer` never checks `recipientChain`. Verified
+  low: the deployment-unique `managerAddress` equality check subsumes what `toChain` does on
+  EVM (where identical contract addresses recur across chains). Defense-in-depth gap, not a
+  reachable exploit.
+- **INV-028/029 (payload length limits)** — Encoders contain no explicit uint16/uint8 length
+  assertions; outbound size safety rests on the core Emitter's byte cap. Not reachable in
+  practice (Canton emits fixed-shape messages); worth an assertion for parity.
+
+### Access control and authorization (see also §3)
+
+- **INV-007 (owner-only admin)** — Held. Config choices (`SetPeer`, `SetFactory`,
+  `TransferAdmin`) are `controller admin`. Ledger `Credit`/`Debit`/`SetCustodyHint` require
+  the full signatory set, reachable only through the manager's own choice bodies.
+- **INV-008 (transceiver authorization)** — Held structurally: the single transceiver is
+  fixed at registration and validated at send time (`owner == namespace`, operator,
+  emitterId); inbound checks `emitterAddress == peer.transceiverAddress`.
+
+### Rate limiting, thresholds, pause, upgrade
+
+- **INV-009/010/011/026 (rate limiting)** — Absent (F13). Verified acceptable to defer: the
+  EVM reference ships a `NttManagerNoRateLimiting` variant and treats limits as optional.
+  README documents inbound rate limits as a follow-up.
+- **INV-012/022/023/024/025 (multi-transceiver thresholds)** — Not applicable / structurally
+  satisfied (F4). Canton has one non-disableable transceiver; effective threshold is fixed
+  at 1. The register/enable/threshold machinery does not exist and is not needed.
+- **INV-014/015 (pause)** — Absent (F13, the material half). All three references enforce
+  pause; EVM keeps `whenNotPaused` even in the no-rate-limit variant. Canton has no
+  first-class halt and no unilateral gg halt (archiving the manager needs all four
+  signatories). A partial, reversible substitute exists — the admin can overwrite a chain's
+  peer to a sentinel, blocking that chain's inbound and outbound — but it is per-chain, has
+  no separate fast pauser role, and is undocumented as an emergency procedure.
+- **INV-016/017 (upgrade)** — Daml/Canton upgrade model differs from the EVM proxy model;
+  not evaluated in depth here. Contracts are replaced by governance, not upgraded in place.
+
+### Decimals, peers, timing
+
+- **INV-018 (decimals consistency)** — Partially held. Local decimals bounded 0..10
+  (substrate-forced: Daml Decimal has 10 fractional digits); inbound rescale truncates and
+  never overpays. The outbound peer-decimals gap (F2) is the divergence.
+- **INV-021 (peer not on same chain)** — Unenforced (F9). Admin-only, so misconfiguration
+  not attack; a same-chain peer yields only a supply-neutral burn-then-mint loop. Note
+  Solana/Sui also lack this guard; it is EVM-specific hardening.
+- **INV-027 (redemption controls)** — Held. Approval (VAA verification + peer + recipient
+  binding) precedes any payout; replay state prevents duplicate redemption.
+
+---
+
+## 3. Access control
+
+The four-party signatory model (`operator`, `namespace`, `admin`, `guardianGovernance`)
+is coherent and each signature has a distinct, documented job. Verified sound:
+
+- **The custody model is access-control-safe** (F12). `Release` accepts caller-supplied
+  input holdings and `ConsolidateCustody` is permissionless, but the payout amount and
+  recipient are fixed by the guardian-signed VAA, the transfer sender is hardcoded to
+  `admin`, exact delivery is asserted, and every spent holding is validated as the current
+  admin's own, of this instrument, unlocked. An executor cannot spend a third party's
+  holdings or redirect value. Within the shared gg pool, the per-deployment `LockedLedger`
+  cap keeps a hostile-peer deployment away from the others' collateral. Residual griefing
+  (staling a custody hint) is bounded and permissionlessly repairable.
+- **Burn/mint mint authority** is the guardian quorum itself — `DepositPreapproval.Deposit`
+  is controlled by `instrumentId.admin` (= gg). The "arbitrary mint" surface is the
+  intended burn/mint trust model, not a relayer-reachable bug: gg is the token's mint
+  authority and a k-of-n quorum party.
+- **Instrument binding** (burn/mint exclusivity) is enforced by a hash commitment in the
+  instrument id (`instrumentId.id == nttInstrumentIdFor namespace nonce`), the Canton analog
+  of EVM's `setMinter`. Tested for exclusivity.
+- **Admin handoff** (`TransferAdmin`, usually propose-accept) is dual-authorized, moves the
+  reserve with the role, and enforces a coverage check; the deployment identity (addresses,
+  replay scope, ledger) stays with the stable namespace, so nothing changes on the wire.
+
+One doc-vs-code discrepancy to fix (not a code bug): the README says replay is scoped to
+`admin` and the burn/mint instrument is bound to `admin`; the code correctly uses
+`namespace` (the stable identity) in both places. The code is the safer, self-consistent
+choice; the README paragraphs are stale from the cip56 rework.
+
+---
+
+## 4. Findings, ranked
+
+| ID | Finding | Severity | Class | Invariants |
+|----|---------|----------|-------|------------|
+| F3 | No assigned Wormhole chain id (launch prerequisite) | medium | missing-feature | INV-019 |
+| F2 | Outbound trim ignores peer decimals → value loss to <8-dec peers | medium | spec-divergence | INV-001, INV-018 |
+| F13 | No pause/halt; burn/mint mint uncapped | medium | spec-divergence | INV-014/015 (+009/010/011/026) |
+| F1 | Inbound `recipientChain` not checked (subsumed by managerAddress) | low | spec-divergence | INV-019 |
+| F4 | Single transceiver ⇒ EVM peers need global threshold=1 | low | intended-design | INV-012/022-025 |
+| F5 | No TransceiverInit/Registration broadcasts (accountant only) | low | missing-feature | — |
+| F6 | `sender` field = manager address, not user | low | spec-divergence | — |
+| F7 | Decoders tolerate trailing bytes (not exploitable) | low | spec-divergence | INV-006 |
+| F9 | `SetPeer` lacks EVM guards (admin-only, misconfig only) | low | spec-divergence | INV-021 |
+| F10 | Outbound `sourceToken` caller-supplied, unchecked (metadata) | low | spec-divergence | — |
+| F8 | Replay scope per-namespace not per-manager (sound) | info | intended-design | — |
+| F11 | Decimals bounded 0..10; 0-dec can't be an EVM peer | info | intended-design | INV-018 |
+| F12 | Custody override / permissionless consolidate (sound) | info | intended-design | — |
+
+Uint64 asymmetry (not a numbered finding, folded into wire compat): Daml's signed 64-bit
+`Int` cannot represent wire amounts in `[2^63, 2^64)`; such an inbound transfer aborts
+(fail-closed, never mis-paid) but is a wire-compatibility asymmetry. A peer must not send
+amounts at that scale to Canton.
+
+---
+
+## 5. Tests added
+
+`canton/test/daml/Test/TestNttVectors.daml` (new, isolated, 6 scripts, all pass):
+
+- `testVectorTransceiverMessage1` — byte-exact encode + full decode round-trip against the
+  canonical cross-runtime vector. The core wire-compatibility proof.
+- `testVectorAdditionalPayload` — the 32-byte `additionalPayload` extension, byte-exact.
+- `testVectorNonCanonicalEmptyPayload` — the explicit-zero-length form is accepted on
+  decode and re-encodes to the canonical (shorter) form, matching the reference.
+- `testTrimVectorsMatching` — TrimmedAmount cases where Canton matches the reference.
+- `testTrimVectorsPeerDecimalDivergence` — pins the F2 divergence: Canton emits
+  `{158434, dec 6}` where the reference emits `{158, dec 3}`, and a 3-decimal peer then
+  drops `0.000434`.
+- `testAmountUint64Bound` — pins the signed-64-bit `Int` limit.
+
+---
+
+## 6. Recommendations
+
+Ordered by value. None is required for correctness; the first three close the material gaps.
+
+1. **Chain id (F3):** obtain a Wormhole chain id assignment, add the Canton entry to
+   `sdk-base` and platform support to `sdk/`/`cli/`, and regenerate the vectors that bake in
+   `72`. Optionally add a local `chainId` field to `NttManager` so the inbound path can also
+   enforce the INV-019 `toChain` check explicitly.
+2. **Peer decimals (F2):** add a `decimals` field to `Peer` (validated non-zero in
+   `SetPeer`, mirroring EVM), trim outbound to `min(8, tokenDecimals, peerDecimals)`, and
+   reject transfers whose amount does not round-trip (the `TransferAmountHasDust` analog).
+   Removes silent sender value loss and restores burn/mint conservation across decimals.
+3. **Pause (F13):** add a first-class `paused` flag on `NttManager`, checked in
+   `Transfer`/`Release`/`Mint`, togglable by admin (and settable by a designated pauser or
+   gg, mirroring EVM's owner/pauser split). Separately, prioritize the deferred inbound cap
+   for burn/mint mode, whose mint is otherwise unbounded against a compromised peer.
+4. **Low-cost hygiene:** exact-length assertion in the decoders (F7); `SetPeer` guards for
+   chain-id range, same-chain, and zero addresses (F9); set `sender` to the originating user
+   and `sourceToken` to a committed identifier (F6, F10); consider excluding 0 from the
+   decimals bound (F11).
+5. **Docs:** fix the stale README paragraphs that say `admin` where the code uses
+   `namespace` (replay scope and instrument binding); document the single-transceiver /
+   threshold-1 deployment constraint (F4) and the accountant-broadcast absence (F5).

--- a/audits/canton/2026-07-23-internal-canton-ntt-compliance-evaluation.md
+++ b/audits/canton/2026-07-23-internal-canton-ntt-compliance-evaluation.md
@@ -1,5 +1,18 @@
 # NTT Canton Implementation — Compliance Evaluation
 
+NOTE: this audit was done by Claude, with the following prompt:
+
+      ultracode this branch implements the NTT standard for Canton. it is instrumental that
+      our NTT implementation is compliant with the standard. The standard is loosely
+      specified via invariants, documentation, and reference implementations. your task
+      is to distill the spec and verify that the Canton implementation matches it. the first
+      thing to verify is functional: is it compatible with the NTT flow (can it be connected
+      into an existing NTT mesh, and if so, how?). second is security (this is where the
+      invariants come in). finally, the access control component. some things you might want
+      to do is adopt the deserialisation tests from the other runtime implementations.
+      I want you to just evaluate the current state, and you're free to
+      implement tests to verify any property.
+
 Date: 2026-07-23. Audited commit: `c41edbf6cb97499fd39933a542c798a0981492f4`
 ("canton: enforce reserve coverage on admin handoff and exact registry delivery"),
 the tip of branch `canton/ntt-cip56-rework` at the time of evaluation. All file and

--- a/canton/README.md
+++ b/canton/README.md
@@ -175,7 +175,8 @@ checks, in order:
    signature (`TestNtt:testReceivePinsGuardianGovernance`).
 2. Verify the VAA's guardian signatures and consume its digest, atomically,
    with the core `VerifyAndConsumeVAA` (the per-consumer replay trie, scoped
-   to `admin`, so each deployment consumes a VAA at most once).
+   to the stable `namespace`, so each deployment consumes a VAA at most once
+   and the scope is unaffected by an admin handoff).
 3. Check the VAA emitter is the configured peer transceiver for its source
    chain, and that the nested message's source and recipient manager addresses
    match the peer and this deployment.
@@ -321,16 +322,17 @@ assumed. It cannot be enforced by lookup (no contract keys, so "nobody has
 claimed this instrument yet" is not an on-ledger-checkable fact), and a
 claimed-instruments set on the root would grow without bound. Instead the
 binding lives in the instrument's identity: `RegisterManager` requires
-`instrumentId.id == nttInstrumentIdFor admin nonce`, a hash commitment to the
-registering admin. A CIP-0056 instrument id is fixed at creation, so whoever
-creates the instrument decides, once and forever, which admin can bind a
-manager to it. This is the role EVM NTT's `setMinter` pointer plays, attached
-to the immutable instrument identity instead of a mutable token field
+`instrumentId.id == nttInstrumentIdFor namespace nonce`, a hash commitment to
+the registering namespace. A CIP-0056 instrument id is fixed at creation, so
+whoever creates the instrument decides, once and forever, which namespace can
+bind a manager to it. This is the role EVM NTT's `setMinter` pointer plays,
+attached to the immutable instrument identity instead of a mutable token field
 (`TestNtt:testBurnMintInstrumentIsExclusiveToItsAdmin`). Two consequences: the
-admin party must be durable (the binding cannot be re-pointed; recovery from a
-lost admin party means a new instrument and a holder migration), and the
-instrument must be created with the binding already in its id, which is a
-deployment-setup requirement documented rather than enforced here.
+namespace party must be durable (the binding cannot be re-pointed; recovery
+from a lost namespace party means a new instrument and a holder migration) —
+which it already is, since the namespace is the deployment's stable identity —
+and the instrument must be created with the binding already in its id, which is
+a deployment-setup requirement documented rather than enforced here.
 
 **Synchronous settlement.** Lock and release require the registry's
 `TransferFactory_Transfer` to settle in the same transaction; a `Pending` or

--- a/canton/ntt/daml/Wormhole/Ntt/Amount.daml
+++ b/canton/ntt/daml/Wormhole/Ntt/Amount.daml
@@ -28,7 +28,8 @@ tenPow : Int -> Int
 tenPow n = if n <= 0 then 1 else 10 * tenPow (n - 1)
 
 -- | Convert a local amount (@rawAmount@ integer units at @fromDecimals@) to
--- the wire form, truncating anything below 10^-8.
+-- the wire form, truncating anything below 10^-8. Trims by the source decimals
+-- alone; 'trimAmountTo' additionally accounts for the destination's decimals.
 trimAmount : Int -> Int -> TrimmedAmount
 trimAmount rawAmount fromDecimals =
   if fromDecimals <= maxTrimmedDecimals
@@ -36,6 +37,21 @@ trimAmount rawAmount fromDecimals =
     else TrimmedAmount with
            decimals = maxTrimmedDecimals
            amount = rawAmount / tenPow (fromDecimals - maxTrimmedDecimals)
+
+-- | Convert a local amount to the wire form, trimming to
+-- @min(8, fromDecimals, toDecimals)@ decimals. This mirrors the reference
+-- implementation, which trims to the destination's decimals so no precision is
+-- put on the wire that the receiving token cannot represent. The result never
+-- scales up: @toDecimals@ only lowers the wire precision. A caller that must
+-- not silently drop value should reject any @rawAmount@ that does not
+-- round-trip through the result (see the dust check in
+-- 'Wormhole.Ntt.Manager.Transfer').
+trimAmountTo : Int -> Int -> Int -> TrimmedAmount
+trimAmountTo rawAmount fromDecimals toDecimals =
+  let d = min maxTrimmedDecimals (min fromDecimals toDecimals)
+  in TrimmedAmount with
+       decimals = d
+       amount = rawAmount / tenPow (fromDecimals - d)
 
 -- | Rescale a wire amount to integer units at @toDecimals@, truncating
 -- precision the local token cannot represent.

--- a/canton/ntt/daml/Wormhole/Ntt/Governance.daml
+++ b/canton/ntt/daml/Wormhole/Ntt/Governance.daml
@@ -54,6 +54,7 @@ template NttGovernance
       with
         namespace             : Party
         admin                 : Party
+        chainId               : Int   -- this deployment's own Wormhole chain id (uint16)
         transceiverEmitterCid : ContractId Emitter
         instrumentId          : InstrumentId
         instrumentNonce       : Int   -- the nonce in the burn/mint instrument-id binding
@@ -71,6 +72,8 @@ template NttGovernance
         -- fractional digits a Daml Decimal carries.
         assertMsg "ntt: tokenDecimals must be between 0 and 10"
           (tokenDecimals >= 0 && tokenDecimals <= 10)
+        assertMsg "ntt: chainId must be a positive uint16"
+          (chainId > 0 && chainId <= 65535)
         case tokenConfig of
           BurnMint -> do
             assertMsg
@@ -88,6 +91,7 @@ template NttGovernance
           namespace
           admin
           guardianGovernance
+          chainId
           managerId = nextId
           managerAddress
           transceiverEmitterId = transceiver.emitterId

--- a/canton/ntt/daml/Wormhole/Ntt/Governance.daml
+++ b/canton/ntt/daml/Wormhole/Ntt/Governance.daml
@@ -100,6 +100,7 @@ template NttGovernance
           tokenDecimals
           peers = Map.empty
           factory
+          paused = False
         ledger <- case tokenConfig of
           LockUnlock -> Some <$> create LockedLedger with
             operator

--- a/canton/ntt/daml/Wormhole/Ntt/Manager.daml
+++ b/canton/ntt/daml/Wormhole/Ntt/Manager.daml
@@ -328,6 +328,7 @@ template NttManager
     tokenDecimals        : Int             -- the local token's decimals (0..10)
     peers                : Map Int Peer    -- chain id -> peer deployment
     factory              : NttFactory      -- the registry's committed factory, typed by mode
+    paused               : Bool            -- emergency halt: blocks Transfer/Release/Mint
   where
     -- See the module header for what each signature contributes. All four are
     -- inherited from the NttGovernance root at registration (namespace and
@@ -353,6 +354,19 @@ template NttManager
         assertMsg "ntt: peer transceiver address must be non-zero"
           (not (isZeroAddress peer.transceiverAddress))
         create this with peers = Map.insert chainId (normalizePeer peer) peers
+
+    -- | Emergency halt. While @paused@, 'Transfer', 'Release', and 'Mint' all
+    -- abort; config choices ('SetPeer', 'SetFactory', 'TransferAdmin') keep
+    -- working, matching the reference, where pause blocks value movement but not
+    -- administration. Controlled by @admin@, so on a gg-adminned deployment
+    -- pausing is a governance action. (The reference additionally allows a
+    -- separate pauser role to pause but only the owner to unpause; a dedicated
+    -- pauser party could be added here the same way.)
+    choice SetPaused : ContractId NttManager
+      with
+        newPaused : Bool
+      controller admin
+      do create this with paused = newPaused
 
     -- | Repoint the committed registry factory. Needed only when the registry
     -- is upgraded and re-creates its factory under a new cid; @admin@ resolves
@@ -462,6 +476,7 @@ template NttManager
         extraArgs             : ExtraArgs
       controller user
       do
+        assertMsg "ntt: deployment is paused" (not paused)
         let peer = fromSomeNote ("ntt: no peer for chain " <> show recipientChain)
                      (Map.lookup recipientChain peers)
             trimmed = trimAmountTo rawAmount tokenDecimals peer.decimals
@@ -585,6 +600,7 @@ template NttManager
         extraArgs        : ExtraArgs
       controller executor
       do
+        assertMsg "ntt: deployment is paused" (not paused)
         assertMsg "ntt: release is only for lock/unlock deployments"
           (tokenConfig == LockUnlock)
         ledger <- resolveLedger this ledgerCid
@@ -687,6 +703,7 @@ template NttManager
         extraArgs             : ExtraArgs
       controller executor
       do
+        assertMsg "ntt: deployment is paused" (not paused)
         assertMsg "ntt: mint is only for burn/mint deployments"
           (tokenConfig == BurnMint)
         ntt <- verifyInboundTransfer this executor coreStateCid replayNodeCid

--- a/canton/ntt/daml/Wormhole/Ntt/Manager.daml
+++ b/canton/ntt/daml/Wormhole/Ntt/Manager.daml
@@ -136,15 +136,20 @@ requireBurnMintFactory = \case
   TransferFactoryCid _ -> abort "ntt: deployment's committed factory is not a burn/mint factory"
 
 -- | A peer NTT deployment on another chain: its manager address (the
--- @recipientManager@/@sourceManager@ in the transceiver message) and its
--- transceiver address (the emitter of inbound VAAs). Both 32 bytes.
+-- @recipientManager@/@sourceManager@ in the transceiver message), its
+-- transceiver address (the emitter of inbound VAAs, both 32 bytes), and the
+-- number of decimals of the peer's token. The decimals let an outbound
+-- transfer trim to the precision the peer can represent, so no dust is silently
+-- dropped when the far side rescales; this mirrors the peer @decimals@ the
+-- reference @setPeer@ stores.
 data Peer = Peer with
     managerAddress     : Bytes32
     transceiverAddress : Bytes32
+    decimals           : Int
   deriving (Eq, Show)
 
 normalizePeer : Peer -> Peer
-normalizePeer p = Peer with
+normalizePeer p = p with
     managerAddress = normalizeHex p.managerAddress
     transceiverAddress = normalizeHex p.transceiverAddress
 
@@ -341,6 +346,8 @@ template NttManager
           (chainId > 0 && chainId <= 65535)
         assertMsg "ntt: peer chain id must not be this deployment's own chain"
           (chainId /= this.chainId)
+        assertMsg "ntt: peer decimals must be a positive uint8"
+          (peer.decimals > 0 && peer.decimals <= 255)
         assertMsg "ntt: peer manager address must be non-zero"
           (not (isZeroAddress peer.managerAddress))
         assertMsg "ntt: peer transceiver address must be non-zero"
@@ -457,9 +464,15 @@ template NttManager
       do
         let peer = fromSomeNote ("ntt: no peer for chain " <> show recipientChain)
                      (Map.lookup recipientChain peers)
-            trimmed = trimAmount rawAmount tokenDecimals
+            trimmed = trimAmountTo rawAmount tokenDecimals peer.decimals
             amount = trimmedToDecimal trimmed
         assertMsg "ntt: transfer amount is zero after trimming" (amount > 0.0)
+        -- Reject dust the peer cannot represent: the trimmed amount must
+        -- rescale back to exactly what the user asked to send, so the amount
+        -- locked or burned here equals the amount the peer will release or
+        -- mint. Without this a low-decimals peer would silently drop precision.
+        assertMsg "ntt: transfer amount has dust the peer cannot represent"
+          (untrimAmount trimmed tokenDecimals == rawAmount)
         transceiver <- fetch transceiverEmitterCid
         assertMsg "ntt: transceiver emitter is not this deployment's"
           (transceiver.owner == namespace

--- a/canton/ntt/daml/Wormhole/Ntt/Manager.daml
+++ b/canton/ntt/daml/Wormhole/Ntt/Manager.daml
@@ -148,6 +148,13 @@ normalizePeer p = Peer with
     managerAddress = normalizeHex p.managerAddress
     transceiverAddress = normalizeHex p.transceiverAddress
 
+-- | Whether a 32-byte address is all zeros (the unset/sentinel address the
+-- reference @setPeer@ rejects).
+isZeroAddress : Bytes32 -> Bool
+isZeroAddress b =
+  normalizeHex (leftPadTo 32 b)
+    == "0000000000000000000000000000000000000000000000000000000000000000"
+
 -- | Domain-separation tag for NTT manager addresses.
 nttManagerAddressTag : Text
 nttManagerAddressTag = "wormhole:ntt-manager:v1"
@@ -295,6 +302,8 @@ verifyInboundTransfer mgr executor coreStateCid replayNodeCid vaaBytes pubKeys r
     (wm.sourceManager == peer.managerAddress)
   let mm = decodeNttManagerMessage wm.managerPayload
       ntt = decodeNativeTokenTransfer mm.payload
+  assertMsg "ntt: transfer is not destined for this chain"
+    (ntt.recipientChain == mgr.chainId)
   assertMsg "ntt: recipient does not match VAA recipientAddress"
     (recipientAddressFor recipient == normalizeHex ntt.recipientAddress)
   pure ntt
@@ -305,6 +314,7 @@ template NttManager
     namespace            : Party           -- stable identity: address preimages, replay scope, emitter owner
     admin                : Party           -- operational role and lock/unlock custodian; transferable
     guardianGovernance   : Party           -- gg: mint authority and trust anchor
+    chainId              : Int             -- this deployment's own Wormhole chain id (uint16)
     managerId            : Int             -- allocated by NttGovernance; in the address preimage
     managerAddress       : Bytes32         -- nttManagerAddressFor operator namespace managerId
     transceiverEmitterId : Int             -- the deployment's transceiver Emitter (owner = namespace)
@@ -326,7 +336,16 @@ template NttManager
         chainId : Int
         peer    : Peer
       controller admin
-      do create this with peers = Map.insert chainId (normalizePeer peer) peers
+      do
+        assertMsg "ntt: peer chain id must be a positive uint16"
+          (chainId > 0 && chainId <= 65535)
+        assertMsg "ntt: peer chain id must not be this deployment's own chain"
+          (chainId /= this.chainId)
+        assertMsg "ntt: peer manager address must be non-zero"
+          (not (isZeroAddress peer.managerAddress))
+        assertMsg "ntt: peer transceiver address must be non-zero"
+          (not (isZeroAddress peer.transceiverAddress))
+        create this with peers = Map.insert chainId (normalizePeer peer) peers
 
     -- | Repoint the committed registry factory. Needed only when the registry
     -- is upgraded and re-creates its factory under a new cid; @admin@ resolves

--- a/canton/test/daml/Test/TestNtt.daml
+++ b/canton/test/daml/Test/TestNtt.daml
@@ -731,6 +731,50 @@ testTransferTrimsToPeerDecimals = do
   [(_, ledger)] <- query @LockedLedger operator
   ledger.balance === 0.001
 
+-- | Pausing halts outbound sends and lifting the pause restores them; config
+-- (here, SetPaused itself) keeps working while paused.
+testPauseHaltsSend : Script ()
+testPauseHaltsSend = do
+  (operator, gg, csId) <- nttSetup
+  alice <- allocateParty "PauseAlice"
+  (d, discs) <- sendScaffold operator gg alice LockUnlock csId
+  holding <- mkHolding gg alice d.instrumentId 0.01
+
+  pausedMgr <- submit alice do exerciseCmd d.mgrCid SetPaused with newPaused = True
+  let dP = d with mgrCid = pausedMgr
+  res <- trySubmitWithDiscs alice discs do sendTransfer alice dP csId [holding]
+  expectAbort "deployment is paused" res
+
+  liveMgr <- submit alice do exerciseCmd dP.mgrCid SetPaused with newPaused = False
+  let dL = dP with mgrCid = liveMgr
+  _ <- submitWithDiscs alice discs do sendTransfer alice dL csId [holding]
+  [(_, ledger)] <- query @LockedLedger operator
+  ledger.balance === 0.01
+
+-- | Pausing also halts inbound release: the pause check runs before any VAA
+-- verification, so a paused deployment rejects an otherwise-valid relay.
+testPauseHaltsRelease : Script ()
+testPauseHaltsRelease = do
+  (operator, gg, csId) <- nttSetup
+  admin <- allocateParty "PauseRelAdmin"
+  recipient <- allocateParty "PauseRelRecipient"
+  (mgrCid, _, ledgerCid) <- setupFixedManager operator gg admin LockUnlock
+  pausedMgr <- submit admin do exerciseCmd mgrCid SetPaused with newPaused = True
+  (nodeCid, _) <- coveringDisclosure operator admin nttTransferDigest
+
+  res <- trySubmit (actAs operator) do
+    exerciseCmd pausedMgr Release with
+      executor = operator
+      coreStateCid = csId
+      replayNodeCid = nodeCid
+      vaaBytes = nttTransferVAA
+      pubKeys = [(0, devnetGuardianPubKey)]
+      recipient
+      ledgerCid = fromSome ledgerCid
+      inputHoldingCids = []
+      extraArgs = emptyExtraArgs
+  expectAbort "deployment is paused" res
+
 -- | Anyone can merge custody fragments back into one pot and repoint the
 -- ledger's hint: the repair path for stale hints and explicit-input releases.
 testConsolidateCustody : Script ()
@@ -1486,6 +1530,7 @@ setupFixedManagerOn operator gg admin config chainId = do
       tokenDecimals = 8
       peers = Map.empty
       factory
+      paused = False
   mgrCid <- submit admin do
     exerciseCmd mgrCid SetPeer with
       chainId = 2

--- a/canton/test/daml/Test/TestNtt.daml
+++ b/canton/test/daml/Test/TestNtt.daml
@@ -221,6 +221,12 @@ discloseTransferFactory gg = do
 b32 : Text -> Bytes32
 b32 = leftPadTo 32
 
+-- | The placeholder Wormhole chain id the fixtures use for this Canton
+-- deployment (the fixture NTT payload's @recipientChain@ is 72). A real
+-- deployment uses its assigned id.
+cantonChainId : Int
+cantonChainId = 72
+
 -- | Assert that a submission failed with a message containing @needle@.
 expectAbort : Text -> Either SubmitError a -> Script ()
 expectAbort needle res = case res of
@@ -355,6 +361,7 @@ deploy operator gg admin config = do
     exerciseCmd govCid RegisterManager with
       namespace = admin
       admin
+      chainId = cantonChainId
       transceiverEmitterCid = emitterCid
       instrumentId
       instrumentNonce = 0
@@ -404,6 +411,7 @@ testBurnMintRegistrationRequiresBoundInstrument = do
     exerciseCmd govCid RegisterManager with
       namespace = admin
       admin
+      chainId = cantonChainId
       transceiverEmitterCid = emitterCid
       instrumentId = InstrumentId with admin = gg, id = "NTT"
       instrumentNonce = 0
@@ -431,6 +439,7 @@ testBurnMintInstrumentIsExclusiveToItsAdmin = do
       exerciseCmd govCid RegisterManager with
         namespace = mallory
         admin = mallory
+        chainId = cantonChainId
         transceiverEmitterCid = emitterCid
         instrumentId = d.instrumentId
         instrumentNonce = nonce
@@ -455,6 +464,7 @@ testRegistrationBounds = do
     exerciseCmd govCid RegisterManager with
       namespace = admin
       admin
+      chainId = cantonChainId
       transceiverEmitterCid = emitterCid
       instrumentId = InstrumentId with admin = outsider, id = nttInstrumentIdFor admin 0
       instrumentNonce = 0
@@ -467,6 +477,7 @@ testRegistrationBounds = do
     exerciseCmd govCid RegisterManager with
       namespace = admin
       admin
+      chainId = cantonChainId
       transceiverEmitterCid = emitterCid
       instrumentId = bridgedInstrument gg
       instrumentNonce = 0
@@ -481,6 +492,7 @@ testRegistrationBounds = do
     exerciseCmd govCid RegisterManager with
       namespace = admin
       admin
+      chainId = cantonChainId
       transceiverEmitterCid = emitterCid
       instrumentId = bridgedInstrument gg
       instrumentNonce = 0
@@ -488,6 +500,49 @@ testRegistrationBounds = do
       tokenDecimals = 8
       factory = BurnMintFactoryCid (coerceContractId emitterCid)
   expectAbort "factory type does not match" res
+
+  -- The deployment's own chain id must be a positive uint16.
+  res <- trySubmit (actAs admin <> disclose govDisc) do
+    exerciseCmd govCid RegisterManager with
+      namespace = admin
+      admin
+      chainId = 0
+      transceiverEmitterCid = emitterCid
+      instrumentId = bridgedInstrument gg
+      instrumentNonce = 0
+      tokenConfig = LockUnlock
+      tokenDecimals = 8
+      factory = TransferFactoryCid (coerceContractId emitterCid)
+  expectAbort "chainId must be a positive uint16" res
+
+-- | 'SetPeer' rejects an out-of-range chain id, the deployment's own chain id
+-- (INV-021: a peer must not be on the manager's own chain), and zero
+-- addresses. Only the trusted admin can set peers, so these guards catch
+-- misconfiguration rather than an attack.
+testSetPeerGuards : Script ()
+testSetPeerGuards = do
+  (operator, gg, _) <- nttSetup
+  admin <- allocateParty "SetPeerAdmin"
+  d <- deploy operator gg admin LockUnlock
+  let goodPeer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc"
+
+  res <- trySubmit admin do
+    exerciseCmd d.mgrCid SetPeer with chainId = 70000, peer = goodPeer
+  expectAbort "positive uint16" res
+
+  res <- trySubmit admin do
+    exerciseCmd d.mgrCid SetPeer with chainId = cantonChainId, peer = goodPeer
+  expectAbort "own chain" res
+
+  res <- trySubmit admin do
+    exerciseCmd d.mgrCid SetPeer with
+      chainId = 2
+      peer = Peer with managerAddress = b32 "", transceiverAddress = b32 "cc"
+  expectAbort "manager address must be non-zero" res
+
+  -- A well-formed peer on another chain is accepted.
+  _ <- submit admin do exerciseCmd d.mgrCid SetPeer with chainId = 2, peer = goodPeer
+  pure ()
 
 ----------------------------------------------------------------------
 -- The locked ledger
@@ -1350,7 +1405,15 @@ nttTransferDigest = (parseVAA nttTransferVAA).hash
 setupFixedManager
   : Party -> Party -> Party -> NttTokenConfig
   -> Script (ContractId NttManager, NttFactory, Optional (ContractId LockedLedger))
-setupFixedManager operator gg admin config = do
+setupFixedManager operator gg admin config =
+  setupFixedManagerOn operator gg admin config cantonChainId
+
+-- | 'setupFixedManager' with an explicit local chain id, for the inbound
+-- destination-chain check.
+setupFixedManagerOn
+  : Party -> Party -> Party -> NttTokenConfig -> Int
+  -> Script (ContractId NttManager, NttFactory, Optional (ContractId LockedLedger))
+setupFixedManagerOn operator gg admin config chainId = do
   let instrumentId = bridgedInstrument gg
   factory <- case config of
     BurnMint -> do
@@ -1365,6 +1428,7 @@ setupFixedManager operator gg admin config = do
       namespace = admin
       admin
       guardianGovernance = gg
+      chainId
       managerId = 999
       managerAddress = b32 "aa"
       transceiverEmitterId = 999
@@ -1419,6 +1483,37 @@ testReceiveByExecutorRecipientMismatchFails = do
       inputHoldingCids = []
       extraArgs = emptyExtraArgs
   expectAbort "recipient does not match" res
+
+-- | Inbound enforces the destination chain: the VAA's NativeTokenTransfer
+-- carries @recipientChain = 72@, so a deployment whose own chain id is not 72
+-- rejects it with "not destined for this chain" (INV-019 inbound half). The
+-- check sits after the peer/manager checks and before the recipient binding,
+-- so a wrong chain id fails regardless of the recipient.
+testReceiveWrongChainRejected : Script ()
+testReceiveWrongChainRejected = do
+  (operator, gg, csId) <- nttSetup
+  admin <- allocateParty "WrongChainAdmin"
+  relayer <- allocateParty "WrongChainRelayer"
+  recipient <- allocateParty "WrongChainRecipient"
+  -- Same fixed deployment, but its own chain id is 99, not the fixture's 72.
+  (mgrCid, _, ledgerCid) <- setupFixedManagerOn operator gg admin LockUnlock 99
+  (nodeCid, nodeDisc) <- coveringDisclosure operator admin nttTransferDigest
+  dMgr <- fromSome <$> queryDisclosure operator mgrCid
+  dCs  <- fromSome <$> queryDisclosure operator csId
+  dLedger <- fromSome <$> queryDisclosure operator (fromSome ledgerCid)
+
+  res <- trySubmitWithDiscs relayer [dMgr, dCs, nodeDisc, dLedger] do
+    exerciseCmd mgrCid Release with
+      executor = relayer
+      coreStateCid = csId
+      replayNodeCid = nodeCid
+      vaaBytes = nttTransferVAA
+      pubKeys = [(0, devnetGuardianPubKey)]
+      recipient
+      ledgerCid = fromSome ledgerCid
+      inputHoldingCids = []
+      extraArgs = emptyExtraArgs
+  expectAbort "not destined for this chain" res
 
 -- | The guardian trust root is pinned to the committed @guardianGovernance@,
 -- not the operator. A compromised operator could co-sign a forged 'CoreState'

--- a/canton/test/daml/Test/TestNtt.daml
+++ b/canton/test/daml/Test/TestNtt.daml
@@ -524,7 +524,7 @@ testSetPeerGuards = do
   (operator, gg, _) <- nttSetup
   admin <- allocateParty "SetPeerAdmin"
   d <- deploy operator gg admin LockUnlock
-  let goodPeer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc"
+  let goodPeer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc", decimals = 8
 
   res <- trySubmit admin do
     exerciseCmd d.mgrCid SetPeer with chainId = 70000, peer = goodPeer
@@ -537,8 +537,14 @@ testSetPeerGuards = do
   res <- trySubmit admin do
     exerciseCmd d.mgrCid SetPeer with
       chainId = 2
-      peer = Peer with managerAddress = b32 "", transceiverAddress = b32 "cc"
+      peer = Peer with managerAddress = b32 "", transceiverAddress = b32 "cc", decimals = 8
   expectAbort "manager address must be non-zero" res
+
+  res <- trySubmit admin do
+    exerciseCmd d.mgrCid SetPeer with
+      chainId = 2
+      peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc", decimals = 0
+  expectAbort "peer decimals must be a positive uint8" res
 
   -- A well-formed peer on another chain is accepted.
   _ <- submit admin do exerciseCmd d.mgrCid SetPeer with chainId = 2, peer = goodPeer
@@ -585,7 +591,7 @@ sendScaffold operator gg admin config csId = do
   mgrCid <- submit admin do
     exerciseCmd d.mgrCid SetPeer with
       chainId = 2
-      peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc"
+      peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc", decimals = 8
   csDisc <- fromSome <$> queryDisclosure operator csId
   factoryDisc <- case config of
     BurnMint -> discloseBurnMintFactory gg
@@ -681,6 +687,49 @@ testTransferLockAccounting = do
       h.amount === 0.015
       ledger2.custodyHoldingCid === Some (toInterfaceContractId @Holding cid)
     _ -> abort ("expected one merged custody holding, got: " <> show custody2)
+
+-- | A send to a peer whose token has fewer decimals than the amount carries is
+-- trimmed to the peer's decimals, and any leftover dust is rejected up front so
+-- the amount locked here always equals the amount the peer will release. A
+-- round amount the peer can represent goes through. (Token decimals 8, peer
+-- decimals 3.)
+testTransferTrimsToPeerDecimals : Script ()
+testTransferTrimsToPeerDecimals = do
+  (operator, gg, csId) <- nttSetup
+  alice <- allocateParty "DustAlice"
+  (d, discs) <- sendScaffold operator gg alice LockUnlock csId
+  mgrCid <- submit alice do
+    exerciseCmd d.mgrCid SetPeer with
+      chainId = 5
+      peer = Peer with managerAddress = b32 "b5", transceiverAddress = b32 "c5", decimals = 3
+  let d' = d with mgrCid
+      sendTo chainId rawAmount holding =
+        exerciseCmd d'.mgrCid Transfer with
+          user = alice
+          transceiverEmitterCid = d'.emitterCid
+          coreStateCid = csId
+          ledgerCid = d'.ledgerCid
+          recipientChain = chainId
+          recipientAddress = b32 "ee"
+          sourceToken = b32 "dd"
+          rawAmount
+          nonce = 0
+          consistencyLevel = 0
+          inputHoldingCids = [holding]
+          feeAllocation = None
+          extraArgs = emptyExtraArgs
+
+  -- 0.00158434 at 8 decimals cannot be represented at 3 decimals: rejected.
+  dustHolding <- mkHolding gg alice d.instrumentId 0.00158434
+  res <- trySubmitWithDiscs alice discs do sendTo 5 158434 dustHolding
+  expectAbort "dust the peer cannot represent" res
+
+  -- 0.001 is representable at 3 decimals: locked, and the ledger is credited
+  -- by exactly that amount.
+  roundHolding <- mkHolding gg alice d.instrumentId 0.001
+  _ <- submitWithDiscs alice discs do sendTo 5 100000 roundHolding
+  [(_, ledger)] <- query @LockedLedger operator
+  ledger.balance === 0.001
 
 -- | Anyone can merge custody fragments back into one pot and repoint the
 -- ledger's hint: the repair path for stale hints and explicit-input releases.
@@ -1026,11 +1075,11 @@ testGgAdminnedOps = do
   submitMustFail alice do
     exerciseCmd mgrCid SetPeer with
       chainId = 3
-      peer = Peer with managerAddress = b32 "b1", transceiverAddress = b32 "c1"
+      peer = Peer with managerAddress = b32 "b1", transceiverAddress = b32 "c1", decimals = 8
   _ <- submit gg do
     exerciseCmd mgrCid SetPeer with
       chainId = 3
-      peer = Peer with managerAddress = b32 "b1", transceiverAddress = b32 "c1"
+      peer = Peer with managerAddress = b32 "b1", transceiverAddress = b32 "c1", decimals = 8
   pure ()
 
 -- | The propose-accept handoff: the current admin leaves a standing
@@ -1233,7 +1282,7 @@ testNttSend = do
   _ <- submit alice do
     exerciseCmd d.mgrCid SetPeer with
       chainId = 2
-      peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc"
+      peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc", decimals = 8
   [(mgrCid, _)] <- query @NttManager operator
   let d' = d with mgrCid
 
@@ -1307,7 +1356,7 @@ testNttTransferByDifferentUser = do
   mgrCid <- submit admin do
     exerciseCmd d.mgrCid SetPeer with
       chainId = 2
-      peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc"
+      peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc", decimals = 8
   (mgrCid, _) <- submit (actAs admin <> actAs gg) do
     exerciseCmd mgrCid TransferAdmin with
       newAdmin = gg
@@ -1363,7 +1412,7 @@ testNttTransferRequiresUserAuthority = do
   mgrCid <- submit admin do
     exerciseCmd d.mgrCid SetPeer with
       chainId = 2
-      peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc"
+      peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc", decimals = 8
   let doTransfer = exerciseCmd mgrCid Transfer with
         user = bob
         transceiverEmitterCid = d.emitterCid
@@ -1440,7 +1489,7 @@ setupFixedManagerOn operator gg admin config chainId = do
   mgrCid <- submit admin do
     exerciseCmd mgrCid SetPeer with
       chainId = 2
-      peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc"
+      peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc", decimals = 8
   ledgerCid <- case config of
     LockUnlock -> Some <$> submit (actAs operator <> actAs admin <> actAs gg) do
       createCmd LockedLedger with

--- a/canton/test/daml/Test/TestNttVectors.daml
+++ b/canton/test/daml/Test/TestNttVectors.daml
@@ -1,0 +1,233 @@
+-- | Cross-runtime wire-compatibility vectors for the NTT codec, ported from
+-- the reference implementations so the Canton encoder/decoder can be checked
+-- byte-for-byte against the bytes EVM, Solana, and the TS SDK agree on.
+--
+-- The message vectors are the shared fixtures in @evm/test/payloads/@ (also
+-- consumed by the Solana Rust tests via @include_str!@ and by the TS SDK
+-- tests). The TrimmedAmount numeric vectors are the unit-test values from
+-- @solana/modules/ntt-messages/src/trimmed_amount.rs@ and the identical Sui
+-- suite. Where Canton's behavior diverges from the reference the divergence is
+-- called out inline and the test pins Canton's ACTUAL behavior.
+module Test.TestNttVectors where
+
+import Daml.Script
+import DA.Assert ((===))
+
+import Wormhole.Core.Bytes
+import Wormhole.Ntt.Amount
+import Wormhole.Ntt.Payload
+
+----------------------------------------------------------------------
+-- The canonical shared TransceiverMessage vector
+-- (evm/test/payloads/transceiver_message_1.txt, 217 bytes).
+--
+-- The EVM test comment calls this out as "a useful test case for
+-- implementations on other runtimes". If the Canton encoder produces these
+-- exact bytes and the decoder round-trips them, the Canton wire format is
+-- byte-identical to the reference for this message.
+----------------------------------------------------------------------
+
+-- The 32-byte fields carry their data left-aligned (right-padded with zeros),
+-- exactly as the Solidity `bytes32` literals in the fixture do.
+vecSourceManager : Bytes32
+vecSourceManager = "042942fafabe0000000000000000000000000000000000000000000000000000"
+
+vecRecipientManager : Bytes32
+vecRecipientManager = "042942fababe0000000000000000000000000000000000000000000000000000"
+
+vecId : Bytes32
+vecId = "128434bafe23430000000000000000000000000000000000ce00aa0000000000"
+
+vecSender : Bytes32
+vecSender = "4667921341234300000000000000000000000000000000000000000000000000"
+
+vecSourceToken : Bytes32
+vecSourceToken = "beefface00000000000000000000000000000000000000000000000000000000"
+
+vecRecipient : Bytes32
+vecRecipient = "feebcafe00000000000000000000000000000000000000000000000000000000"
+
+-- The inner NativeTokenTransfer shared by every message vector below:
+-- amount 1234567 at 7 decimals, toChain 2 (Ethereum), no additional payload.
+vecNtt : NativeTokenTransfer
+vecNtt = NativeTokenTransfer with
+    decimals = 7
+    amount = 1234567
+    sourceToken = vecSourceToken
+    recipientAddress = vecRecipient
+    recipientChain = 2
+    additionalPayload = ""
+
+vecMm : NttManagerMessage
+vecMm = NttManagerMessage with
+    id = vecId
+    sender = vecSender
+    payload = encodeNativeTokenTransfer vecNtt
+
+vecWm : WormholeTransceiverMessage
+vecWm = WormholeTransceiverMessage with
+    sourceManager = vecSourceManager
+    recipientManager = vecRecipientManager
+    managerPayload = encodeNttManagerMessage vecMm
+    transceiverPayload = ""
+
+transceiverMessage1 : Bytes
+transceiverMessage1 = "9945ff10042942fafabe0000000000000000000000000000000000000000000000000000042942fababe00000000000000000000000000000000000000000000000000000091128434bafe23430000000000000000000000000000000000ce00aa00000000004667921341234300000000000000000000000000000000000000000000000000004f994e545407000000000012d687beefface00000000000000000000000000000000000000000000000000000000feebcafe0000000000000000000000000000000000000000000000000000000000020000"
+
+-- | Byte-exact encode and decode round-trip against the shared 217-byte
+-- vector. This is the load-bearing compatibility check: it proves a Canton
+-- send produces bytes an EVM/Solana peer parses identically, and that Canton
+-- parses what they produce.
+testVectorTransceiverMessage1 : Script ()
+testVectorTransceiverMessage1 = do
+  -- Encode matches the reference bytes exactly.
+  encodeWormholeTransceiverMessage vecWm === transceiverMessage1
+  -- Decode of the reference bytes recovers the structure, all the way down to
+  -- the NativeTokenTransfer.
+  let wm = decodeWormholeTransceiverMessage transceiverMessage1
+  wm.sourceManager === vecSourceManager
+  wm.recipientManager === vecRecipientManager
+  wm.transceiverPayload === ""
+  let mm = decodeNttManagerMessage wm.managerPayload
+  mm.id === vecId
+  mm.sender === vecSender
+  decodeNativeTokenTransfer mm.payload === vecNtt
+
+----------------------------------------------------------------------
+-- The 32-byte-additionalPayload vector
+-- (transceiver_message_with_32byte_payload.txt, 251 bytes).
+----------------------------------------------------------------------
+
+vecNtt32 : NativeTokenTransfer
+vecNtt32 = vecNtt with
+    additionalPayload = "deadbeef000000000000000000000000000000000000000000000000deadbeef"
+
+vecWm32 : WormholeTransceiverMessage
+vecWm32 = vecWm with
+    managerPayload = encodeNttManagerMessage (vecMm with payload = encodeNativeTokenTransfer vecNtt32)
+
+transceiverMessage32 : Bytes
+transceiverMessage32 = "9945ff10042942fafabe0000000000000000000000000000000000000000000000000000042942fababe000000000000000000000000000000000000000000000000000000b3128434bafe23430000000000000000000000000000000000ce00aa000000000046679213412343000000000000000000000000000000000000000000000000000071994e545407000000000012d687beefface00000000000000000000000000000000000000000000000000000000feebcafe0000000000000000000000000000000000000000000000000000000000020020deadbeef000000000000000000000000000000000000000000000000deadbeef0000"
+
+-- | The optional additionalPayload extension (uint16 length + bytes) encodes
+-- and decodes byte-exactly against the reference.
+testVectorAdditionalPayload : Script ()
+testVectorAdditionalPayload = do
+  encodeWormholeTransceiverMessage vecWm32 === transceiverMessage32
+  let wm = decodeWormholeTransceiverMessage transceiverMessage32
+      mm = decodeNttManagerMessage wm.managerPayload
+      ntt = decodeNativeTokenTransfer mm.payload
+  ntt === vecNtt32
+  ntt.additionalPayload === "deadbeef000000000000000000000000000000000000000000000000deadbeef"
+
+----------------------------------------------------------------------
+-- The non-canonical empty-payload vector
+-- (transceiver_message_with_empty_payload.txt, 219 bytes).
+--
+-- This is a NativeTokenTransfer that carries an explicit additionalPayload
+-- length of 0x0000 rather than omitting the field. The reference calls it a
+-- message that "can't be generated but does technically adhere to the spec":
+-- parsers must accept it and recover an empty additional payload, but encoders
+-- never emit it. Canton behaves the same way, which is what keeps it
+-- wire-compatible: two distinct byte strings decode to the same message.
+----------------------------------------------------------------------
+
+emptyPayloadInnerNtt : Bytes
+emptyPayloadInnerNtt = "994e545407000000000012d687beefface00000000000000000000000000000000000000000000000000000000feebcafe0000000000000000000000000000000000000000000000000000000000020000"
+
+-- | The non-canonical form decodes to the same NativeTokenTransfer as the
+-- canonical form, but re-encoding yields the canonical (shorter) bytes, never
+-- the non-canonical input. Matches the EVM/SDK behavior exactly.
+testVectorNonCanonicalEmptyPayload : Script ()
+testVectorNonCanonicalEmptyPayload = do
+  let decoded = decodeNativeTokenTransfer emptyPayloadInnerNtt
+  decoded === vecNtt
+  decoded.additionalPayload === ""
+  -- The trailing 0x0000 length is dropped on re-encode: the canonical bytes
+  -- are shorter than the accepted non-canonical input.
+  assert (encodeNativeTokenTransfer decoded /= emptyPayloadInnerNtt)
+  byteLength emptyPayloadInnerNtt === 81
+  byteLength (encodeNativeTokenTransfer decoded) === 79
+
+----------------------------------------------------------------------
+-- TrimmedAmount numeric vectors, ported from
+-- solana/modules/ntt-messages/src/trimmed_amount.rs and the identical Sui
+-- suite. The reference `trim` takes (amount, fromDecimals, toDecimals) and
+-- trims to min(8, fromDecimals, toDecimals). Canton's `trimAmount` takes only
+-- (amount, fromDecimals) and trims to min(8, fromDecimals): it has no
+-- destination-decimals input because a Canton deployment stores no per-peer
+-- decimals. These tests pin where the two agree and where they diverge.
+----------------------------------------------------------------------
+
+-- | Cases where min(8, from, to) == min(8, from): Canton matches the reference.
+testTrimVectorsMatching : Script ()
+testTrimVectorsMatching = do
+  -- reference trim(1e17, from=18, to=13) -> {amount 1e7, decimals 8};
+  -- min(8,18,13) == min(8,18) == 8, so Canton agrees.
+  let t1 = trimAmount 100000000000000000 18
+  t1 === TrimmedAmount with decimals = 8, amount = 10000000
+
+  -- reference trim(1e17, from=7, to=11) -> unchanged at decimals 7 (NOOP);
+  -- min(8,7,11) == min(8,7) == 7.
+  let t2 = trimAmount 100000000000000000 7
+  t2 === TrimmedAmount with decimals = 7, amount = 100000000000000000
+
+  -- reference trim(5e18,18,8).untrim(18) == 5e18 (EVM testTrimmingRoundTrip,
+  -- scaled down from 50e18: the reference uses a uint256/u64 amount, but 50e18
+  -- exceeds Daml's signed 64-bit Int max (~9.2e18) and cannot be written here
+  -- at all -- see testAmountUint64Bound for that divergence).
+  let t3 = trimAmount 5000000000000000000 18
+  untrimAmount t3 18 === 5000000000000000000
+
+  -- reference {amount 1, decimals 6}.untrim(13) == 1e7.
+  untrimAmount (TrimmedAmount with decimals = 6, amount = 1) 13 === 10000000
+
+  -- reference trim(100555555555555555,18,9).untrim(18) == 100555550000000000;
+  -- min(8,18,9) == 8, matches Canton.
+  let t5 = trimAmount 100555555555555555 18
+  untrimAmount t5 18 === 100555550000000000
+
+-- | Cases where the destination decimals are below min(8, fromDecimals). The
+-- reference trims further (to the destination decimals) and the EVM manager
+-- rejects any leftover dust at send time (TransferAmountHasDust). Canton
+-- cannot: it does not know the peer's decimals, so it trims only to
+-- min(8, fromDecimals) and sends more precision than a low-decimal peer can
+-- represent. The peer then truncates on receive, so value is lost relative to
+-- what the sender committed. These asserts pin Canton's actual (divergent)
+-- output.
+testTrimVectorsPeerDecimalDivergence : Script ()
+testTrimVectorsPeerDecimalDivergence = do
+  -- reference trim(158434, from=6, to=3) == {amount 158, decimals 3}.
+  -- Canton trims only by fromDecimals=6:
+  trimAmount 158434 6 === TrimmedAmount with decimals = 6, amount = 158434
+  -- (reference would be decimals = 3, amount = 158)
+
+  -- reference trim(100555555555555555, from=18, to=1).untrim(18)
+  --   == 100000000000000000 (trimmed to 1 decimal).
+  -- Canton trims to 8 decimals and preserves far more precision:
+  let t = trimAmount 100555555555555555 18
+  untrimAmount t 18 === 100555550000000000
+  -- (reference, trimming to min(8,18,1)=1, would yield 100000000000000000)
+
+  -- Demonstration of end-to-end value loss to a 3-decimal peer:
+  -- sender at 6 decimals sends 158434 units (= 0.158434). Canton puts
+  -- {amount 158434, decimals 6} on the wire; a 3-decimal peer untrims to
+  -- 158434 / 10^3 = 158 units (= 0.158), silently dropping 0.000434.
+  let onWire = trimAmount 158434 6
+  untrimAmount onWire 3 === 158
+
+-- | The wire amount field is a uint64 (0 .. 2^64-1). Daml's Int is signed
+-- 64-bit, so its max is 2^63-1 (about 9.2e18). Amounts in [2^63, 2^64) are
+-- legal on the wire and producible by an EVM/Solana peer, but cannot be
+-- represented on Canton: the value 9223372036854775807 is the largest Int, and
+-- decoding a larger wire amount overflows and aborts the transaction. This is
+-- fail-closed (such an inbound transfer is undeliverable, never mis-paid) but
+-- is a wire-compatibility asymmetry, so a peer must not send amounts at that
+-- scale to a Canton deployment.
+testAmountUint64Bound : Script ()
+testAmountUint64Bound = do
+  -- The largest amount Canton can carry; one more would not typecheck as an
+  -- Int literal and larger values decoded off the wire overflow at runtime.
+  let maxInt = 9223372036854775807
+  (trimAmount maxInt 0).amount === maxInt
+  pure ()

--- a/canton/test/daml/Test/TestNttVectors.daml
+++ b/canton/test/daml/Test/TestNttVectors.daml
@@ -187,34 +187,36 @@ testTrimVectorsMatching = do
   let t5 = trimAmount 100555555555555555 18
   untrimAmount t5 18 === 100555550000000000
 
--- | Cases where the destination decimals are below min(8, fromDecimals). The
--- reference trims further (to the destination decimals) and the EVM manager
--- rejects any leftover dust at send time (TransferAmountHasDust). Canton
--- cannot: it does not know the peer's decimals, so it trims only to
--- min(8, fromDecimals) and sends more precision than a low-decimal peer can
--- represent. The peer then truncates on receive, so value is lost relative to
--- what the sender committed. These asserts pin Canton's actual (divergent)
--- output.
-testTrimVectorsPeerDecimalDivergence : Script ()
-testTrimVectorsPeerDecimalDivergence = do
+-- | The destination-decimals cases. The reference trims to
+-- min(8, fromDecimals, toDecimals) so no precision is put on the wire that the
+-- peer cannot represent, and rejects any leftover dust at send time. The
+-- manager now uses 'trimAmountTo' for exactly this, so it matches the reference
+-- here. (The bare two-argument 'trimAmount' still trims by source decimals
+-- only and is retained for the codec-level round-trip vectors; the manager does
+-- not use it on the send path.)
+testTrimToPeerDecimals : Script ()
+testTrimToPeerDecimals = do
   -- reference trim(158434, from=6, to=3) == {amount 158, decimals 3}.
-  -- Canton trims only by fromDecimals=6:
+  trimAmountTo 158434 6 3 === TrimmedAmount with decimals = 3, amount = 158
+  -- The bare source-only helper keeps all 6 decimals (why the manager must not
+  -- use it against a lower-decimals peer).
   trimAmount 158434 6 === TrimmedAmount with decimals = 6, amount = 158434
-  -- (reference would be decimals = 3, amount = 158)
 
   -- reference trim(100555555555555555, from=18, to=1).untrim(18)
   --   == 100000000000000000 (trimmed to 1 decimal).
-  -- Canton trims to 8 decimals and preserves far more precision:
-  let t = trimAmount 100555555555555555 18
-  untrimAmount t 18 === 100555550000000000
-  -- (reference, trimming to min(8,18,1)=1, would yield 100000000000000000)
+  let t = trimAmountTo 100555555555555555 18 1
+  untrimAmount t 18 === 100000000000000000
 
-  -- Demonstration of end-to-end value loss to a 3-decimal peer:
-  -- sender at 6 decimals sends 158434 units (= 0.158434). Canton puts
-  -- {amount 158434, decimals 6} on the wire; a 3-decimal peer untrims to
-  -- 158434 / 10^3 = 158 units (= 0.158), silently dropping 0.000434.
-  let onWire = trimAmount 158434 6
-  untrimAmount onWire 3 === 158
+  -- A round amount for a 3-decimal peer survives with no dust: 158000 units at
+  -- 6 decimals (= 0.158) trims to {158, dec 3} and round-trips exactly, so the
+  -- manager's dust check (untrim == raw) passes.
+  let onWire = trimAmountTo 158000 6 3
+  onWire === TrimmedAmount with decimals = 3, amount = 158
+  untrimAmount onWire 6 === 158000
+
+  -- 158434 does NOT round-trip to a 3-decimal peer (untrim gives 158000, not
+  -- 158434), which is exactly the dust the manager's Transfer now rejects.
+  assert (untrimAmount (trimAmountTo 158434 6 3) 6 /= 158434)
 
 -- | The wire amount field is a uint64 (0 .. 2^64-1). Daml's Int is signed
 -- 64-bit, so its max is 2^63-1 (about 9.2e18). Amounts in [2^63, 2^64) are


### PR DESCRIPTION
Prompted claude with the following:

```
ultracode this branch implements the NTT standard for Canton. it is instrumental that
      our NTT implementation is compliant with the standard. The standard is loosely
      specified via invariants, documentation, and reference implementations. your task
      is to distill the spec and verify that the Canton implementation matches it. the first
      thing to verify is functional: is it compatible with the NTT flow (can it be connected
      into an existing NTT mesh, and if so, how?). second is security (this is where the
      invariants come in). finally, the access control component. some things you might want
      to do is adopt the deserialisation tests from the other runtime implementations.
      I want you to just evaluate the current state, and you're free to
      implement tests to verify any property.
```

This uncovered a small number of deviations, which were fixed in follow up commits. Stored the resulting evaluation as an artefact for posterity.

The most notable functional changes is the addition of pausing, currently just by the admin (no separate pauser role).