### PR TITLE
canton: burn/mint minter de-escalation — keep gg out of caller-committed factories

### DIFF
--- a/canton/ntt/daml/Wormhole/Ntt/Governance.daml
+++ b/canton/ntt/daml/Wormhole/Ntt/Governance.daml
@@ -6,7 +6,8 @@
 -- NTT. Afterwards, 'RegisterManager' lends the root's inherited signatures to
 -- create a fully co-signed 'NttManager' per deployment, so deployment stays
 -- permissionless and crankless: any admin with a disclosure of this root can
--- register, and no fresh quorum runs per manager. This is the same
+-- register (for burn/mint, co-signed by the instrument's admin — see
+-- 'RegisterManager'), and no fresh quorum runs per manager. This is the same
 -- signed-anchor pattern the core uses for @EmitterRegistry@.
 --
 -- Lending gg's signature this way is safe because 'RegisterManager' only ever
@@ -41,10 +42,11 @@ template NttGovernance
     -- the deployment's gg-owned transceiver 'Emitter' and claim its gg-scoped
     -- replay-trie root, then create the 'NttManager' (plus, for lock/unlock,
     -- its zero-balance 'LockedLedger'). @admin@ is the transferable
-    -- operational role — the sole controller, since gg's authority (the
-    -- transceiver owner, the replay consumer) is inherited from this
-    -- contract's own signatories, and no separate namespace party exists
-    -- anymore.
+    -- operational role. For lock/unlock it is the sole controller — gg's
+    -- authority (the transceiver owner, the replay consumer) is inherited
+    -- from this contract's own signatories, and no separate namespace party
+    -- exists anymore. For burn/mint the instrument's admin co-signs; see the
+    -- controller note below.
     --
     -- The deployment's stable identity is the derived @namespace : Text@:
     -- @"ntt:" <> keccak256(tag ‖ instrument.admin ‖ instrument.id ‖
@@ -60,12 +62,12 @@ template NttGovernance
     -- permissionless without ever pooling an unvetted deployment's custody
     -- with anyone else's.
     --
-    -- For burn/mint, two checks make the mint capability sound:
-    -- @guardianGovernance@ must administer the instrument (otherwise the
-    -- manager could never mint it), and the instrument id must be
-    -- hash-committed to the registering admin via 'nttInstrumentIdFor' — see
-    -- there for why this keeps a bridged instrument exclusive to one
-    -- deployment.
+    -- For burn/mint, two rules make the mint capability sound: the
+    -- instrument's admin — the party whose mint authority the deployment
+    -- borrows — must co-sign the registration (see the controller note
+    -- below), and the instrument id must be hash-committed to the registering
+    -- admin via 'nttInstrumentIdFor' — see there for why this keeps a bridged
+    -- instrument exclusive to one deployment.
     --
     -- @coreStateCid@/@emitterFeeAllocation@/@claimFeeAllocation@ fund the
     -- registries' onboarding fees; @None@ when a registry charges none.
@@ -93,7 +95,14 @@ template NttGovernance
         coreStateCid          : Optional (ContractId CoreState)  -- required iff either onboarding fee > 0
         emitterFeeAllocation  : Optional (ContractId Allocation, ExtraArgs)
         claimFeeAllocation    : Optional (ContractId Allocation, ExtraArgs)
-      controller admin
+      -- For burn/mint, the instrument's admin (the minter) co-signs, because
+      -- it is lending its mint authority to this deployment. An external
+      -- minter simply consents, so registration stays permissionless; when
+      -- the minter is gg, the co-signature makes registration a governance
+      -- action, so an attacker cannot stand up a gg-minted deployment behind
+      -- a factory it controls. Lock/unlock has no minter and stays
+      -- @admin@-only.
+      controller admin :: (if tokenConfig == BurnMint then [instrumentId.admin] else [])
       do
         -- Decimal conversions ('untrimToDecimal') are exact only up to the 10
         -- fractional digits a Daml Decimal carries.
@@ -102,10 +111,11 @@ template NttGovernance
         assertMsg "ntt: chainId must be a positive uint16"
           (chainId > 0 && chainId <= 65535)
         case tokenConfig of
-          BurnMint -> do
-            assertMsg
-              "ntt: burn/mint requires guardianGovernance to administer the instrument"
-              (guardianGovernance == instrumentId.admin)
+          BurnMint ->
+            -- The instrument's admin — gg or an external minter — co-signs via
+            -- the controller, so no on-ledger check of its consent is needed
+            -- here. The id binding keeps the instrument exclusive to one
+            -- deployment (see 'nttInstrumentIdFor').
             assertMsg "ntt: burn/mint instrument id is not bound to the registering admin"
               (instrumentId.id == nttInstrumentIdFor admin instrumentNonce)
           LockUnlock -> pure ()
@@ -155,6 +165,13 @@ template NttGovernance
           peers = Map.empty
           factory
           paused = False
+          -- An external minter (instrument admin ≠ gg) becomes a manager
+          -- signatory so the burn/mint paths run on its authority, not gg's;
+          -- gg-minted deployments carry None and mint on gg's inherited
+          -- signature.
+          minter = case tokenConfig of
+            BurnMint | instrumentId.admin /= guardianGovernance -> Some instrumentId.admin
+            _ -> None
         ledger <- case tokenConfig of
           LockUnlock -> Some <$> create LockedLedger with
             operator

--- a/canton/ntt/daml/Wormhole/Ntt/Manager.daml
+++ b/canton/ntt/daml/Wormhole/Ntt/Manager.daml
@@ -6,18 +6,23 @@
 -- 'TIV1.TransferFactory', 'BurnMintFactory') directly, so any conforming token
 -- works without a per-token wrapper contract.
 --
--- Three parties sign the manager, and each signature has one job:
+-- Three parties sign every manager, and each signature has one job:
 --
 --   * @admin@ is the operational role: it maintains the peer table, rotates
 --     the committed factory, and owns the lock/unlock reserve. It is
 --     transferable ('TransferAdmin'); transferring it to gg is the guardian
 --     quorum's custody opt-in.
 --   * @guardianGovernance@ (gg), the guardians' k-of-n threshold party, is the
---     mint authority for burn/mint instruments, the owner of the deployment's
---     transceiver 'Emitter', the replay-scope consumer, and the quorum
---     end-state of 'TransferAdmin': a gg-adminned deployment's reserve is
---     quorum-owned and its admin operations are governance actions.
+--     mint authority for gg-administered burn/mint instruments, the owner of
+--     the deployment's transceiver 'Emitter', the replay-scope consumer, and
+--     the quorum end-state of 'TransferAdmin': a gg-adminned deployment's
+--     reserve is quorum-owned and its admin operations are governance actions.
 --   * @operator@ ties the deployment to its core bridge instance.
