### PR TITLE
canton: back ByVaa trust-anchor pins with signatory-membership checks

### DIFF
--- a/canton/ntt/daml/Wormhole/Ntt/Governance.daml
+++ b/canton/ntt/daml/Wormhole/Ntt/Governance.daml
@@ -154,9 +154,9 @@ template NttGovernance
         -- 1. Pin CoreState before trusting any of its fields.
         cs <- fetch coreStateCid
         assertMsg "ntt governance: core state is not the committed guardian trust anchor"
-          (cs.guardianGovernance == guardianGovernance)
+          (cs.guardianGovernance == guardianGovernance && guardianGovernance `elem` signatory cs)
         assertMsg "ntt governance: core state operator mismatch"
-          (cs.operator == operator)
+          (cs.operator == operator && operator `elem` signatory cs)
 
         -- 2. Read-only VAA signature verification; nothing consumed yet.
         vaa <- exercise coreStateCid ParseAndVerifyVAA with
@@ -164,7 +164,7 @@ template NttGovernance
           encodedVAA = vaaBytes
           pubKeys
 
-        -- 3. Governance hardening.
+        -- 3. VAA origin checks.
         assertMsg "ntt governance: not signed by current guardian set"
           (vaa.guardianSetIndex == cs.guardianSetIndex)
         assertMsg "ntt governance: wrong emitter chain"

--- a/canton/ntt/daml/Wormhole/Ntt/Manager.daml
+++ b/canton/ntt/daml/Wormhole/Ntt/Manager.daml
@@ -160,7 +160,7 @@ requireCanonicalFactory guardianGovernance factory = do
   case r of
     None -> abort "ntt governance: factory is not the canonical NttCoinFactory"
     Some (_, ncf) -> assertMsg "ntt governance: factory's guardianGovernance does not match this deployment's"
-      (ncf.guardianGovernance == guardianGovernance)
+      (ncf.guardianGovernance == guardianGovernance && guardianGovernance `elem` signatory ncf)
 
 -- | The party that administers this deployment's burn/mint instrument and
 -- therefore authorizes minting/burning: the external @minter@ when present,
@@ -708,9 +708,9 @@ template NttManager
 
         cs <- fetch coreStateCid
         assertMsg "ntt: core state is not the committed guardian trust anchor"
-          (cs.guardianGovernance == guardianGovernance)
+          (cs.guardianGovernance == guardianGovernance && guardianGovernance `elem` signatory cs)
         assertMsg "ntt: core state operator mismatch"
-          (cs.operator == operator)
+          (cs.operator == operator && operator `elem` signatory cs)
 
         (vaa, _node) <- exercise coreStateCid VerifyAndConsumeVAA with
           encodedVAA = vaaBytes

--- a/canton/test/daml/Test/TestNtt.daml
+++ b/canton/test/daml/Test/TestNtt.daml
@@ -2881,6 +2881,70 @@ testRegisterManagerByVaaBindingMismatch = do
     registerManagerByVaaCmd admin fx csId 0 dummyFactory registerHappyVAA
   expectAbort "registration binding does not match" res
 