+--
+-- A burn/mint deployment whose instrument an external party administers
+-- carries that party as a fourth signatory, @minter@; the burn and mint paths
+-- then run on its authority instead of gg's (see 'effectiveMinter' and
+-- 'BurnMintMinterProxy').
 --
 -- The deployment's stable identity is no longer a co-signing party — it is a
 -- derived @namespace : Text@ (see 'nttNamespaceFor'), committed at
@@ -61,11 +66,11 @@
 -- extra holdings of its own to 'ConsolidateCustody', and 'TransferAdmin'
 -- refuses to hand over a reserve that no longer covers the balance.
 --
--- Because every choice body carries all four signatures, custody paths must
--- never rely on ambient authority: 'sumCustodyHoldings' checks that each
--- custody holding the manager spends is owned by the deployment's own current
--- @admin@, so one deployment's choices can never spend another custodian's
--- holdings even when that party's authority is in scope.
+-- Because every choice body carries all of the manager's signatures, custody
+-- paths must never rely on ambient authority: 'sumCustodyHoldings' checks
+-- that each custody holding the manager spends is owned by the deployment's
+-- own current @admin@, so one deployment's choices can never spend another
+-- custodian's holdings even when that party's authority is in scope.
 --
 -- The registry factory is deployment config, not per-call input. The token's
 -- factory is a stateless service contract whose cid is stable (its choices are
@@ -82,7 +87,7 @@ module Wormhole.Ntt.Manager where
 import DA.Crypto.Text (keccak256, toHex)
 import DA.Map (Map)
 import DA.Map qualified as Map
-import DA.Optional (fromSomeNote)
+import DA.Optional (fromSomeNote, fromOptional, optionalToList)
 
 import Splice.Api.Token.AllocationV1 (Allocation)
 import Splice.Api.Token.HoldingV1 (Holding, InstrumentId (..))
@@ -140,6 +145,60 @@ requireBurnMintFactory : NttFactory -> Update (ContractId BurnMintFactory)
 requireBurnMintFactory = \case
   BurnMintFactoryCid cid -> pure cid
   TransferFactoryCid _ -> abort "ntt: deployment's committed factory is not a burn/mint factory"
+
+-- | The party that administers this deployment's burn/mint instrument and
+-- therefore authorizes minting/burning: the external @minter@ when present,
+-- otherwise gg (the gg-minted case). Equal to @instrumentId.admin@ by
+-- construction (see 'Wormhole.Ntt.Governance.RegisterManager'). It is always a
+-- signatory of the manager, so the manager can drive the factory on its
+-- authority.
+effectiveMinter : NttManager -> Party
+effectiveMinter mgr = fromOptional mgr.guardianGovernance mgr.minter
+
+-- | A privilege-de-escalation proxy for the outbound burn.
+--
+-- The manager must not exercise a caller-committed 'BurnMintFactory'
+-- directly. Its choice bodies always carry gg (a lifetime signatory), and
+-- 'BurnMintFactory_BurnMint' is controlled by the factory's own interface
+-- view admin — a value the implementation is free to report as gg. A direct
+-- call would therefore hand gg's authority to arbitrary factory code.
+--
+-- Routing the burn through this @minter@-signed proxy resets the authority
+-- at the choice boundary to @{minter, user}@. gg does not cross it, so a
+-- lying @view.admin = gg@ controller can no longer be satisfied. For an
+-- external minter this fully firewalls gg. For a gg-minted deployment
+-- (@minter@ = gg) the proxy still carries gg — necessarily, since gg is the
+-- real mint authority — which is why a gg-minted deployment can only ever
+-- commit a gg-vetted factory (gg co-signs
+-- 'Wormhole.Ntt.Governance.RegisterManager').
+--
+-- Created and consumed inside 'NttManager.Transfer'; never persisted.
+template BurnMintMinterProxy
+  with
+    minter : Party
+  where
+    signatory minter
+
+    choice ProxyBurnMint : ()
+      with
+        factoryCid       : ContractId BurnMintFactory
+        instrumentId     : InstrumentId
+        inputHoldingCids : [ContractId Holding]
+        outputs          : [BurnMintOutput]
+        user             : Party
+        extraArgs        : ExtraArgs
+      -- Both the minter (mint authority) and the token owner authorize; gg is
+      -- deliberately absent from this body.
+      controller minter, user
+      do
+        _ <- exercise factoryCid BurnMintFactory_BurnMint with
+          expectedAdmin = minter
+          instrumentId
+          inputHoldingCids
+          outputs
+          extraActors = [user]
+          extraArgs
+        pure ()
 
 -- | A peer NTT deployment on another chain: its manager address (the
 -- @recipientManager@/@sourceManager@ in the transceiver message), its
@@ -370,12 +429,22 @@ template NttManager
     peers                : Map Int Peer    -- chain id -> peer deployment
     factory              : NttFactory      -- the registry's committed factory, typed by mode
     paused               : Bool            -- emergency halt: blocks Transfer/Release/Mint
+    minter               : Optional Party  -- external burn/mint minter (Some) — see 'effectiveMinter'; None when gg mints
   where
     -- See the module header for what each signature contributes. All three
-    -- are inherited from the NttGovernance root at registration (admin from
-    -- the registering caller); no signatory acts per transfer. @namespace@ is
-    -- derived data, not a party — it needs no signature of its own.
-    signatory operator, admin, guardianGovernance
+    -- base signatures are inherited from the NttGovernance root at
+    -- registration (admin from the registering caller); no signatory acts per
+    -- transfer. @namespace@ is derived data, not a party.
+    --
+    -- @minter@, when present, co-signs too: it is the external party that
+    -- administers a burn/mint instrument (@instrumentId.admin@) and thereby
+    -- lends its mint authority to this deployment. It is committed at
+    -- registration and never mutated, so a conditional signatory over it is
+    -- stable across every re-creating choice, and it survives 'TransferAdmin'
+    -- (which changes @admin@, not @minter@). Making it a signatory is what lets
+    -- the manager drive burn/mint on the minter's authority instead of gg's —
+    -- see 'effectiveMinter' and the de-escalation in the burn/'Mint' paths.
+    signatory (operator :: admin :: guardianGovernance :: optionalToList minter)
 
     -- | Register or replace a peer deployment. Consuming, but only admin
     -- config changes it, so the manager cid is stable across transfer traffic.
@@ -596,14 +665,17 @@ template NttManager
                   if change == 0.0
                     then []
                     else [ BurnMintOutput with owner = user, amount = change, context = extraArgs.context ]
-            _ <- exercise burnMintFactoryCid BurnMintFactory_BurnMint with
-              expectedAdmin = instrumentId.admin
+            -- Drive the factory through a minter-signed de-escalation proxy so
+            -- gg (a lifetime manager signatory) never crosses into the
+            -- caller-committed factory. The proxy carries only {minter, user}.
+            proxyCid <- create BurnMintMinterProxy with minter = effectiveMinter this
+            exercise proxyCid ProxyBurnMint with
+              factoryCid = burnMintFactoryCid
               instrumentId
               inputHoldingCids
               outputs
-              extraActors = [user]
+              user
               extraArgs
-            pure ()
         let ntt = NativeTokenTransfer with
               decimals = trimmed.decimals
               amount = trimmed.amount

--- a/canton/ntt/daml/Wormhole/Ntt/Manager.daml
+++ b/canton/ntt/daml/Wormhole/Ntt/Manager.daml
@@ -80,8 +80,8 @@
 -- commitment is typed by mode ('NttFactory'), matched against 'NttTokenConfig'
 -- at registration and rotation, so no call site coerces a contract id. @admin@
 -- refreshes it with 'SetFactory' on the rare occasion the registry is
--- upgraded; on a gg-adminned deployment that rotation is automatically a
--- governance action.
+-- upgraded; for burn/mint the 'effectiveMinter' co-signs that rotation, so
+-- the committed factory stays minter-vetted for the deployment's whole life.
 module Wormhole.Ntt.Manager where
 
 import DA.Crypto.Text (keccak256, toHex)
@@ -169,8 +169,9 @@ effectiveMinter mgr = fromOptional mgr.guardianGovernance mgr.minter
 -- external minter this fully firewalls gg. For a gg-minted deployment
 -- (@minter@ = gg) the proxy still carries gg — necessarily, since gg is the
 -- real mint authority — which is why a gg-minted deployment can only ever
--- commit a gg-vetted factory (gg co-signs
--- 'Wormhole.Ntt.Governance.RegisterManager').
+-- commit a gg-vetted factory (gg co-signs both
+-- 'Wormhole.Ntt.Governance.RegisterManager' and every later 'SetFactory'
+-- rotation).
 --
 -- Created and consumed inside 'NttManager.Transfer'; never persisted.
 template BurnMintMinterProxy
@@ -481,12 +482,21 @@ template NttManager
 
     -- | Repoint the committed registry factory. Needed only when the registry
     -- is upgraded and re-creates its factory under a new cid; @admin@ resolves
-    -- the new cid from the registry and commits it here. On a gg-adminned
-    -- deployment this is automatically a governance action.
+    -- the new cid from the registry and commits it here.
+    --
+    -- For burn/mint the 'effectiveMinter' — the party whose mint authority
+    -- the factory wields — co-signs the rotation, mirroring the co-signature
+    -- 'Wormhole.Ntt.Governance.RegisterManager' requires when the factory is
+    -- first committed. Without it a mutable @admin@ could later swap in a
+    -- look-alike factory; on a gg-minted deployment, where gg reaches the
+    -- factory body directly, that would re-open the authority leak the
+    -- de-escalation closes. The committed factory must stay minter-vetted
+    -- for the life of the deployment, not just at registration. Lock/unlock's
+    -- transfer factory never wields gg, so it stays @admin@-only.
     choice SetFactory : ContractId NttManager
       with
         newFactory : NttFactory
-      controller admin
+      controller admin :: (if tokenConfig == BurnMint then [effectiveMinter this] else [])
       do
         assertMsg "ntt: factory type does not match the token config"
           (factoryMatchesConfig tokenConfig newFactory)

--- a/canton/test/daml/Test/TestFactoryAuthority.daml
+++ b/canton/test/daml/Test/TestFactoryAuthority.daml
@@ -1,0 +1,485 @@
+-- | Does an attacker-supplied token factory inherit gg's authority when the
+-- manager calls into it?
+--
+-- NTT registration is permissionless and commits a caller-supplied factory
+-- that the gg-signed manager later exercises. The worry: because the manager
+-- is signed by gg, a malicious factory implementation might wield gg's
+-- authority inside its own choice body — to create contracts signed by gg,
+-- or to spend gg's holdings.
+--
+-- The Daml authorization model says otherwise. The authority available
+-- inside a choice body is @signatories(contract) UNION controllers(choice)@;
+-- the caller's authority is used only to authorize the exercise itself and
+-- does NOT flow down into the callee's body. So a factory signed by the
+-- attacker can wield gg's authority only if gg is a CONTROLLER of the
+-- factory choice.
+--
+-- The proxies here reproduce the manager faithfully: a gg-signed contract
+-- (standing in for the gg-signed NttManager) exercises an attacker-authored
+-- factory whose implementation tries to create a contract signed by
+-- @expectedAdmin@ (gg, exactly the value the manager passes). gg's authority
+-- reaches the proxy's choice body through the proxy's signatory, precisely
+-- as it reaches the manager's Transfer/Mint bodies — the submission is NOT
+-- made as gg. If gg is not a controller of the factory choice, the forged
+-- create is rejected. The unit-level probes establish where the leak is and
+-- which shapes are safe; the tests at the end drive the real
+-- 'RegisterManager' and 'NttManager.Transfer' paths.
+module Test.TestFactoryAuthority where
+
+import Daml.Script
+import DA.Optional (fromSome)
+import DA.Time (hours, addRelTime)
+
+import Splice.Api.Token.HoldingV1 (Holding, HoldingView (..), InstrumentId (..))
+import Splice.Api.Token.MetadataV1 (emptyMetadata)
+import Splice.Api.Token.BurnMintV1
+import Splice.Api.Token.TransferInstructionV1
+import Wormhole.Core.Fees (emptyExtraArgs)
+import Wormhole.Core.State (Emitter)
+import Wormhole.Ntt.Governance (NttGovernance, RegisterManager (..))
+import Wormhole.Ntt.Manager qualified as M
+import Test.TestNtt (nttSetup, coreRegistries, cantonChainId, b32)
+
+-- | A contract signed by @victim@. If an attacker-authored factory can create
+-- one of these, it wielded @victim@'s (gg's) authority.
+template ForgedWithGgAuthority
+  with
+    victim : Party
+    thief  : Party
+  where
+    signatory victim
+    observer thief
+
+-- | An attacker's TransferFactory. Signed by the attacker (@thief@) alone,
+-- but its interface view reports @viewAdmin@ as the admin — the view is
+-- implementation-controlled and may lie. On transfer it tries to forge a
+-- contract signed by the @expectedAdmin@ the caller passed (gg).
+template EvilTransferFactory
+  with
+    thief        : Party
+    viewAdmin    : Party
+    attemptForge : Bool
+  where
+    signatory thief
+
+    interface instance TransferFactory for EvilTransferFactory where
+      view = TransferFactoryView with admin = viewAdmin, meta = emptyMetadata
+
+      transferFactory_transferImpl _self arg = do
+        if attemptForge
+          then do
+            _ <- create ForgedWithGgAuthority with victim = arg.expectedAdmin, thief
+            pure ()
+          else pure ()
+        pure TransferInstructionResult with
+          output = TransferInstructionResult_Completed with receiverHoldingCids = []
+          senderChangeCids = []
+          meta = emptyMetadata
+
+      transferFactory_publicFetchImpl _self _arg =
+        pure TransferFactoryView with admin = viewAdmin, meta = emptyMetadata
+
+-- | An attacker's BurnMintFactory, same idea, with a possibly-lying view admin.
+template EvilBurnMintFactory
+  with
+    thief        : Party
+    viewAdmin    : Party
+    attemptForge : Bool
+  where
+    signatory thief
+
+    interface instance BurnMintFactory for EvilBurnMintFactory where
+      view = BurnMintFactoryView with admin = viewAdmin, meta = emptyMetadata
+
+      burnMintFactory_burnMintImpl _self arg = do
+        if attemptForge
+          then do
+            _ <- create ForgedWithGgAuthority with victim = arg.expectedAdmin, thief
+            pure ()
+          else pure ()
+        pure BurnMintFactory_BurnMintResult with outputCids = []
+
+      burnMintFactory_publicFetchImpl _self _arg =
+        pure BurnMintFactoryView with admin = viewAdmin, meta = emptyMetadata
+
+-- | Exercise a burn/mint factory with the argument shape the manager uses: a
+-- placeholder instrument administered by @expectedAdmin@, no holdings, no
+-- outputs. Just enough to reach the factory's choice body — all that matters
+-- in these probes is which authority crosses into it.
+probeBurnMint : ContractId BurnMintFactory -> Party -> [Party] -> Update ()
+probeBurnMint factoryCid expectedAdmin extraActors = do
+  _ <- exercise factoryCid BurnMintFactory_BurnMint with
+    expectedAdmin
+    instrumentId = InstrumentId with admin = expectedAdmin, id = "X"
+    inputHoldingCids = []
+    outputs = []
+    extraActors
+    extraArgs = emptyExtraArgs
+  pure ()
+
+-- | Stands in for the gg-signed NttManager: a contract signed by gg whose
+-- choice body (controlled by an ordinary caller) exercises a factory, exactly
+-- as the manager's Transfer/Mint bodies do. gg's authority is present in the
+-- body via the signatory, not via the submission.
+template ManagerProxy
+  with
+    gg     : Party
+    caller : Party
+  where
+    signatory gg
+    observer caller
+
+    nonconsuming choice RunTransferFactory : ()
+      with
+        factoryCid    : ContractId TransferFactory
+        expectedAdmin : Party
+      controller caller
+      do
+        now <- getTime
+        _ <- exercise factoryCid TransferFactory_Transfer with
+          expectedAdmin
+          transfer = Transfer with
+            sender = caller
+            receiver = caller
+            amount = 1.0
+            instrumentId = InstrumentId with admin = expectedAdmin, id = "X"
+            requestedAt = now
+            executeBefore = now `addRelTime` hours 24
+            inputHoldingCids = []
+            meta = emptyMetadata
+          extraArgs = emptyExtraArgs
+        pure ()
+
+    nonconsuming choice RunBurnMintFactory : ()
+      with
+        factoryCid    : ContractId BurnMintFactory
+        expectedAdmin : Party
+      controller caller
+      do probeBurnMint factoryCid expectedAdmin [caller]
+
+-- | An admin-owned deployment: the manager is signed by @admin@ (the mint
+-- authority) and NOT by gg. This models a burn/mint deployment that does not
+-- lend gg's authority — the mint runs on the admin's own authority, the way
+-- lock/unlock custody starts admin-owned. gg is absent from the choice body,
+-- so there is nothing for a lying factory view to capture.
+template AdminOwnedProxy
+  with
+    admin  : Party
+    caller : Party
+  where
+    signatory admin
+    observer caller
+
+    nonconsuming choice RunBurnMintFactoryAO : ()
+      with
+        factoryCid    : ContractId BurnMintFactory
+        expectedAdmin : Party
+      controller caller
+      do probeBurnMint factoryCid expectedAdmin [caller]
+
+-- | A privilege de-escalation proxy for the burn/mint operation: signed and
+-- controlled by the minter (the deployment's stable party) alone, never gg.
+-- Driving the factory THROUGH this contract resets the ambient authority to
+-- {minter} at the choice boundary, so a gg-signed manager can run a burn/mint
+-- without ever lending gg to the factory.
+template BurnMintDeescalationProxy
+  with
+    minter : Party
+  where
+    signatory minter
+
+    nonconsuming choice RunBurnMintDeescalated : ()
+      with
+        factoryCid    : ContractId BurnMintFactory
+        expectedAdmin : Party
+      controller minter
+      do probeBurnMint factoryCid expectedAdmin [minter]
+
+-- | Models the real manager once the replay trie forces gg to be a permanent
+-- signatory: signed by BOTH gg and admin. It runs burn/mint through the
+-- de-escalation proxy instead of exercising the factory directly.
+template ManagerWithGgAndAdmin
+  with
+    gg     : Party
+    admin  : Party
+    caller : Party
+  where
+    signatory gg, admin
+    observer caller
+
+    nonconsuming choice MintViaDeescalation : ()
+      with
+        factoryCid    : ContractId BurnMintFactory
+        expectedAdmin : Party
+      controller caller
+      do
+        deesc <- create BurnMintDeescalationProxy with minter = admin
+        _ <- exercise deesc RunBurnMintDeescalated with factoryCid, expectedAdmin
+        pure ()
+
+-- | The de-escalation mitigation, with gg PERMANENTLY on the manager. The
+-- manager routes burn/mint through an admin-signed proxy; the factory body
+-- then carries only {admin}, so a lying view.admin = gg controller cannot be
+-- satisfied and no gg-signed contract is forged. Contrast with
+-- testEvilBurnMintFactoryForgesGgContract, where the gg-signed manager drives
+-- the factory directly and leaks.
+testDeescalationProxyBlocksGgLeak : Script ()
+testDeescalationProxyBlocksGgLeak = do
+  gg <- allocateParty "GgD"
+  admin <- allocateParty "AdminD"
+  factorySigner <- allocateParty "FacD"
+  caller <- allocateParty "CallerD"
+  mgr <- submit (actAs gg <> actAs admin) do
+    createCmd ManagerWithGgAndAdmin with gg, admin, caller
+  factoryCid <- submit factorySigner do
+    createCmd EvilBurnMintFactory with thief = factorySigner, viewAdmin = gg, attemptForge = True
+  fdisc <- fromSome <$> queryDisclosure factorySigner factoryCid
+  submitMustFail (actAs caller <> disclose fdisc) do
+    exerciseCmd mgr MintViaDeescalation with
+      factoryCid = toInterfaceContractId @BurnMintFactory factoryCid
+      expectedAdmin = gg
+  forged <- query @ForgedWithGgAuthority gg
+  assertMsg "de-escalation proxy failed to firewall gg" (null forged)
+
+-- | And an honest admin-minted burn/mint still works through the proxy: the
+-- factory's view.admin = admin, which the proxy's {admin} body satisfies.
+testDeescalationProxyStillMints : Script ()
+testDeescalationProxyStillMints = do
+  gg <- allocateParty "GgD2"
+  admin <- allocateParty "AdminD2"
+  caller <- allocateParty "CallerD2"
+  mgr <- submit (actAs gg <> actAs admin) do
+    createCmd ManagerWithGgAndAdmin with gg, admin, caller
+  factoryCid <- submit admin do
+    createCmd EvilBurnMintFactory with thief = admin, viewAdmin = admin, attemptForge = False
+  fdisc <- fromSome <$> queryDisclosure admin factoryCid
+  submit (actAs caller <> disclose fdisc) do
+    exerciseCmd mgr MintViaDeescalation with
+      factoryCid = toInterfaceContractId @BurnMintFactory factoryCid
+      expectedAdmin = admin
+
+-- | The mitigation. When the burn/mint manager is NOT gg-signed, even a
+-- factory that lies (view.admin = gg) and is driven with expectedAdmin = gg
+-- cannot capture gg: the choice's gg controller can no longer be satisfied,
+-- so the call is rejected before the forge and no gg-signed contract appears.
+-- Contrast with testEvilBurnMintFactoryForgesGgContract, where the gg-signed
+-- proxy leaks.
+testAdminOwnedManagerCannotLeakGg : Script ()
+testAdminOwnedManagerCannotLeakGg = do
+  gg <- allocateParty "GgAO"
+  admin <- allocateParty "AdminAO"
+  factorySigner <- allocateParty "FactoryAO"
+  caller <- allocateParty "CallerAO"
+  proxy <- submit admin do createCmd AdminOwnedProxy with admin, caller
+  factoryCid <- submit factorySigner do
+    createCmd EvilBurnMintFactory with thief = factorySigner, viewAdmin = gg, attemptForge = True
+  fdisc <- fromSome <$> queryDisclosure factorySigner factoryCid
+  submitMustFail (actAs caller <> disclose fdisc) do
+    exerciseCmd proxy RunBurnMintFactoryAO with
+      factoryCid = toInterfaceContractId @BurnMintFactory factoryCid
+      expectedAdmin = gg
+  forged <- query @ForgedWithGgAuthority gg
+  assertMsg "gg leaked from a manager that was not gg-signed" (null forged)
+
+-- | And the admin-owned mint still works without gg: the admin drives its own
+-- factory (view.admin = admin) on its own authority.
+testAdminOwnedManagerMintsWithoutGg : Script ()
+testAdminOwnedManagerMintsWithoutGg = do
+  admin <- allocateParty "AdminAO2"
+  caller <- allocateParty "CallerAO2"
+  proxy <- submit admin do createCmd AdminOwnedProxy with admin, caller
+  factoryCid <- submit admin do
+    createCmd EvilBurnMintFactory with thief = admin, viewAdmin = admin, attemptForge = False
+  fdisc <- fromSome <$> queryDisclosure admin factoryCid
+  submit (actAs caller <> disclose fdisc) do
+    exerciseCmd proxy RunBurnMintFactoryAO with
+      factoryCid = toInterfaceContractId @BurnMintFactory factoryCid
+      expectedAdmin = admin
+
+-- | Control: the proxy can drive a benign (non-forging) attacker factory to
+-- completion, so any failure in the forging variant is the forge itself, not
+-- an incidental error in the call path.
+testEvilTransferFactoryBenignPathWorks : Script ()
+testEvilTransferFactoryBenignPathWorks = do
+  gg <- allocateParty "GgT"
+  thief <- allocateParty "ThiefT"
+  caller <- allocateParty "CallerT"
+  proxy <- submit (actAs gg <> actAs caller) do createCmd ManagerProxy with gg, caller
+  factoryCid <- submit thief do createCmd EvilTransferFactory with thief, viewAdmin = gg, attemptForge = False
+  fdisc <- fromSome <$> queryDisclosure thief factoryCid
+  submit (actAs caller <> disclose fdisc) do
+    exerciseCmd proxy RunTransferFactory with
+      factoryCid = toInterfaceContractId @TransferFactory factoryCid
+      expectedAdmin = gg
+
+-- | The attack: the attacker factory tries to create a gg-signed contract
+-- while driven by the gg-signed proxy. It must fail — gg's manager-signatory
+-- authority does not reach the factory body. The factory is disclosed to the
+-- caller (as a real submission would disclose the committed factory), so the
+-- call actually reaches the factory body; the only thing that can then fail
+-- is the forge itself. If this ever SUCCEEDS, gg's authority leaked and the
+-- submitMustFail turns into a loud test failure.
+testEvilTransferFactoryCannotForgeGgContract : Script ()
+testEvilTransferFactoryCannotForgeGgContract = do
+  gg <- allocateParty "GgT2"
+  thief <- allocateParty "ThiefT2"
+  caller <- allocateParty "CallerT2"
+  proxy <- submit (actAs gg <> actAs caller) do createCmd ManagerProxy with gg, caller
+  factoryCid <- submit thief do createCmd EvilTransferFactory with thief, viewAdmin = gg, attemptForge = True
+  fdisc <- fromSome <$> queryDisclosure thief factoryCid
+  submitMustFail (actAs caller <> disclose fdisc) do
+    exerciseCmd proxy RunTransferFactory with
+      factoryCid = toInterfaceContractId @TransferFactory factoryCid
+      expectedAdmin = gg
+  -- No gg-signed contract was forged.
+  forged <- query @ForgedWithGgAuthority gg
+  assertMsg "gg authority leaked into the transfer factory" (null forged)
+
+-- | Control for the burn/mint pair: the same call path with the forge
+-- disabled runs to completion, so the vulnerability test below measures the
+-- forge alone.
+testEvilBurnMintFactoryBenignPathWorks : Script ()
+testEvilBurnMintFactoryBenignPathWorks = do
+  gg <- allocateParty "GgB"
+  thief <- allocateParty "ThiefB"
+  caller <- allocateParty "CallerB"
+  proxy <- submit (actAs gg <> actAs caller) do createCmd ManagerProxy with gg, caller
+  factoryCid <- submit thief do createCmd EvilBurnMintFactory with thief, viewAdmin = gg, attemptForge = False
+  fdisc <- fromSome <$> queryDisclosure thief factoryCid
+  submit (actAs caller <> disclose fdisc) do
+    exerciseCmd proxy RunBurnMintFactory with
+      factoryCid = toInterfaceContractId @BurnMintFactory factoryCid
+      expectedAdmin = gg
+
+-- | THE VULNERABILITY. Unlike the transfer factory, an attacker's burn/mint
+-- factory CAN forge a gg-signed contract when a gg-signed contract exercises
+-- it directly: BurnMintFactory_BurnMint is controlled by the factory's view
+-- admin, which the implementation controls and can set to gg; the gg-signed
+-- caller satisfies that controller, and gg's authority is delegated into the
+-- attacker's choice body. This test passes when the forge SUCCEEDS — it
+-- documents the leak, not a safe outcome. It is why the manager never
+-- exercises the committed factory directly and burns through
+-- 'M.BurnMintMinterProxy' instead;
+-- testExternalMinterMaliciousFactoryFirewallsGg shows that de-escalation
+-- holding on the real burn path.
+testEvilBurnMintFactoryForgesGgContract : Script ()
+testEvilBurnMintFactoryForgesGgContract = do
+  gg <- allocateParty "GgB2"
+  thief <- allocateParty "ThiefB2"
+  caller <- allocateParty "CallerB2"
+  proxy <- submit (actAs gg <> actAs caller) do createCmd ManagerProxy with gg, caller
+  factoryCid <- submit thief do createCmd EvilBurnMintFactory with thief, viewAdmin = gg, attemptForge = True
+  fdisc <- fromSome <$> queryDisclosure thief factoryCid
+  submit (actAs caller <> disclose fdisc) do
+    exerciseCmd proxy RunBurnMintFactory with
+      factoryCid = toInterfaceContractId @BurnMintFactory factoryCid
+      expectedAdmin = gg
+  forged <- query @ForgedWithGgAuthority gg
+  assertMsg "expected the attacker's burn/mint factory to forge a gg-signed contract" (not (null forged))
+
+-- | The registration submission the end-to-end tests share: @admin@ registers
+-- a burn/mint deployment for @inst@, committing @factoryCid@ — an
+-- attacker-supplied factory, which is why these tests cannot use TestNtt's
+-- honest 'Test.TestNtt.deploy'. Returns the disclosures the submission needs
+-- and the command itself, so each test decides whether it must succeed or
+-- fail.
+registerBurnMint
+  : Party -> Party -> InstrumentId -> ContractId BurnMintFactory
+  -> Script ([Disclosure], Commands (ContractId M.NttManager, ContractId Emitter))
+registerBurnMint operator admin inst factoryCid = do
+  [(govCid, _)] <- query @NttGovernance operator
+  govDisc <- fromSome <$> queryDisclosure operator govCid
+  (emReg, emRegDisc, rrReg, rrRegDisc) <- coreRegistries operator
+  let register = exerciseCmd govCid RegisterManager with
+        admin
+        chainId = cantonChainId
+        emitterRegistryCid = emReg
+        replayRootRegistryCid = rrReg
+        instrumentId = inst
+        instrumentNonce = 0
+        tokenConfig = M.BurnMint
+        tokenDecimals = 8
+        factory = M.BurnMintFactoryCid factoryCid
+        coreStateCid = None
+        emitterFeeAllocation = None
+        claimFeeAllocation = None
+  pure ([govDisc, emRegDisc, rrRegDisc], (\(_, mgrCid, emitterCid, _) -> (mgrCid, emitterCid)) <$> register)
+
+-- | Through the real registration: an attacker cannot permissionlessly stand
+-- up a gg-minted deployment (instrument admin = gg), because 'RegisterManager'
+-- requires the instrument's admin to co-sign and the attacker cannot supply
+-- gg's authority. This closes the permissionless entry point the exploit
+-- relied on.
+testAttackerCannotRegisterGgMintedManager : Script ()
+testAttackerCannotRegisterGgMintedManager = do
+  (operator, gg, _) <- nttSetup
+  attacker <- allocateParty "AttackerGgMint"
+  evilFactory <- submit attacker do
+    createCmd EvilBurnMintFactory with thief = attacker, viewAdmin = gg, attemptForge = True
+  let inst = InstrumentId with admin = gg, id = M.nttInstrumentIdFor attacker 0
+  (discs, register) <- registerBurnMint operator attacker inst
+    (toInterfaceContractId @BurnMintFactory evilFactory)
+  submitMustFail (actAs attacker <> mconcat (map disclose discs)) register
+
+-- | A holding signed by its owner alone whose interface view lies about the
+-- instrument (claiming a gg-administered id). The manager's burn path reads
+-- only the view (owner, instrument, lock), never the signatories, so this
+-- passes its input checks — letting the attacker reach the committed factory
+-- with no genuine gg-issued holdings.
+template FakeHolding
+  with
+    owner      : Party
+    instrument : InstrumentId
+    amount     : Decimal
+  where
+    signatory owner
+    interface instance Holding for FakeHolding where
+      view = HoldingView with
+        owner
+        instrumentId = instrument
+        amount
+        lock = None
+        meta = emptyMetadata
+
+-- | The fix, end-to-end through the real manager. An external-minter
+-- deployment (minter = the registering party, not gg) commits a MALICIOUS
+-- factory whose view claims gg as admin, then drives a real burn. Because
+-- the outbound burn now routes through the minter-signed de-escalation proxy,
+-- gg never reaches the factory: the lying view.admin = gg controller cannot
+-- be satisfied, the burn aborts, and no gg-signed contract is forged.
+-- Contrast with testEvilBurnMintFactoryForgesGgContract, which forges one on
+-- this very path when driven directly.
+testExternalMinterMaliciousFactoryFirewallsGg : Script ()
+testExternalMinterMaliciousFactoryFirewallsGg = do
+  (operator, gg, csId) <- nttSetup
+  minter <- allocateParty "ExtMinter"   -- external minter and admin; also the attacker
+  evilFactory <- submit minter do
+    createCmd EvilBurnMintFactory with thief = minter, viewAdmin = gg, attemptForge = True
+  let inst = InstrumentId with admin = minter, id = M.nttInstrumentIdFor minter 0
+  (discs, register) <- registerBurnMint operator minter inst
+    (toInterfaceContractId @BurnMintFactory evilFactory)
+  (mgrCid, emitterCid) <- submit (actAs minter <> mconcat (map disclose discs)) register
+  mgrCid <- submit minter do
+    exerciseCmd mgrCid M.SetPeer with
+      chainId = 2
+      peer = M.Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc", decimals = 8
+  fakeHolding <- submit minter do
+    createCmd FakeHolding with owner = minter, instrument = inst, amount = 1.0
+  csDisc <- fromSome <$> queryDisclosure operator csId
+  submitMustFail (actAs minter <> disclose csDisc) do
+    exerciseCmd mgrCid M.Transfer with
+      user = minter
+      transceiverEmitterCid = emitterCid
+      coreStateCid = csId
+      ledgerCid = None
+      recipientChain = 2
+      recipientAddress = b32 "ee"
+      sourceToken = b32 "dd"
+      rawAmount = 100000000
+      nonce = 0
+      consistencyLevel = 0
+      inputHoldingCids = [toInterfaceContractId @Holding fakeHolding]
+      feeAllocation = None
+      extraArgs = emptyExtraArgs
+  forged <- query @ForgedWithGgAuthority gg
+  assertMsg "external-minter de-escalation failed to firewall gg via the real manager" (null forged)

--- a/canton/test/daml/Test/TestFactoryAuthority.daml
+++ b/canton/test/daml/Test/TestFactoryAuthority.daml
@@ -38,6 +38,7 @@ import Wormhole.Core.Fees (emptyExtraArgs)
 import Wormhole.Core.State (Emitter)
 import Wormhole.Ntt.Governance (NttGovernance, RegisterManager (..))
 import Wormhole.Ntt.Manager qualified as M
+import Wormhole.Ntt.Deposit (DepositPreapproval (..), Deposit (..))
 import Test.TestNtt (nttSetup, coreRegistries, cantonChainId, b32)
 
 -- | A contract signed by @victim@. If an attacker-authored factory can create
@@ -483,3 +484,77 @@ testExternalMinterMaliciousFactoryFirewallsGg = do
       extraArgs = emptyExtraArgs
   forged <- query @ForgedWithGgAuthority gg
   assertMsg "external-minter de-escalation failed to firewall gg via the real manager" (null forged)
+
+-- | Models the inbound Mint's call into the recipient's DepositPreapproval.
+-- Signed by gg (a lifetime manager signatory) AND the external minter, it
+-- drives the real 'Deposit' choice exactly as 'NttManager.Mint' does.
+-- 'Deposit' is controlled by the instrument admin — the minter — so its body
+-- carries {recipient, minter} and never gg: the inbound counterpart of the
+-- outbound de-escalation. (The VAA verification that 'Mint' runs before this
+-- point is orthogonal guardian-signature checking, and the recipient-hash
+-- binding makes a full VAA-driven mint a live-sandbox test; these tests
+-- exercise the authority boundary the inbound path relies on.)
+template MintManagerProxy
+  with
+    gg       : Party
+    minter   : Party
+    executor : Party
+  where
+    signatory gg, minter
+    observer executor
+
+    nonconsuming choice RunInboundDeposit : ()
+      with
+        preCid     : ContractId DepositPreapproval
+        factoryCid : ContractId BurnMintFactory
+        amount     : Decimal
+      controller executor
+      do
+        exercise preCid Deposit with amount, factoryCid, extraArgs = emptyExtraArgs
+        pure ()
+
+-- | Inbound firewall: for an external minter the inbound mint runs through the
+-- recipient's DepositPreapproval, whose 'Deposit' is controlled by the minter,
+-- not gg. Even driven by a gg-signed manager, a malicious factory reporting
+-- view.admin = gg cannot capture gg here, so no gg-signed contract is forged.
+testExternalMinterInboundMintFirewallsGg : Script ()
+testExternalMinterInboundMintFirewallsGg = do
+  gg <- allocateParty "GgIn"
+  minter <- allocateParty "MinterIn"
+  recipient <- allocateParty "RecipIn"
+  executor <- allocateParty "ExecIn"
+  let inst = InstrumentId with admin = minter, id = "EXT"
+  preCid <- submit recipient do createCmd DepositPreapproval with owner = recipient, instrumentId = inst
+  factoryCid <- submit minter do
+    createCmd EvilBurnMintFactory with thief = minter, viewAdmin = gg, attemptForge = True
+  proxy <- submit (actAs gg <> actAs minter) do createCmd MintManagerProxy with gg, minter, executor
+  fdisc <- fromSome <$> queryDisclosure minter factoryCid
+  pdisc <- fromSome <$> queryDisclosure recipient preCid
+  submitMustFail (actAs executor <> disclose fdisc <> disclose pdisc) do
+    exerciseCmd proxy RunInboundDeposit with
+      preCid
+      factoryCid = toInterfaceContractId @BurnMintFactory factoryCid
+      amount = 1.0
+  forged <- query @ForgedWithGgAuthority gg
+  assertMsg "inbound mint leaked gg for an external minter" (null forged)
+
+-- | And the external-minter inbound mint works with the minter's own factory
+-- (view.admin = minter), on the minter's authority, with no gg involved.
+testExternalMinterInboundMintWorks : Script ()
+testExternalMinterInboundMintWorks = do
+  gg <- allocateParty "GgIn2"
+  minter <- allocateParty "MinterIn2"
+  recipient <- allocateParty "RecipIn2"
+  executor <- allocateParty "ExecIn2"
+  let inst = InstrumentId with admin = minter, id = "EXT"
+  preCid <- submit recipient do createCmd DepositPreapproval with owner = recipient, instrumentId = inst
+  factoryCid <- submit minter do
+    createCmd EvilBurnMintFactory with thief = minter, viewAdmin = minter, attemptForge = False
+  proxy <- submit (actAs gg <> actAs minter) do createCmd MintManagerProxy with gg, minter, executor
+  fdisc <- fromSome <$> queryDisclosure minter factoryCid
+  pdisc <- fromSome <$> queryDisclosure recipient preCid
+  submit (actAs executor <> disclose fdisc <> disclose pdisc) do
+    exerciseCmd proxy RunInboundDeposit with
+      preCid
+      factoryCid = toInterfaceContractId @BurnMintFactory factoryCid
+      amount = 1.0

--- a/canton/test/daml/Test/TestNtt.daml
+++ b/canton/test/daml/Test/TestNtt.daml
@@ -393,8 +393,13 @@ deploy operator gg admin config = do
   [(govCid, _)] <- query @NttGovernance operator
   govDisc <- fromSome <$> queryDisclosure operator govCid
   (emReg, emRegDisc, rrReg, rrRegDisc) <- coreRegistries operator
+  -- Burn/mint registration is co-signed by the instrument's minter (here gg);
+  -- lock/unlock is admin-only.
+  let minterActAs = case config of
+        BurnMint -> actAs gg
+        LockUnlock -> mempty
   (_, mgrCid, emitterCid, ledgerCid) <-
-    submit (actAs admin <> disclose govDisc <> disclose emRegDisc <> disclose rrRegDisc) do
+    submit (actAs admin <> minterActAs <> disclose govDisc <> disclose emRegDisc <> disclose rrRegDisc) do
       exerciseCmd govCid RegisterManager with
         admin
         chainId = cantonChainId
@@ -484,7 +489,9 @@ testBurnMintRegistrationRequiresBoundInstrument = do
   [(govCid, _)] <- query @NttGovernance operator
   govDisc <- fromSome <$> queryDisclosure operator govCid
   (emReg, emRegDisc, rrReg, rrRegDisc) <- coreRegistries operator
-  res <- trySubmit (actAs admin <> disclose govDisc <> disclose emRegDisc <> disclose rrRegDisc) do
+  -- gg (the instrument admin) co-signs; the id binding still rejects the
+  -- unbound instrument id.
+  res <- trySubmit (actAs admin <> actAs gg <> disclose govDisc <> disclose emRegDisc <> disclose rrRegDisc) do
     exerciseCmd govCid RegisterManager with
       admin
       chainId = cantonChainId
@@ -501,10 +508,11 @@ testBurnMintRegistrationRequiresBoundInstrument = do
   expectAbort "not bound to the registering admin" res
 
 -- | The exclusivity attack the binding exists to stop: mallory registers her
--- own manager for an instrument that alice already bridges (it is
--- gg-administered, so the admin check alone would pass), aiming to mint it
--- against VAAs from a peer she controls. The id is bound to alice, so
--- mallory's registration fails no matter what nonce she picks.
+-- own manager for an instrument that alice already bridges, aiming to mint it
+-- against VAAs from a peer she controls. Even with the instrument admin (gg)
+-- co-signing, the id is bound to alice, so mallory's registration fails no
+-- matter what nonce she picks — a second defense behind the required minter
+-- co-signature.
 testBurnMintInstrumentIsExclusiveToItsAdmin : Script ()
 testBurnMintInstrumentIsExclusiveToItsAdmin = do
   (operator, gg, _) <- nttSetup
@@ -515,7 +523,7 @@ testBurnMintInstrumentIsExclusiveToItsAdmin = do
   govDisc <- fromSome <$> queryDisclosure operator govCid
   (emReg, emRegDisc, rrReg, rrRegDisc) <- coreRegistries operator
   forA_ [0, 1, 7] \nonce -> do
-    res <- trySubmit (actAs mallory <> disclose govDisc <> disclose emRegDisc <> disclose rrRegDisc) do
+    res <- trySubmit (actAs mallory <> actAs gg <> disclose govDisc <> disclose emRegDisc <> disclose rrRegDisc) do
       exerciseCmd govCid RegisterManager with
         admin = mallory
         chainId = cantonChainId
@@ -544,7 +552,10 @@ testRegistrationBounds = do
   (emReg, emRegDisc, rrReg, rrRegDisc) <- coreRegistries operator
   let discs = disclose govDisc <> disclose emRegDisc <> disclose rrRegDisc
 
-  res <- trySubmit (actAs admin <> discs) do
+  -- A burn/mint instrument's minter must co-sign registration (it lends its
+  -- mint authority). Here the external minter @outsider@ does not co-sign, so
+  -- the registration is unauthorized.
+  submitMustFail (actAs admin <> discs) do
     exerciseCmd govCid RegisterManager with
       admin
       chainId = cantonChainId