+-- | The guardian trust root is pinned to the deployment's committed
+-- @guardianGovernance@, not the operator. A compromised operator co-signing
+-- a forged 'CoreState' under a throwaway gg party fails at the pin, before
+-- any VAA verification runs. Mirrors 'testAcceptAdminByVaaPinsGuardianGovernance'.
+testRegisterManagerByVaaPinsGuardianGovernance : Script ()
+testRegisterManagerByVaaPinsGuardianGovernance = do
+  (operator, gg, _) <- nttSetup
+  admin <- allocateParty "RegisterPinGovAdmin"
+  rogueGov <- allocateParty "RegisterPinRogueGovernance"
+  rogueObserver <- allocateParty "RegisterPinRogueObserver"
+  let rogueInst = InstrumentId with admin = rogueGov, id = "UNUSED"
+  fakeCsId <- submit (actAs operator <> actAs rogueGov) do
+    createCmd (mkInitialCoreState operator rogueGov solanaGovernanceChainId defaultGovernanceContract
+                 ["1111111111111111111111111111111111111111"] rogueObserver rogueInst rogueGov)
+  fx <- registerByVaaFixture operator gg fakeCsId
+  let dummyFactory = BurnMintFactoryCid (coerceContractId fx.emReg)   -- unused; fails first
+  res <- trySubmitWithDiscs admin fx.discs do
+    registerManagerByVaaCmd admin fx fakeCsId 0 dummyFactory registerHappyVAA
+  expectAbort "committed guardian trust anchor" res
+
+-- | The other half of the same pin: a forged 'CoreState' co-signed by the
+-- deployment's real @guardianGovernance@ but a rogue operator fails on the
+-- operator mismatch, before any VAA verification runs.
+testRegisterManagerByVaaPinsOperator : Script ()
+testRegisterManagerByVaaPinsOperator = do
+  (operator, gg, _) <- nttSetup
+  admin <- allocateParty "RegisterPinOpAdmin"
+  rogueOp <- allocateParty "RegisterPinRogueOperator"
+  rogueObserver <- allocateParty "RegisterPinOpRogueObserver"
+  let rogueInst = InstrumentId with admin = gg, id = "UNUSED"
+  fakeCsId <- submit (actAs rogueOp <> actAs gg) do
+    createCmd (mkInitialCoreState rogueOp gg solanaGovernanceChainId defaultGovernanceContract
+                 ["1111111111111111111111111111111111111111"] rogueObserver rogueInst gg)
+  -- The real operator is not a stakeholder of this forged CoreState (it is
+  -- co-signed by the rogue operator and the real gg instead), so the
+  -- CoreState disclosure must be resolved via gg, unlike 'registerByVaaFixture'.
+  [(govCid, _)] <- query @NttGovernance operator
+  govDisc <- fromSome <$> queryDisclosure operator govCid
+  (emReg, emRegDisc, rrReg, rrRegDisc) <- coreRegistries operator
+  csDisc <- fromSome <$> queryDisclosure gg fakeCsId
+  let fx = RegisterByVaaFixture with govCid, emReg, rrReg, discs = [govDisc, emRegDisc, rrRegDisc, csDisc]
+      dummyFactory = BurnMintFactoryCid (coerceContractId emReg)   -- unused; fails first
+  res <- trySubmitWithDiscs admin fx.discs do
+    registerManagerByVaaCmd admin fx fakeCsId 0 dummyFactory registerHappyVAA
+  expectAbort "core state operator mismatch" res
+
+-- | A look-alike 'MockBurnMintFactory' fed to 'RegisterManagerByVaa' is
+-- rejected the same as any other factory argument: the registration-binding
+-- gate (step 7) runs before the factory template-pin (step 8) and rejects
+-- every static VAA fixture first (see 'testRegisterManagerByVaaBindingMismatch'),
+-- so the factory-pin's own message is unreachable here in Daml Script — this
+-- test only confirms the non-canonical factory never slips past the deeper
+-- gate either.
+testRegisterManagerByVaaRejectsNonCanonicalFactory : Script ()
+testRegisterManagerByVaaRejectsNonCanonicalFactory = do
+  (operator, gg, csId) <- nttSetup
+  admin <- allocateParty "RegisterNonCanonicalAdmin"
+  fx <- registerByVaaFixture operator gg csId
+  mockFc <- submit gg do createCmd MockBurnMintFactory with admin = gg, instrument = bridgedInstrument gg
+  let nonCanonicalFactory = BurnMintFactoryCid (toInterfaceContractId @BurnMintFactory mockFc)
+  res <- trySubmitWithDiscs admin fx.discs do
+    registerManagerByVaaCmd admin fx csId 0 nonCanonicalFactory registerHappyVAA
+  expectAbort "registration binding does not match" res
+
 ----------------------------------------------------------------------
 -- SetFactoryByVaa
 ----------------------------------------------------------------------