@@ -558,7 +569,6 @@ testRegistrationBounds = do
       coreStateCid = None
       emitterFeeAllocation = None
       claimFeeAllocation = None
-  expectAbort "requires guardianGovernance to administer" res
 
   res <- trySubmit (actAs admin <> discs) do
     exerciseCmd govCid RegisterManager with
@@ -1824,6 +1834,7 @@ setupFixedManagerOn operator gg admin config chainId = do
       peers = Map.empty
       factory
       paused = False
+      minter = None
   mgrCid <- submit admin do
     exerciseCmd mgrCid SetPeer with
       chainId = 2

--- a/canton/test/daml/Test/TestNtt.daml
+++ b/canton/test/daml/Test/TestNtt.daml
@@ -1085,6 +1085,25 @@ testSetFactory = do
   [(_, ledger)] <- query @LockedLedger operator
   ledger.balance === 0.01
 
+-- | Rotating a gg-minted deployment's factory is gg-gated: the admin alone
+-- cannot repoint it (that would let a mutable admin swap in a look-alike
+-- factory that the gg-signed manager would then mint through), but the admin
+-- together with gg — the party whose mint authority the factory wields — can.
+-- This keeps the committed factory gg-vetted for the life of the deployment,
+-- not just at registration.
+testSetFactoryGgMintedRequiresGg : Script ()
+testSetFactoryGgMintedRequiresGg = do
+  (operator, gg, _) <- nttSetup
+  admin <- allocateParty "SFGgAdmin"
+  d <- deploy operator gg admin BurnMint
+  freshFc <- submit gg do createCmd MockBurnMintFactory with admin = gg, instrument = d.instrumentId
+  let freshFactory = BurnMintFactoryCid (toInterfaceContractId @BurnMintFactory freshFc)
+  -- Admin alone cannot rotate a gg-minted factory.
+  submitMustFail admin do exerciseCmd d.mgrCid SetFactory with newFactory = freshFactory
+  -- Admin and gg together can.
+  _ <- submit (actAs admin <> actAs gg) do exerciseCmd d.mgrCid SetFactory with newFactory = freshFactory
+  pure ()
+
 ----------------------------------------------------------------------
 -- Admin transfer (custody handoff)
 ----------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The NTT manager is signed by gg (guardian governance) for its lifetime — the replay trie and the transceiver need that — and its burn path exercised the `BurnMintFactory` the registering caller committed. `BurnMintFactory_BurnMint` is controlled by the factory's own interface view admin, and the view is implementation-controlled, so a malicious factory could report gg as its admin; the gg-signed manager then satisfied that controller and delegated gg's authority into attacker code (demonstrated in `testEvilBurnMintFactoryForgesGgContract`).

## Fix

Two flows close the hole, both keeping gg a permanent manager signatory:

**External minter.** `NttManager` gains an optional `minter` field: the party that administers the burn/mint instrument, fixed at registration (`= instrumentId.admin`), never mutated (so it survives `TransferAdmin`), and a signatory when present. The outbound burn now routes through a minter-signed `BurnMintMinterProxy` whose choice body carries only `{minter, user}`; gg does not cross that boundary, so a factory claiming `view.admin = gg` can no longer capture it. The inbound `Mint` already runs through `DepositPreapproval`, whose `Deposit` choice is controlled by `instrumentId.admin`, so it is firewalled the same way once the minter is external.

**gg as minter.** `RegisterManager` now requires the instrument's admin to co-sign a burn/mint registration. An external minter simply consents, keeping registration permissionless; when the instrument is gg-administered, the co-signature makes registration a governance action, so an attacker can no longer stand up a gg-minted deployment behind a factory it controls. The stale "gg must administer the instrument" data check is dropped.

**Factory rotation.** `SetFactory` requires the same co-signature (the `effectiveMinter`: gg for gg-minted, the external minter otherwise), so a mutable admin cannot later swap in a look-alike factory and re-open the leak. The committed factory stays minter-vetted for the life of the deployment. Lock/unlock's transfer factory never wields gg and stays admin-only.

## Tests

The new `TestFactoryAuthority` suite carries the regression:

- Unit-level authority probes demonstrating the Daml authorization model, the leak itself, and the de-escalation shapes that block it.
- End-to-end through the real manager: an attacker cannot register a gg-minted deployment; a malicious factory on an external-minter deployment cannot forge a gg-signed contract on the real burn path.
- Inbound: the mint path through the recipient's real `DepositPreapproval` firewalls gg, and an honest minter-owned factory still mints. (A full VAA-driven `Mint` remains a live-sandbox test, since the recipient-hash binding needs a VAA signed over a freshly allocated party.)
- `SetFactory` rotation of a gg-minted deployment fails with admin alone, succeeds with admin + gg.

Full suite 91/91.