@@ -2923,6 +2987,30 @@ testSetFactoryByVaaHappyPath = do
   res <- trySubmitWithDiscs admin [csDisc, factoryDisc, dFreshNode] do
     rotateByVaaCmd mgrCid' newFactory csId freshNode rotateHappyVAA
   expectAbort "digest already consumed" res
+
+-- | The guardian trust root is pinned to the deployment's committed
+-- @guardianGovernance@, not the operator, mirroring
+-- 'testRegisterManagerByVaaPinsGuardianGovernance': a forged 'CoreState'
+-- co-signed by the real operator under a throwaway gg party fails at the
+-- pin, before any VAA verification runs.
+testSetFactoryByVaaPinsGuardianGovernance : Script ()
+testSetFactoryByVaaPinsGuardianGovernance = do
+  (operator, gg, _) <- nttSetup
+  admin <- allocateParty "RotatePinGovAdmin"
+  rogueGov <- allocateParty "RotatePinRogueGovernance"
+  rogueObserver <- allocateParty "RotatePinRogueObserver"
+  (mgrCid, _, _) <- setupFixedManager operator gg admin BurnMint
+  realFactoryCid <- nttCoinFactorySetup gg
+  let newFactory = BurnMintFactoryCid (toInterfaceContractId @BurnMintFactory realFactoryCid)
+      rogueInst = InstrumentId with admin = rogueGov, id = "UNUSED"
+  fakeCsId <- submit (actAs operator <> actAs rogueGov) do
+    createCmd (mkInitialCoreState operator rogueGov solanaGovernanceChainId defaultGovernanceContract
+                 ["1111111111111111111111111111111111111111"] rogueObserver rogueInst rogueGov)
+  csDisc <- fromSome <$> queryDisclosure operator fakeCsId
+  factoryDisc <- fromSome <$> queryDisclosure gg realFactoryCid
+  res <- trySubmitWithDiscs admin [csDisc, factoryDisc] do
+    rotateByVaaCmd mgrCid newFactory fakeCsId (coerceContractId mgrCid) rotateHappyVAA
+  expectAbort "committed guardian trust anchor" res
 
 -- | A rotation VAA signed for a different epoch than the deployment currently
 -- carries is rejected — the TOCTOU pin, mirroring


### PR DESCRIPTION
Stacked on #48 (which now carries the RegisterManagerByVaa / SetFactoryByVaa work).

The ByVaa choices pin the caller-supplied CoreState (and canonical factory) by field equality against the deployment's committed trust anchors. Those fields are signatory-clause fields, so the pin is today equivalent to a signature check — but only implicitly. This backs each pin with an explicit `elem signatory` membership check (idiom already used by wormhole-core's `chargeFee`), stating the authorization intent directly and failing closed if a signatory clause is ever refactored. Zero runtime cost: pure recomputation of the clause over the already-fetched payload.

- `RegisterManagerByVaa` CoreState pin (Governance.daml): both fields now also require membership in `signatory cs`.
- `SetFactoryByVaa` CoreState pin (Manager.daml): same.
- `requireCanonicalFactory`: `guardianGovernance` must be a signatory of the fetched `NttCoinFactory`.
- Comment rename: "Governance hardening" -> "VAA origin checks".

New negative tests (TestNtt.daml): forged-CoreState rejection for both new choices (rogue guardianGovernance and rogue operator — the operator-mismatch message previously had no coverage) and a non-canonical-factory rejection on the register path. Full suite: 237 tests green under dpm 3.5.1.

Deliberately untouched: registerManagerBody's registry pins (emitter.guardianGovernance is not an Emitter signatory; those cids are same-transaction exercise returns) and the pre-existing AcceptAdminTransferByVaa pins.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wormholelabs-xyz/codesmith/native-token-transfers/pr/53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787966084&installation_model_id=15502&pr_number=53&repository=wormholelabs-xyz%2Fnative-token-transfers&return_to=https%3A%2F%2Fgithub.com%2Fwormholelabs-xyz%2Fnative-token-transfers%2Fpull%2F53&signature=7089a69deae9ca2e1637db0016629203270da19b23cc7697162a0e0a7fabc376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->