### PR TITLE
canton: accountant broadcasts bundled into SetPeer/RegisterManager, VAA-gated peer edits

### DIFF
--- a/canton/README.md
+++ b/canton/README.md
@@ -159,16 +159,25 @@ scale byte, at most 8 decimals. Round-trips are covered by
 The same module also codes NTT's own governance packets — `module(32)
 "Ntt" ‖ action(1) ‖ chain(2) ‖ <action-specific>`, under the module id `"Ntt"`
 so an NTT governance VAA can never be confused with (or replayed as) a core
-one. `NttGovernanceAction` is a genuine sum type over the three actions
+one. `NttGovernanceAction` is a genuine sum type over the four actions
 guardians can sign: accept an admin handoff
 (`AcceptAdminToGovernance`, `NttManager.AcceptAdminTransferByVaa`), co-sign a
 gg-minted burn/mint registration (`RegisterBurnMintManager`,
-`NttGovernance.RegisterManagerByVaa`), and vet a factory rotation
-(`RotateToCanonicalFactory`, `NttManager.SetFactoryByVaa`). Every call site
-dispatches on the parsed constructor exhaustively and aborts on the wrong one,
-even where two actions share an identical byte layout (accept-admin and
-rotate both do) — a guardian-signed VAA for one purpose must never satisfy a
-different choice just because its bytes happen to parse.
+`NttGovernance.RegisterManagerByVaa`), vet a factory rotation
+(`RotateToCanonicalFactory`, `NttManager.SetFactoryByVaa`), and edit a
+gg-adminned deployment's peer table (`SetPeerByGovernance`,
+`NttManager.SetPeerByVaa`). Every call site dispatches on the parsed
+constructor exhaustively and aborts on the wrong one, even where two actions
+share an identical byte layout (accept-admin and rotate both do) — a
+guardian-signed VAA for one purpose must never satisfy a different choice
+just because its bytes happen to parse.
+
+Two further payloads are published bare (no `0x9945FF10` framing) at the core
+bridge and are consumed only by the off-chain NTT Global Accountant — no chain
+has a receive path for either: `TransceiverRegistration` (`0x18fc67c2`, 38
+bytes), published as part of every `SetPeer`, and `TransceiverInit`
+(`0x9c23bd3b`, 70 bytes), published once as part of `RegisterManager`. See
+"Accountant broadcasts" below.
 
 ## Send (`NttManager.Transfer`)
 
@@ -198,6 +207,111 @@ The user is not a stakeholder of the manager, the transceiver, the
 `CoreState`, the `LockedLedger`, the custody pot holding, or the registry
 factory, so a submission attaches them as explicit disclosures. This is a
 visibility requirement, not an authorization one.
+
+## Accountant broadcasts (bundled into `SetPeer` / `RegisterManager`)
+
+`TransceiverRegistration` and `TransceiverInit` are no longer published by
+dedicated choices; they publish as a bundled effect of the choices that
+already change the state each payload attests to. There is no standalone
+broadcast choice and no separate re-broadcast path.
+
+- `SetPeer` (`controller admin, payer`, consuming) publishes
+  `TransceiverRegistration` (prefix `0x18fc67c2`, 38 bytes: `prefix(4) ‖
+  peerChain(2) ‖ peerAddress(32)`) every time it runs — the first peer for a
+  chain and every replacement alike — at nonce 0. `payer` is an explicit
+  parameter, not hardcoded to `admin`: the direct admin path calls it with
+  `payer = admin` (self-funding, unchanged in effect from before `payer`
+  existed), while `SetPeerByVaa` (below) calls it with `payer = executor`, so
+  the relayer funds the governance path's fee instead of `gg`. `payer` must
+  co-control because Daml authorization does not carry a choice's controllers
+  past a nested exercise on the same contract; without it the nested
+  `PublishMessage` (`controller owner, payer`) would lose the caller's
+  authority the moment a wrapper choice like `SetPeerByVaa` calls in here. It
+  exercises the deployment's transceiver `Emitter` in the same transaction as
+  the peer-table update and returns the resulting `WormholeMessage` alongside
+  the new manager cid.
+- `RegisterManager` publishes `TransceiverInit` (prefix `0x9c23bd3b`, 70 bytes:
+  `prefix(4) ‖ managerAddress(32) ‖ mode(1) ‖ tokenAddress(32) ‖ decimals(1)`)
+  exactly once, at registration, also at nonce 0 and `admin`-paid — this
+  deployment's manager address, mode (`0` = lock/unlock, `1` = burn/mint),
+  token address, and decimals.
+
+Re-announcing a registration means re-exercising `SetPeer` with the same peer
+values (see the divergence note below); `RegisterManager`'s init broadcast has
+no re-play path at all, since registration itself runs only once per
+deployment. An accountant that needs an already-signed VAA again simply
+re-fetches it from the guardian API rather than asking the chain to re-emit
+it. Neither publish checks `paused` (pause blocks value movement, not
+administration), and neither touches the `LockedLedger`, factory, or any
+holding.
+
+**Divergence from EVM.** EVM's transceiver peer is immutable once set
+(`PeerAlreadySet`), specifically to keep the accountant's bookkeeping simple.
+Canton's peer stays replaceable: `SetPeer` always accepts a new value for
+`peers[chainId]` and always re-broadcasts. That divergence is not
+accounting-neutral. The accountant's peer entries are write-once per
+`(emitter, peer chain)`
+(`ntt-global-accountant/src/contract.rs` rejects a second registration with
+`"peer entry for this chain already exists"`) and `TRANSCEIVER_PEER` is read on
+every transfer observation, with a cross-registration check that bails
+`"peers are not cross-registered"` if the two sides disagree. So after a peer
+rotation W → X, the accountant keeps W forever: inbound transfers from the new
+peer X fail `MissingHubRegistration` (X was never recorded), while outbound
+transfers to X still resolve — and cross-check — against the stale W entry.
+The corridor's accounting for that chain is now permanently wrong, with no
+on-chain repair path, since `transceiverEmitterId` is immutable. This does not
+argue for reverting to write-once peers on Canton (that would neuter
+`SetPeerByVaa`, whose entire purpose is quorum-driven peer edits, and local
+routing correctness matters more than accountant bookkeeping) — the honest
+framing is that a peer rotation is a **deployment-level event**, exactly as it
+is on EVM, where the answer is "deploy a new transceiver": Canton's equivalent
+is a new deployment (new manager, new emitter), because the emitter identity
+never changes in place
+(`TestNtt:testSetPeerReplacementBroadcastsAgain` pins the local-routing half of
+this; the accountant-side consequence is operational, not tested here). Note
+also that the accountant only processes `TransceiverInit` from lock/unlock
+(hub) managers; burn/mint spokes are registered through the hub's own peer
+registrations.
+
+**Token address.** A CIP-0056 `InstrumentId` (`admin : Party, id : Text`) has
+no native 32-byte form, so `TransceiverInit.tokenAddress` uses
+`keccak256("wormhole:ntt-token:v1" ‖ lp(adminText) ‖ lp(id))`, the same
+length-prefixed-hash convention as the manager and transceiver address
+derivations above. It is computed once at `RegisterManager` and stored on the
+manager (`tokenAddress`), not recomputed, so it survives `TransferAdmin`
+exactly like `managerAddress`. Pinned by
+`TestNttVectors:testVectorTokenAddress`.
+
+**Shared sequence counter.** Both payloads publish through the same
+transceiver `Emitter` as `Transfer`, so registration/init messages interleave
+with transfer messages in the same sequence space. `RegisterManager`'s
+`TransceiverInit` claims sequence 0, so a fresh deployment's emitter sequence
+is already at 1 before its first `Transfer`, and every subsequent `SetPeer`
+bumps the counter again. Any consumer must discriminate by the 4-byte payload
+prefix (`0x9945FF10` transfer, `0x18fc67c2` peer registration, `0x9c23bd3b`
+init) and must never assume a sequence number implies a transfer.
+
+**Governance-gated peer edits (`SetPeerByVaa`).** A gg-adminned deployment
+(admin handed to `guardianGovernance`, see "Custody follows the admin" below)
+can have its peer table edited by guardian quorum vote instead of a live
+`admin` action. `SetPeerByVaa` (`controller executor`, nonconsuming; NTT
+governance action 4, a 142-byte packet: `module(32) ‖ action(1)=4 ‖ chain(2)
+‖ managerAddress(32) ‖ peerEpoch(8) ‖ peerChain(2) ‖ peerManagerAddress(32) ‖
+peerTransceiverAddress(32) ‖ peerDecimals(1)`) runs the same verification
+ladder as `AcceptAdminTransferByVaa`: the disclosed `CoreState` pinned to this
+deployment's own guardian trust anchor and operator; the VAA verified and its
+digest consumed into `gg`'s replay trie, sub-scoped by the deployment's
+`namespace` (governance and transfer VAAs share one trie, so a governance VAA
+can never be replayed as, or by, a transfer one); signed by the CURRENT
+guardian set only; and the standard emitter chain/address and target
+chain/managerAddress checks. `peerEpoch` mirrors action 1's `factoryEpoch`: it
+must equal the manager's current `peerEpoch` (bumped by every `SetPeer`), so a
+withheld or superseded peer VAA can never reinstate a since-replaced peer. It
+additionally requires `admin == guardianGovernance` before nesting a `SetPeer`
+exercise (`payer = executor`, so the relayer self-funds the broadcast fee, not
+gg) with the parsed peer values, so a governance-driven edit broadcasts
+exactly like an admin-driven one. Any `executor` (a relayer) can submit; the
+VAA is the only authority that matters.
 
 ## Receive (`NttManager.Release` / `NttManager.Mint`)
 
@@ -415,12 +529,17 @@ quorum takes on by accepting the role.
 
 ## Contention and contract churn
 
-The manager itself is consumed only by its config choices (`SetPeer`,
-`SetFactory`, and the rare `TransferAdmin`), so across transfer traffic its
-cid is stable and disclosures of it stay valid. What serializes is:
+The manager itself is consumed by its config choices (`SetPeer`, `SetFactory`,
+and the rare `TransferAdmin`), so a config edit still leaves the manager cid
+stable across ordinary `Transfer` traffic (which is nonconsuming). What
+serializes is:
 
-- Sends, on the transceiver `Emitter` (consumed by every publish). Inherent to
-  Wormhole sequence numbering.
+- Publishing, on the transceiver `Emitter` (consumed by every
+  `PublishMessage`). This is no longer sends-only: `SetPeer` bundles its
+  registration broadcast through the same emitter (see "Accountant
+  broadcasts"), so a peer edit now contends with `Transfer` traffic on the
+  identical contract, not a separate one. `RegisterManager`'s one-shot init
+  broadcast contends the same way, but only once, at registration.
 - Lock-mode value movement, on the `LockedLedger` and the custody pot holding
   (both `Transfer` and `Release` touch them, in the same transactions).
   Burn/mint deployments have no ledger, so their sends contend only on the
@@ -428,7 +547,16 @@ cid is stable and disclosures of it stay valid. What serializes is:
 - VAA consumption, on the covering replay-trie node.
 
 A submission that loses a race re-resolves the fresh cid and retries, the same
-fail-closed pattern the core publish path uses.
+fail-closed pattern the core publish path uses. This is a liveness cost, not a
+correctness one — but it is griefable: a dust-transfer spammer can keep the
+emitter churning fast enough that an urgent peer repoint (say, retiring a
+compromised peer) keeps losing the race, and the admin is not an `Emitter`
+stakeholder, so each retry needs a fresh off-ledger disclosure round-trip.
+The runbook for an urgent peer change is therefore **pause first, then
+`SetPeer`**: `SetPaused` (`admin`-controlled) takes no `CoreState`/`Emitter` at
+all, so it can never lose this race, and once paused `Transfer` aborts
+outright, which stops new contention on the emitter before the peer edit is
+retried.
 
 ## Follow-ups
 

--- a/canton/ntt/daml/Wormhole/Ntt/Governance.daml
+++ b/canton/ntt/daml/Wormhole/Ntt/Governance.daml
@@ -28,12 +28,14 @@ import Splice.Api.Token.MetadataV1 (ExtraArgs)
 import Wormhole.Core.Bytes (Bytes, Bytes32, normalizeHex)
 import Wormhole.Core.Replay (ReplayNode, defaultSplitThreshold)
 import Wormhole.Core.State
-  ( Emitter, CoreState, EmitterRegistry, ReplayRootRegistry
-  , RegisterEmitter (..), ClaimReplayRoot (..), ParseAndVerifyVAA (..) )
+  ( Emitter, CoreState, EmitterRegistry, ReplayRootRegistry, WormholeMessage
+  , RegisterEmitter (..), ClaimReplayRoot (..), ParseAndVerifyVAA (..), PublishMessage (..) )
 import Wormhole.Core.VAA ()   -- HasField instances for VAA record-dot access
 import Wormhole.Ntt.Ledger
 import Wormhole.Ntt.Manager
-import Wormhole.Ntt.Payload (NttGovernanceAction (..), parseNttGovernance)
+import Wormhole.Ntt.Payload
+  ( NttGovernanceAction (..), parseNttGovernance
+  , TransceiverInit (..), encodeTransceiverInit, nttTokenAddressFor )
 
 template NttGovernance
   with
@@ -89,7 +91,7 @@ template NttGovernance
     -- 'ReplayRootRegistry' anchors); a loser re-resolves the fresh cids and
     -- retries.
     choice RegisterManager
-      : (ContractId NttGovernance, ContractId NttManager, ContractId Emitter, Optional (ContractId LockedLedger))
+      : (ContractId NttGovernance, ContractId NttManager, ContractId Emitter, Optional (ContractId LockedLedger), WormholeMessage)
       with
         admin                 : Party
         chainId               : Int   -- this deployment's own Wormhole chain id (uint16)
@@ -100,9 +102,11 @@ template NttGovernance
         tokenConfig           : NttTokenConfig
         tokenDecimals         : Int
         factory               : NttFactory  -- the registry's factory, typed by mode
-        coreStateCid          : Optional (ContractId CoreState)  -- required iff either onboarding fee > 0
+        coreStateCid          : ContractId CoreState  -- also funds the TransceiverInit broadcast, so no longer optional
+        consistencyLevel      : Int
         emitterFeeAllocation  : Optional (ContractId Allocation, ExtraArgs)
         claimFeeAllocation    : Optional (ContractId Allocation, ExtraArgs)
+        feeAllocation         : Optional (ContractId Allocation, ExtraArgs)  -- the TransceiverInit message fee
       -- For burn/mint, the instrument's admin (the minter) co-signs, because
       -- it is lending its mint authority to this deployment. An external
       -- minter simply consents, so registration stays permissionless; when
@@ -112,13 +116,13 @@ template NttGovernance
       -- @admin@-only.
       controller admin :: (if tokenConfig == BurnMint then [instrumentId.admin] else [])
       do
-        (mgr, emitterCid, ledger) <- registerManagerBody
+        (mgr, emitterCid, ledger, msg) <- registerManagerBody
           operator guardianGovernance nextId admin chainId
           emitterRegistryCid replayRootRegistryCid
           instrumentId instrumentNonce tokenConfig tokenDecimals factory
-          coreStateCid emitterFeeAllocation claimFeeAllocation
+          coreStateCid consistencyLevel emitterFeeAllocation claimFeeAllocation feeAllocation
         reg' <- create this with nextId = nextId + 1
-        pure (reg', mgr, emitterCid, ledger)
+        pure (reg', mgr, emitterCid, ledger, msg)
 
     -- | Governance-VAA-gated registration of a gg-minted burn/mint deployment:
     -- the guardian quorum co-signs off-chain, alongside the registering
@@ -136,7 +140,7 @@ template NttGovernance
     -- until that handoff runs, @admin@ still controls
     -- 'Wormhole.Ntt.Manager.SetPeer'.
     choice RegisterManagerByVaa
-      : (ContractId NttGovernance, ContractId NttManager, ContractId Emitter, Optional (ContractId LockedLedger))
+      : (ContractId NttGovernance, ContractId NttManager, ContractId Emitter, Optional (ContractId LockedLedger), WormholeMessage)
       with
         admin                 : Party
         emitterRegistryCid    : ContractId EmitterRegistry
@@ -144,8 +148,10 @@ template NttGovernance
         instrumentNonce       : Int
         factory               : NttFactory
         coreStateCid          : ContractId CoreState  -- mandatory: needed for VAA verification even at zero fees
+        consistencyLevel      : Int
         emitterFeeAllocation  : Optional (ContractId Allocation, ExtraArgs)
         claimFeeAllocation    : Optional (ContractId Allocation, ExtraArgs)
+        feeAllocation         : Optional (ContractId Allocation, ExtraArgs)  -- the TransceiverInit message fee
         vaaBytes              : Bytes
         pubKeys               : [(Int, Bytes)]
         extraArgs             : ExtraArgs
@@ -197,22 +203,23 @@ template NttGovernance
               id = nttInstrumentIdFor admin instrumentNonce
 
         -- 9. Run the shared registration body; recreate the root once.
-        (mgr, emitterCid, ledger) <- registerManagerBody
+        (mgr, emitterCid, ledger, msg) <- registerManagerBody
           operator guardianGovernance nextId admin chainId
           emitterRegistryCid replayRootRegistryCid
           instrumentId instrumentNonce BurnMint tokenDecimals factory
-          (Some coreStateCid) emitterFeeAllocation claimFeeAllocation
+          coreStateCid consistencyLevel emitterFeeAllocation claimFeeAllocation feeAllocation
         reg' <- create this with
           nextId = nextId + 1
           consumedGovernance = Set.insert vaa.hash consumedGovernance
-        pure (reg', mgr, emitterCid, ledger)
+        pure (reg', mgr, emitterCid, ledger, msg)
 
 -- | Registration body shared by 'RegisterManager' and
 -- 'RegisterManagerByVaa': mints the transceiver 'Emitter', claims the
--- replay-trie root, and creates the 'NttManager' (plus 'LockedLedger' for
--- lock/unlock). Module-level, not a choice, so 'RegisterManagerByVaa' can
--- call it after consuming @self@, without nest-exercising 'RegisterManager'.
--- Callers create the successor 'NttGovernance' root themselves.
+-- replay-trie root, creates the 'NttManager' (plus 'LockedLedger' for
+-- lock/unlock), and publishes the deployment's identity for the accountant.
+-- Module-level, not a choice, so 'RegisterManagerByVaa' can call it after
+-- consuming @self@, without nest-exercising 'RegisterManager'. Callers create
+-- the successor 'NttGovernance' root themselves.
 registerManagerBody
   : Party                          -- operator
   -> Party                          -- guardianGovernance
@@ -226,21 +233,27 @@ registerManagerBody
   -> NttTokenConfig
   -> Int                            -- tokenDecimals
   -> NttFactory
-  -> Optional (ContractId CoreState)
+  -> ContractId CoreState           -- also funds the TransceiverInit broadcast, so no longer optional
+  -> Int                            -- consistencyLevel (the TransceiverInit broadcast)
   -> Optional (ContractId Allocation, ExtraArgs)  -- emitterFeeAllocation
   -> Optional (ContractId Allocation, ExtraArgs)  -- claimFeeAllocation
-  -> Update (ContractId NttManager, ContractId Emitter, Optional (ContractId LockedLedger))
+  -> Optional (ContractId Allocation, ExtraArgs)  -- feeAllocation (TransceiverInit message fee)
+  -> Update (ContractId NttManager, ContractId Emitter, Optional (ContractId LockedLedger), WormholeMessage)
 registerManagerBody
   operator guardianGovernance nextId admin chainId
   emitterRegistryCid replayRootRegistryCid
   instrumentId instrumentNonce tokenConfig tokenDecimals factory
-  coreStateCid emitterFeeAllocation claimFeeAllocation = do
+  coreStateCid consistencyLevel emitterFeeAllocation claimFeeAllocation feeAllocation = do
     -- Decimal conversions ('untrimToDecimal') are exact only up to the 10
     -- fractional digits a Daml Decimal carries.
     assertMsg "ntt: tokenDecimals must be between 0 and 10"
       (tokenDecimals >= 0 && tokenDecimals <= 10)
     assertMsg "ntt: chainId must be a positive uint16"
       (chainId > 0 && chainId <= 65535)
+    -- Uint8 on the wire; the watcher drops out-of-range messages, and this
+    -- one-shot init has no re-broadcast path.
+    assertMsg "ntt: consistency level must be a uint8"
+      (consistencyLevel >= 0 && consistencyLevel <= 255)
     case tokenConfig of
       BurnMint ->
         -- The instrument's admin co-signs via the controller, so no on-ledger
@@ -257,7 +270,7 @@ registerManagerBody
     (_, emitterCid) <- exercise emitterRegistryCid RegisterEmitter with
       requester = guardianGovernance
       payer = admin
-      coreStateCid
+      coreStateCid = Some coreStateCid
       feeAllocation = emitterFeeAllocation
     emitter <- fetch emitterCid
     -- operator is an Emitter signatory; guardianGovernance is a plain field,
@@ -275,7 +288,7 @@ registerManagerBody
       namespace
       splitThreshold = defaultSplitThreshold
       payer = admin
-      coreStateCid
+      coreStateCid = Some coreStateCid
       feeAllocation = claimFeeAllocation
     root <- fetch rootCid
     -- operator is a ReplayNode signatory, so this equality also proves the
@@ -295,13 +308,16 @@ registerManagerBody
       instrumentId
       tokenConfig
       tokenDecimals
+      tokenAddress = nttTokenAddressFor instrumentId
       peers = Map.empty
       factory
       paused = False
       factoryEpoch = 0
+      peerEpoch = 0
       -- An external minter (instrument admin ≠ gg) becomes a manager
-      -- signatory so burn/mint runs on its authority; gg-minted
-      -- deployments carry None and mint on gg's inherited signature.
+      -- signatory so the burn/mint paths run on its authority, not gg's;
+      -- gg-minted deployments carry None and mint on gg's inherited
+      -- signature.
       minter = case tokenConfig of
         BurnMint | instrumentId.admin /= guardianGovernance -> Some instrumentId.admin
         _ -> None
@@ -314,4 +330,17 @@ registerManagerBody
         balance = 0.0
         custodyHoldingCid = None
       BurnMint -> pure None
-    pure (mgr, emitterCid, ledger)
+
+    -- Publishes the deployment's identity for the accountant, once; no re-broadcast path.
+    msg <- exercise emitterCid PublishMessage with
+      payload = encodeTransceiverInit TransceiverInit with
+        nttManagerAddress = managerAddress
+        nttManagerMode = case tokenConfig of LockUnlock -> 0; BurnMint -> 1
+        tokenAddress = nttTokenAddressFor instrumentId
+        tokenDecimals
+      nonce = 0
+      consistencyLevel
+      coreStateCid
+      payer = admin
+      feeAllocation
+    pure (mgr, emitterCid, ledger, msg)

--- a/canton/ntt/daml/Wormhole/Ntt/Manager.daml
+++ b/canton/ntt/daml/Wormhole/Ntt/Manager.daml
@@ -482,10 +482,12 @@ template NttManager
     instrumentId         : InstrumentId    -- the bridged CIP-56 instrument
     tokenConfig          : NttTokenConfig
     tokenDecimals        : Int             -- the local token's decimals (0..10)
+    tokenAddress         : Bytes32         -- nttTokenAddressFor instrumentId; stored at registration so it survives TransferAdmin
     peers                : Map Int Peer    -- chain id -> peer deployment
     factory              : NttFactory      -- the registry's committed factory, typed by mode
     paused               : Bool            -- emergency halt: blocks Transfer/Release/Mint
     factoryEpoch         : Int             -- TOCTOU pin for 'AcceptAdminTransferByVaa': 'SetFactory' bumps this on every rotation, so a guardian-vetted (managerAddress, factoryEpoch) pair can never be satisfied by a look-alike factory rotated in after the quorum signed
+    peerEpoch            : Int             -- freshness pin for 'SetPeerByVaa': every 'SetPeer' bumps this deployment-wide counter, so a withheld/superseded peer VAA can never reinstate a since-replaced peer
     minter               : Optional Party  -- external burn/mint minter (Some) — see 'effectiveMinter'; None when gg mints
   where
     -- See the module header for what each signature contributes. All three
@@ -503,13 +505,23 @@ template NttManager
     -- see 'effectiveMinter' and the de-escalation in the burn/'Mint' paths.
     signatory (operator :: admin :: guardianGovernance :: optionalToList minter)
 
-    -- | Register or replace a peer deployment. Consuming, but only admin
-    -- config changes it, so the manager cid is stable across transfer traffic.
-    choice SetPeer : ContractId NttManager
+    -- | Register or replace a peer, broadcasting the registration through the transceiver. Consuming.
+    -- @payer@ funds the broadcast: the admin path self-pays (@payer = admin@); 'SetPeerByVaa'
+    -- passes @executor@ so the relayer self-funds and gg's fee-free invariant holds. @payer@ must
+    -- co-control: Daml authorization does not carry a choice's controllers past a nested exercise
+    -- on the same contract, so without this the nested 'PublishMessage' (@controller owner, payer@)
+    -- would lose @executor@'s authority the moment 'SetPeerByVaa' calls in here. When @payer == admin@
+    -- (the direct path) this adds nothing beyond @admin@'s own authority.
+    choice SetPeer : (ContractId NttManager, WormholeMessage)
       with
-        chainId : Int
-        peer    : Peer
-      controller admin
+        chainId               : Int
+        peer                  : Peer
+        transceiverEmitterCid : ContractId Emitter
+        coreStateCid          : ContractId CoreState
+        consistencyLevel      : Int
+        payer                 : Party
+        feeAllocation         : Optional (ContractId Allocation, ExtraArgs)
+      controller admin, payer
       do
         assertMsg "ntt: peer chain id must be a positive uint16"
           (chainId > 0 && chainId <= 65535)
@@ -517,11 +529,38 @@ template NttManager
           (chainId /= this.chainId)
         assertMsg "ntt: peer decimals must be a positive uint8"
           (peer.decimals > 0 && peer.decimals <= 255)
+        -- 'leftPadTo' is the identity above 32 bytes, so an unchecked oversized
+        -- address would publish a malformed registration. Pre-normalization,
+        -- so uppercase hex is rejected rather than lowercased.
+        assertMsg "ntt: peer manager address must be 32 bytes of lowercase hex"
+          (byteLength peer.managerAddress == 32 && isLowerHex peer.managerAddress)
+        assertMsg "ntt: peer transceiver address must be 32 bytes of lowercase hex"
+          (byteLength peer.transceiverAddress == 32 && isLowerHex peer.transceiverAddress)
         assertMsg "ntt: peer manager address must be non-zero"
           (not (isZeroAddress peer.managerAddress))
         assertMsg "ntt: peer transceiver address must be non-zero"
           (not (isZeroAddress peer.transceiverAddress))
-        create this with peers = Map.insert chainId (normalizePeer peer) peers
+        -- Uint8 on the wire; the watcher drops out-of-range messages.
+        assertMsg "ntt: consistency level must be a uint8"
+          (consistencyLevel >= 0 && consistencyLevel <= 255)
+        let peer' = normalizePeer peer
+        newMgrCid <- create this with peers = Map.insert chainId peer' peers, peerEpoch = peerEpoch + 1
+        transceiver <- fetch transceiverEmitterCid
+        assertMsg "ntt: transceiver emitter is not this deployment's"
+          (transceiver.owner == guardianGovernance
+            && transceiver.operator == operator
+            && transceiver.emitterId == transceiverEmitterId)
+        -- Publishes the registration for the accountant; write-once there, replacements are local-only.
+        msg <- exercise transceiverEmitterCid PublishMessage with
+          payload = encodeTransceiverRegistration TransceiverRegistration with
+            peerChain = chainId
+            peerAddress = peer'.transceiverAddress
+          nonce = 0
+          consistencyLevel
+          coreStateCid
+          payer
+          feeAllocation
+        pure (newMgrCid, msg)
 
     -- | Emergency halt. While @paused@, 'Transfer', 'Release', and 'Mint' all
     -- abort; config choices ('SetPeer', 'SetFactory', 'TransferAdmin') keep
@@ -679,8 +718,8 @@ template NttManager
         assertMsg "ntt governance: wrong emitter address"
           (normalizeHex vaa.emitterAddress == normalizeHex cs.governanceContract)
 
-        -- Exhaustive constructor dispatch: a register or rotate VAA must
-        -- abort here, even though 'RotateToCanonicalFactory' shares this
+        -- Exhaustive constructor dispatch: a register, rotate, or set-peer VAA
+        -- must abort here, even though 'RotateToCanonicalFactory' shares this
         -- action's exact byte layout.
         case parseNttGovernance vaa.payload of
           AcceptAdminToGovernance chain targetManagerAddress targetFactoryEpoch -> do
@@ -688,6 +727,7 @@ template NttManager
             assertMsg "ntt governance: wrong manager address"
               (normalizeHex targetManagerAddress == managerAddress)
             assertMsg "ntt governance: wrong factory epoch" (targetFactoryEpoch == factoryEpoch)
+          SetPeerByGovernance {} -> abort "ntt governance: wrong action for AcceptAdminTransferByVaa"
           _ -> abort "ntt governance: not an accept-admin action"
 
         exercise proposalCid AcceptAdminTransfer with
@@ -695,6 +735,60 @@ template NttManager
           ledgerCid
           vettedFactory = factory
           extraArgs
+
+    -- | Quorum-driven peer edit for gg-adminned deployments; nests SetPeer, so it broadcasts.
+    nonconsuming choice SetPeerByVaa : (ContractId NttManager, WormholeMessage)
+      with
+        executor              : Party
+        coreStateCid          : ContractId CoreState
+        replayNodeCid         : ContractId ReplayNode
+        vaaBytes              : Bytes
+        pubKeys               : [(Int, Bytes)]
+        transceiverEmitterCid : ContractId Emitter
+        consistencyLevel      : Int
+        feeAllocation         : Optional (ContractId Allocation, ExtraArgs)
+      controller executor
+      do
+        cs <- requireCommittedCoreState operator guardianGovernance coreStateCid
+
+        (vaa, _node) <- exercise coreStateCid VerifyAndConsumeVAA with
+          encodedVAA = vaaBytes
+          pubKeys
+          consumer = guardianGovernance
+          namespace
+          replayNodeCid
+
+        assertMsg "ntt governance: not signed by current guardian set"
+          (vaa.guardianSetIndex == cs.guardianSetIndex)
+        assertMsg "ntt governance: wrong emitter chain"
+          (vaa.emitterChain == cs.governanceChainId)
+        assertMsg "ntt governance: wrong emitter address"
+          (normalizeHex vaa.emitterAddress == normalizeHex cs.governanceContract)
+
+        case parseNttGovernance vaa.payload of
+          SetPeerByGovernance
+            { chain, managerAddress = actionManagerAddress, peerEpoch = actionPeerEpoch
+            , peerChain, peerManagerAddress, peerTransceiverAddress, peerDecimals
+            } -> do
+            assertMsg "ntt governance: wrong target chain" (chain == chainId)
+            assertMsg "ntt governance: wrong manager address"
+              (normalizeHex actionManagerAddress == managerAddress)
+            assertMsg "ntt governance: wrong peer epoch" (actionPeerEpoch == peerEpoch)
+            assertMsg "ntt: manager is not governance-adminned" (admin == guardianGovernance)
+            exercise self SetPeer with
+              chainId = peerChain
+              peer = Peer with
+                managerAddress = peerManagerAddress
+                transceiverAddress = peerTransceiverAddress
+                decimals = peerDecimals
+              transceiverEmitterCid
+              coreStateCid
+              consistencyLevel
+              payer = executor
+              feeAllocation
+          AcceptAdminToGovernance {} -> abort "ntt governance: wrong action for SetPeerByVaa"
+          RegisterBurnMintManager {} -> abort "ntt governance: wrong action for SetPeerByVaa"
+          RotateToCanonicalFactory {} -> abort "ntt governance: wrong action for SetPeerByVaa"
 
     -- | Governance-VAA-gated factory rotation for gg-minted burn/mint
     -- deployments: the guardian quorum vets a specific (chain, managerAddress,

--- a/canton/ntt/daml/Wormhole/Ntt/Payload.daml
+++ b/canton/ntt/daml/Wormhole/Ntt/Payload.daml
@@ -14,9 +14,24 @@
 -- > WormholeTransceiverMessage (the VAA payload):
 -- >   prefix(4) = 0x9945FF10 ‖ sourceManager(32) ‖ recipientManager(32)
 -- >   ‖ managerPayloadLen(2) ‖ managerPayload ‖ transceiverPayloadLen(2) ‖ transceiverPayload
+-- >
+-- > TransceiverRegistration: prefix(4) = 0x18fc67c2 ‖ peerChain(2) ‖ peerAddress(32)
+-- > TransceiverInit: prefix(4) = 0x9c23bd3b ‖ nttManagerAddress(32) ‖ mode(1) ‖ tokenAddress(32) ‖ decimals(1)
+-- > Consumed only by the off-chain accountant; no chain receives these.
+-- >
+-- > NTT governance action 4 (SetPeerByGovernance): module(32) ‖ action(1)=4
+-- >   ‖ chain(2) ‖ managerAddress(32) ‖ peerEpoch(8) ‖ peerChain(2)
+-- >   ‖ peerManagerAddress(32) ‖ peerTransceiverAddress(32) ‖ peerDecimals(1) — 142 bytes.
+-- >   peerEpoch sits right after managerAddress, mirroring action 1's
+-- >   module‖action‖chain‖managerAddress‖factoryEpoch layout: the epoch is
+-- >   part of the common identity/freshness prefix, not the peer-specific tail.
 --
 -- Decoders 'error' on malformed input (bad prefix / short buffer).
 module Wormhole.Ntt.Payload where
+
+import DA.Crypto.Text (keccak256, toHex)
+
+import Splice.Api.Token.HoldingV1 (InstrumentId (..))
 
 import Wormhole.Core.Bytes
 
@@ -171,6 +186,11 @@ nttGovernanceRegisterBurnMintManagerAction = 2
 nttGovernanceRotateToCanonicalFactoryAction : Int
 nttGovernanceRotateToCanonicalFactoryAction = 3
 
+-- | The guardian quorum edits a gg-adminned manager's peer table. See
+-- 'Wormhole.Ntt.Manager.SetPeerByVaa'.
+nttGovernanceSetPeerAction : Int
+nttGovernanceSetPeerAction = 4
+
 -- | A parsed NTT governance action. Every call site does an exhaustive
 -- constructor match and aborts on the wrong one, even where fields overlap
 -- positionally ('AcceptAdminToGovernance' vs 'RotateToCanonicalFactory') --
@@ -189,13 +209,23 @@ data NttGovernanceAction
       chain          : Int      -- uint16: Wormhole chain id
       managerAddress : Bytes32
       factoryEpoch   : Int      -- uint64: the vetted (managerAddress, factoryEpoch) pair
+  | SetPeerByGovernance with
+      chain                  : Int      -- uint16: Wormhole chain id
+      managerAddress         : Bytes32
+      peerEpoch              : Int      -- uint64: the manager's current peerEpoch when the quorum signed
+      peerChain              : Int      -- uint16
+      peerManagerAddress     : Bytes32
+      peerTransceiverAddress : Bytes32
+      peerDecimals           : Int      -- uint8
   deriving (Eq, Show)
 
 -- | Encode an 'NttGovernanceAction'. The inverse of 'parseNttGovernance'.
 -- @AcceptAdminToGovernance@/@RotateToCanonicalFactory@ are 75 bytes
 -- (module(32) ‖ action(1) ‖ chain(2) ‖ managerAddress(32) ‖ factoryEpoch(8));
 -- @RegisterBurnMintManager@ is 68 (module(32) ‖ action(1) ‖ chain(2) ‖
--- registrationBinding(32) ‖ tokenDecimals(1)).
+-- registrationBinding(32) ‖ tokenDecimals(1)); @SetPeerByGovernance@ is 142
+-- (module(32) ‖ action(1) ‖ chain(2) ‖ managerAddress(32) ‖ peerEpoch(8) ‖
+-- peerChain(2) ‖ peerManagerAddress(32) ‖ peerTransceiverAddress(32) ‖ peerDecimals(1)).
 encodeNttGovernance : NttGovernanceAction -> Bytes
 encodeNttGovernance = \case
   AcceptAdminToGovernance chain managerAddress factoryEpoch ->
@@ -216,6 +246,16 @@ encodeNttGovernance = \case
       <> intToBytesN chain 2
       <> leftPadTo 32 managerAddress
       <> intToBytesN factoryEpoch 8
+  SetPeerByGovernance chain managerAddress peerEpoch peerChain peerManagerAddress peerTransceiverAddress peerDecimals ->
+    nttGovernanceModule
+      <> intToHexByte nttGovernanceSetPeerAction
+      <> intToBytesN chain 2
+      <> leftPadTo 32 managerAddress
+      <> intToBytesN peerEpoch 8
+      <> intToBytesN peerChain 2
+      <> leftPadTo 32 peerManagerAddress
+      <> leftPadTo 32 peerTransceiverAddress
+      <> intToHexByte peerDecimals
 
 -- | Parse an NTT governance packet: verify module = "Ntt", dispatch on action
 -- id, abort (via 'error') on wrong module/unknown action/malformed input.
@@ -228,20 +268,106 @@ parseNttGovernance payload =
     moduleId = normalizeHex (sliceBytes 0 32 payload)
     action = bytesToInt (sliceBytes 32 1 payload)
     chain = bytesToInt (sliceBytes 33 2 payload)
+    managerAddress = normalizeHex (sliceBytes 35 32 payload)
   in
     if moduleId /= nttGovernanceModule
       then error "ntt governance: not the Ntt module"
       else case action of
         1 -> AcceptAdminToGovernance
                chain
-               (normalizeHex (sliceBytes 35 32 payload))
+               managerAddress
                (bytesToInt (sliceBytes 67 8 payload))
         2 -> RegisterBurnMintManager
                chain
-               (normalizeHex (sliceBytes 35 32 payload))
+               managerAddress
                (bytesToInt (sliceBytes 67 1 payload))
         3 -> RotateToCanonicalFactory
                chain
-               (normalizeHex (sliceBytes 35 32 payload))
+               managerAddress
                (bytesToInt (sliceBytes 67 8 payload))
+        4 -> SetPeerByGovernance
+               chain
+               managerAddress
+               (bytesToInt (sliceBytes 67 8 payload))
+               (bytesToInt (sliceBytes 75 2 payload))
+               (normalizeHex (sliceBytes 77 32 payload))
+               (normalizeHex (sliceBytes 109 32 payload))
+               (bytesToInt (sliceBytes 141 1 payload))
         _ -> error ("ntt governance: unsupported action " <> show action)
+
+----------------------------------------------------------------------
+-- TransceiverRegistration / TransceiverInit
+----------------------------------------------------------------------
+
+-- | bytes4(keccak256("WormholePeerRegistration")).
+wormholePeerRegistrationPrefix : Bytes
+wormholePeerRegistrationPrefix = "18fc67c2"
+
+-- | bytes4(keccak256("WormholeTransceiverInit")).
+wormholeTransceiverInitPrefix : Bytes
+wormholeTransceiverInitPrefix = "9c23bd3b"
+
+-- | The accountant's record of a foreign transceiver registration. 38 bytes.
+data TransceiverRegistration = TransceiverRegistration with
+    peerChain   : Int      -- uint16
+    peerAddress : Bytes32
+  deriving (Eq, Show)
+
+encodeTransceiverRegistration : TransceiverRegistration -> Bytes
+encodeTransceiverRegistration r =
+  wormholePeerRegistrationPrefix
+    <> intToBytesN r.peerChain 2
+    <> leftPadTo 32 r.peerAddress
+
+decodeTransceiverRegistration : Bytes -> TransceiverRegistration
+decodeTransceiverRegistration b =
+  let prefix = normalizeHex (sliceBytes 0 4 b)
+      peerChain = bytesToInt (sliceBytes 4 2 b)
+      peerAddress = normalizeHex (sliceBytes 6 32 b)
+  in if prefix /= wormholePeerRegistrationPrefix
+       then error ("ntt: bad TransceiverRegistration prefix: " <> prefix)
+       else TransceiverRegistration with ..
+
+-- | The accountant's record of a deployment's manager/token behind a
+-- transceiver. 70 bytes. @nttManagerMode@: 0 = LockUnlock, 1 = BurnMint.
+data TransceiverInit = TransceiverInit with
+    nttManagerAddress : Bytes32
+    nttManagerMode    : Int      -- uint8
+    tokenAddress      : Bytes32
+    tokenDecimals     : Int      -- uint8
+  deriving (Eq, Show)
+
+encodeTransceiverInit : TransceiverInit -> Bytes
+encodeTransceiverInit i =
+  wormholeTransceiverInitPrefix
+    <> leftPadTo 32 i.nttManagerAddress
+    <> intToHexByte i.nttManagerMode
+    <> leftPadTo 32 i.tokenAddress
+    <> intToHexByte i.tokenDecimals
+
+decodeTransceiverInit : Bytes -> TransceiverInit
+decodeTransceiverInit b =
+  let prefix = normalizeHex (sliceBytes 0 4 b)
+      nttManagerAddress = normalizeHex (sliceBytes 4 32 b)
+      nttManagerMode = bytesToInt (sliceBytes 36 1 b)
+      tokenAddress = normalizeHex (sliceBytes 37 32 b)
+      tokenDecimals = bytesToInt (sliceBytes 69 1 b)
+  in if prefix /= wormholeTransceiverInitPrefix
+       then error ("ntt: bad TransceiverInit prefix: " <> prefix)
+       else TransceiverInit with ..
+
+-- | Domain-separation tag for the token-address binding.
+nttTokenAddressTag : Text
+nttTokenAddressTag = "wormhole:ntt-token:v1"
+
+-- | Canton's opaque 32-byte stand-in for a CIP-56 'InstrumentId' on the wire
+-- (no chain has a native 32-byte token address). Split from
+-- 'nttTokenAddressFor' so tests can pin the encoding against fixed text.
+nttTokenAddressFromText : Text -> Text -> Bytes32
+nttTokenAddressFromText adminText idText =
+  normalizeHex (keccak256 (toHex nttTokenAddressTag
+    <> unLenPrefixed (lenPrefixed (toHex adminText))
+    <> unLenPrefixed (lenPrefixed (toHex idText))))
+
+nttTokenAddressFor : InstrumentId -> Bytes32
+nttTokenAddressFor inst = nttTokenAddressFromText (partyToText inst.admin) inst.id

--- a/canton/test/daml/Test/TestFactoryAuthority.daml
+++ b/canton/test/daml/Test/TestFactoryAuthority.daml
@@ -35,11 +35,11 @@ import Splice.Api.Token.MetadataV1 (emptyMetadata)
 import Splice.Api.Token.BurnMintV1
 import Splice.Api.Token.TransferInstructionV1
 import Wormhole.Core.Fees (emptyExtraArgs)
-import Wormhole.Core.State (Emitter)
+import Wormhole.Core.State (Emitter, CoreState)
 import Wormhole.Ntt.Governance (NttGovernance, RegisterManager (..))
 import Wormhole.Ntt.Manager qualified as M
 import Wormhole.Ntt.Deposit (DepositPreapproval (..), Deposit (..))
-import Test.TestNtt (nttSetup, nttCoinFactorySetup, coreRegistries, cantonChainId, b32)
+import Test.TestNtt (nttSetup, nttCoinFactorySetup, coreRegistries, cantonChainId, b32, resolveEmitter)
 
 -- | A contract signed by @victim@. If an attacker-authored factory can create
 -- one of these, it wielded @victim@'s (gg's) authority.
@@ -385,12 +385,13 @@ testEvilBurnMintFactoryForgesGgContract = do
 -- and the command itself, so each test decides whether it must succeed or
 -- fail.
 registerBurnMint
-  : Party -> Party -> InstrumentId -> ContractId BurnMintFactory
+  : Party -> Party -> InstrumentId -> ContractId BurnMintFactory -> ContractId CoreState
   -> Script ([Disclosure], Commands (ContractId M.NttManager, ContractId Emitter))
-registerBurnMint operator admin inst factoryCid = do
+registerBurnMint operator admin inst factoryCid csId = do
   [(govCid, _)] <- query @NttGovernance operator
   govDisc <- fromSome <$> queryDisclosure operator govCid
   (emReg, emRegDisc, rrReg, rrRegDisc) <- coreRegistries operator
+  csDisc <- fromSome <$> queryDisclosure operator csId
   let register = exerciseCmd govCid RegisterManager with
         admin
         chainId = cantonChainId
@@ -401,10 +402,12 @@ registerBurnMint operator admin inst factoryCid = do
         tokenConfig = M.BurnMint
         tokenDecimals = 8
         factory = M.BurnMintFactoryCid factoryCid
-        coreStateCid = None
+        coreStateCid = csId
+        consistencyLevel = 0
         emitterFeeAllocation = None
         claimFeeAllocation = None
-  pure ([govDisc, emRegDisc, rrRegDisc], (\(_, mgrCid, emitterCid, _) -> (mgrCid, emitterCid)) <$> register)
+        feeAllocation = None
+  pure ([govDisc, emRegDisc, rrRegDisc, csDisc], (\(_, mgrCid, emitterCid, _, _) -> (mgrCid, emitterCid)) <$> register)
 
 -- | Through the real registration: an attacker cannot permissionlessly stand
 -- up a gg-minted deployment (instrument admin = gg), because 'RegisterManager'
@@ -413,25 +416,25 @@ registerBurnMint operator admin inst factoryCid = do
 -- relied on.
 testAttackerCannotRegisterGgMintedManager : Script ()
 testAttackerCannotRegisterGgMintedManager = do
-  (operator, gg, _) <- nttSetup
+  (operator, gg, csId) <- nttSetup
   attacker <- allocateParty "AttackerGgMint"
   evilFactory <- submit attacker do
     createCmd EvilBurnMintFactory with thief = attacker, viewAdmin = gg, attemptForge = True
   let inst = InstrumentId with admin = gg, id = M.nttInstrumentIdFor attacker 0
   (discs, register) <- registerBurnMint operator attacker inst
-    (toInterfaceContractId @BurnMintFactory evilFactory)
+    (toInterfaceContractId @BurnMintFactory evilFactory) csId
   submitMustFail (actAs attacker <> mconcat (map disclose discs)) register
 
 -- | Same property against a real 'Token.CIP0056.CoinFactory.CoinFactory':
 -- the co-signature gate protects registration, not the factory's trustworthiness.
 testAttackerCannotRegisterGgMintedManagerWithRealFactory : Script ()
 testAttackerCannotRegisterGgMintedManagerWithRealFactory = do
-  (operator, gg, _) <- nttSetup
+  (operator, gg, csId) <- nttSetup
   factoryCid <- nttCoinFactorySetup gg
   attacker <- allocateParty "AttackerGgMintRealFactory"
   let inst = InstrumentId with admin = gg, id = M.nttInstrumentIdFor attacker 0
   (discs, register) <- registerBurnMint operator attacker inst
-    (toInterfaceContractId @BurnMintFactory factoryCid)
+    (toInterfaceContractId @BurnMintFactory factoryCid) csId
   submitMustFail (actAs attacker <> mconcat (map disclose discs)) register
 
 -- | A holding signed by its owner alone whose interface view lies about the
@@ -470,12 +473,23 @@ testExternalMinterMaliciousFactoryFirewallsGg = do
     createCmd EvilBurnMintFactory with thief = minter, viewAdmin = gg, attemptForge = True
   let inst = InstrumentId with admin = minter, id = M.nttInstrumentIdFor minter 0
   (discs, register) <- registerBurnMint operator minter inst
-    (toInterfaceContractId @BurnMintFactory evilFactory)
-  (mgrCid, emitterCid) <- submit (actAs minter <> mconcat (map disclose discs)) register
-  mgrCid <- submit minter do
+    (toInterfaceContractId @BurnMintFactory evilFactory) csId
+  (mgrCid, _) <- submit (actAs minter <> mconcat (map disclose discs)) register
+  Some mgr0 <- queryContractId operator mgrCid
+  emitterCid <- resolveEmitter gg mgr0.transceiverEmitterId   -- RegisterManager's own init broadcast churned it
+  emitterDisc <- fromSome <$> queryDisclosure operator emitterCid
+  csDisc0 <- fromSome <$> queryDisclosure operator csId
+  (mgrCid, _) <- submit (actAs minter <> disclose emitterDisc <> disclose csDisc0) do
     exerciseCmd mgrCid M.SetPeer with
       chainId = 2
       peer = M.Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc", decimals = 8
+      transceiverEmitterCid = emitterCid
+      coreStateCid = csId
+      consistencyLevel = 0
+      payer = minter
+      feeAllocation = None
+  Some mgr <- queryContractId operator mgrCid
+  emitterCid <- resolveEmitter gg mgr.transceiverEmitterId   -- SetPeer's broadcast churned it
   fakeHolding <- submit minter do
     createCmd FakeHolding with owner = minter, instrument = inst, amount = 1.0
   csDisc <- fromSome <$> queryDisclosure operator csId

--- a/canton/test/daml/Test/TestNtt.daml
+++ b/canton/test/daml/Test/TestNtt.daml
@@ -48,7 +48,7 @@ import Wormhole.Core.GuardianSet (GuardianSet(..))
 import Wormhole.Core.Replay (ReplayNode, defaultSplitThreshold)
 import Wormhole.Core.Setup (mkInitialCoreState, mkInitialEmitterRegistry, mkInitialReplayRootRegistry, solanaGovernanceChainId, defaultGovernanceContract)
 import Wormhole.Core.State
-  ( Emitter, CoreState, EmitterRegistry, ReplayRootRegistry
+  ( Emitter(..), CoreState, EmitterRegistry, ReplayRootRegistry
   , WormholeMessage, emitterAddressTag, SubmitGovernanceVAA(..), VerifyAndConsumeVAA(..) )
 import Wormhole.Core.VAA (parseVAA)
 import Token.CIP0056.CoinFactory
@@ -316,9 +316,9 @@ testNamespaceVector = do
   assert ("ntt:" `isPrefixOf` n0)
   assert (n0 /= n1)
 
-  (operator, gg, _) <- nttSetup
+  (operator, gg, csId) <- nttSetup
   admin <- allocateParty "NamespaceVectorAdmin"
-  d <- deploy operator gg admin LockUnlock
+  d <- deploy operator gg admin LockUnlock csId
   Some mgr <- queryContractId operator d.mgrCid
   mgr.namespace === nttNamespaceFor d.instrumentId admin mgr.managerId
 
@@ -355,14 +355,26 @@ nttSetupFee = do
     createCmd NttGovernance with operator, guardianGovernance = gg, nextId = 0, consumedGovernance = Set.empty
   pure (operator, gg, csId, mockAdmin, inst, cs.feeRecipient)
 
--- | A registered deployment and the handles its tests need.
+-- | A registered deployment and the handles its tests need. @emitterCid@ is
+-- the live post-registration 'Emitter' (registration itself broadcasts the
+-- 'TransceiverInit', churning the freshly minted one).
 data Deployment = Deployment with
     mgrCid       : ContractId NttManager
     emitterCid   : ContractId Emitter
     factory      : NttFactory
     instrumentId : InstrumentId
     ledgerCid    : Optional (ContractId LockedLedger)  -- lock/unlock only
+    initMsg      : WormholeMessage  -- the TransceiverInit broadcast at registration
   deriving (Eq, Show)
+
+-- | Re-resolve @owner@'s live 'Emitter' by its stable @emitterId@ after a
+-- churn (a nested 'PublishMessage' consumes and recreates it).
+resolveEmitter : Party -> Int -> Script (ContractId Emitter)
+resolveEmitter owner eid = do
+  ems <- query @Emitter owner
+  case [ cid | (cid, em) <- ems, em.emitterId == eid ] of
+    [cid] -> pure cid
+    matches -> abort ("expected exactly one emitter for id " <> show eid <> ", got: " <> show (length matches))
 
 -- | Unwrap a burn/mint deployment's typed factory.
 theBurnMintFactory : NttFactory -> ContractId BurnMintFactory
@@ -383,12 +395,13 @@ coreRegistries operator = do
 
 -- | Create the gg-signed mock registry factory and register the manager
 -- through the shared 'NttGovernance' root — which atomically mints the
--- gg-owned transceiver 'Emitter' and claims the gg-scoped replay root, so no
+-- gg-owned transceiver 'Emitter', claims the gg-scoped replay root, and
+-- broadcasts the deployment's 'TransceiverInit' through that emitter, so no
 -- separate emitter registration precedes this. For burn/mint the instrument
 -- id must be bound to the registering admin, so each deployment gets its own
 -- instrument; lock/unlock uses the shared 'bridgedInstrument'.
-deploy : Party -> Party -> Party -> NttTokenConfig -> Script Deployment
-deploy operator gg admin config = do
+deploy : Party -> Party -> Party -> NttTokenConfig -> ContractId CoreState -> Script Deployment
+deploy operator gg admin config csId = do
   (instrumentId, factory) <- case config of
     BurnMint -> do
       let inst = InstrumentId with admin = gg, id = nttInstrumentIdFor admin 0
@@ -400,13 +413,14 @@ deploy operator gg admin config = do
   [(govCid, _)] <- query @NttGovernance operator
   govDisc <- fromSome <$> queryDisclosure operator govCid
   (emReg, emRegDisc, rrReg, rrRegDisc) <- coreRegistries operator
+  csDisc <- fromSome <$> queryDisclosure operator csId
   -- Burn/mint registration is co-signed by the instrument's minter (here gg);
   -- lock/unlock is admin-only.
   let minterActAs = case config of
         BurnMint -> actAs gg
         LockUnlock -> mempty
-  (_, mgrCid, emitterCid, ledgerCid) <-
-    submit (actAs admin <> minterActAs <> disclose govDisc <> disclose emRegDisc <> disclose rrRegDisc) do
+  (_, mgrCid, _emitterCid, ledgerCid, initMsg) <-
+    submit (actAs admin <> minterActAs <> disclose govDisc <> disclose emRegDisc <> disclose rrRegDisc <> disclose csDisc) do
       exerciseCmd govCid RegisterManager with
         admin
         chainId = cantonChainId
@@ -417,20 +431,24 @@ deploy operator gg admin config = do
         tokenConfig = config
         tokenDecimals = 8
         factory
-        coreStateCid = None
+        coreStateCid = csId
+        consistencyLevel = 0
         emitterFeeAllocation = None
         claimFeeAllocation = None
-  pure Deployment with mgrCid, emitterCid, factory, instrumentId, ledgerCid
+        feeAllocation = None
+  Some mgr <- queryContractId operator mgrCid
+  emitterCid <- resolveEmitter gg mgr.transceiverEmitterId
+  pure Deployment with mgrCid, emitterCid, factory, instrumentId, ledgerCid, initMsg
 
 -- | Two deployments get distinct managers with sequential ids and owner-bound
 -- addresses; a lock/unlock deployment gets a zero-balance ledger.
 testNttDeployment : Script ()
 testNttDeployment = do
-  (operator, gg, _) <- nttSetup
+  (operator, gg, csId) <- nttSetup
   alice <- allocateParty "Alice"
   bob <- allocateParty "Bob"
-  dA <- deploy operator gg alice LockUnlock
-  dB <- deploy operator gg bob BurnMint
+  dA <- deploy operator gg alice LockUnlock csId
+  dB <- deploy operator gg bob BurnMint csId
   Some ma <- queryContractId operator dA.mgrCid
   Some mb <- queryContractId operator dB.mgrCid
   ma.managerId === 0
@@ -461,7 +479,7 @@ testTransceiverIsDeploymentBound = do
   alice <- allocateParty "BoundAlice"
   bob <- allocateParty "BoundBob"
   (dA, discsA) <- sendScaffold operator gg alice LockUnlock csId
-  dB <- deploy operator gg bob LockUnlock
+  dB <- deploy operator gg bob LockUnlock csId
   Some emA <- queryContractId operator dA.emitterCid
   Some emB <- queryContractId operator dB.emitterCid
   emA.owner === gg
@@ -491,14 +509,15 @@ testTransceiverIsDeploymentBound = do
 -- registering admin.
 testBurnMintRegistrationRequiresBoundInstrument : Script ()
 testBurnMintRegistrationRequiresBoundInstrument = do
-  (operator, gg, _) <- nttSetup
+  (operator, gg, csId) <- nttSetup
   admin <- allocateParty "BindAdmin"
   [(govCid, _)] <- query @NttGovernance operator
   govDisc <- fromSome <$> queryDisclosure operator govCid
   (emReg, emRegDisc, rrReg, rrRegDisc) <- coreRegistries operator
+  csDisc <- fromSome <$> queryDisclosure operator csId
   -- gg (the instrument admin) co-signs; the id binding still rejects the
   -- unbound instrument id.
-  res <- trySubmit (actAs admin <> actAs gg <> disclose govDisc <> disclose emRegDisc <> disclose rrRegDisc) do
+  res <- trySubmit (actAs admin <> actAs gg <> disclose govDisc <> disclose emRegDisc <> disclose rrRegDisc <> disclose csDisc) do
     exerciseCmd govCid RegisterManager with
       admin
       chainId = cantonChainId
@@ -509,9 +528,11 @@ testBurnMintRegistrationRequiresBoundInstrument = do
       tokenConfig = BurnMint
       tokenDecimals = 8
       factory = BurnMintFactoryCid (coerceContractId emReg)   -- unused; registration fails first
-      coreStateCid = None
+      coreStateCid = csId
+      consistencyLevel = 0
       emitterFeeAllocation = None
       claimFeeAllocation = None
+      feeAllocation = None
   expectAbort "not bound to the registering admin" res
 
 -- | The exclusivity attack the binding exists to stop: mallory registers her
@@ -522,15 +543,16 @@ testBurnMintRegistrationRequiresBoundInstrument = do
 -- co-signature.
 testBurnMintInstrumentIsExclusiveToItsAdmin : Script ()
 testBurnMintInstrumentIsExclusiveToItsAdmin = do
-  (operator, gg, _) <- nttSetup
+  (operator, gg, csId) <- nttSetup
   alice <- allocateParty "ExclAlice"
   mallory <- allocateParty "ExclMallory"
-  d <- deploy operator gg alice BurnMint
+  d <- deploy operator gg alice BurnMint csId
   [(govCid, _)] <- query @NttGovernance operator
   govDisc <- fromSome <$> queryDisclosure operator govCid
   (emReg, emRegDisc, rrReg, rrRegDisc) <- coreRegistries operator
+  csDisc <- fromSome <$> queryDisclosure operator csId
   forA_ [0, 1, 7] \nonce -> do
-    res <- trySubmit (actAs mallory <> actAs gg <> disclose govDisc <> disclose emRegDisc <> disclose rrRegDisc) do
+    res <- trySubmit (actAs mallory <> actAs gg <> disclose govDisc <> disclose emRegDisc <> disclose rrRegDisc <> disclose csDisc) do
       exerciseCmd govCid RegisterManager with
         admin = mallory
         chainId = cantonChainId
@@ -541,9 +563,11 @@ testBurnMintInstrumentIsExclusiveToItsAdmin = do
         tokenConfig = BurnMint
         tokenDecimals = 8
         factory = BurnMintFactoryCid (coerceContractId emReg)   -- unused; registration fails first
-        coreStateCid = None
+        coreStateCid = csId
+        consistencyLevel = 0
         emitterFeeAllocation = None
         claimFeeAllocation = None
+        feeAllocation = None
     expectAbort "not bound to the registering admin" res
 
 -- | Burn/mint registration rejects an instrument that gg does not administer
@@ -551,13 +575,14 @@ testBurnMintInstrumentIsExclusiveToItsAdmin = do
 -- Daml Decimal cannot represent exactly.
 testRegistrationBounds : Script ()
 testRegistrationBounds = do
-  (operator, gg, _) <- nttSetup
+  (operator, gg, csId) <- nttSetup
   admin <- allocateParty "BoundsAdmin"
   outsider <- allocateParty "BoundsOutsider"
   [(govCid, _)] <- query @NttGovernance operator
   govDisc <- fromSome <$> queryDisclosure operator govCid
   (emReg, emRegDisc, rrReg, rrRegDisc) <- coreRegistries operator
-  let discs = disclose govDisc <> disclose emRegDisc <> disclose rrRegDisc
+  csDisc <- fromSome <$> queryDisclosure operator csId
+  let discs = disclose govDisc <> disclose emRegDisc <> disclose rrRegDisc <> disclose csDisc
 
   -- A burn/mint instrument's minter must co-sign registration (it lends its
   -- mint authority). Here the external minter @outsider@ does not co-sign, so
@@ -573,9 +598,11 @@ testRegistrationBounds = do
       tokenConfig = BurnMint
       tokenDecimals = 8
       factory = BurnMintFactoryCid (coerceContractId emReg)   -- unused; registration fails first
-      coreStateCid = None
+      coreStateCid = csId
+      consistencyLevel = 0
       emitterFeeAllocation = None
       claimFeeAllocation = None
+      feeAllocation = None
 
   res <- trySubmit (actAs admin <> discs) do
     exerciseCmd govCid RegisterManager with
@@ -588,9 +615,11 @@ testRegistrationBounds = do
       tokenConfig = LockUnlock
       tokenDecimals = 11
       factory = TransferFactoryCid (coerceContractId emReg)   -- unused; registration fails first
-      coreStateCid = None
+      coreStateCid = csId
+      consistencyLevel = 0
       emitterFeeAllocation = None
       claimFeeAllocation = None
+      feeAllocation = None
   expectAbort "tokenDecimals must be between 0 and 10" res
 
   -- The committed factory's type must match the mode: a lock/unlock
@@ -606,9 +635,11 @@ testRegistrationBounds = do
       tokenConfig = LockUnlock
       tokenDecimals = 8
       factory = BurnMintFactoryCid (coerceContractId emReg)
-      coreStateCid = None
+      coreStateCid = csId
+      consistencyLevel = 0
       emitterFeeAllocation = None
       claimFeeAllocation = None
+      feeAllocation = None
   expectAbort "factory type does not match" res
 
   -- The deployment's own chain id must be a positive uint16.
@@ -623,9 +654,11 @@ testRegistrationBounds = do
       tokenConfig = LockUnlock
       tokenDecimals = 8
       factory = TransferFactoryCid (coerceContractId emReg)   -- unused; registration fails first
-      coreStateCid = None
+      coreStateCid = csId
+      consistencyLevel = 0
       emitterFeeAllocation = None
       claimFeeAllocation = None
+      feeAllocation = None
   expectAbort "chainId must be a positive uint16" res
 
 -- | 'SetPeer' rejects an out-of-range chain id, the deployment's own chain id
@@ -634,33 +667,38 @@ testRegistrationBounds = do
 -- misconfiguration rather than an attack.
 testSetPeerGuards : Script ()
 testSetPeerGuards = do
-  (operator, gg, _) <- nttSetup
+  (operator, gg, csId) <- nttSetup
   admin <- allocateParty "SetPeerAdmin"
-  d <- deploy operator gg admin LockUnlock
+  d <- deploy operator gg admin LockUnlock csId
   let goodPeer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc", decimals = 8
+  csDisc <- fromSome <$> queryDisclosure operator csId
+  emitterDisc <- fromSome <$> queryDisclosure operator d.emitterCid
+  let discs = [csDisc, emitterDisc]
+      setPeerCmd chainId peer = exerciseCmd d.mgrCid SetPeer with
+        chainId
+        peer
+        transceiverEmitterCid = d.emitterCid
+        coreStateCid = csId
+        consistencyLevel = 0
+        payer = admin
+        feeAllocation = None
 
-  res <- trySubmit admin do
-    exerciseCmd d.mgrCid SetPeer with chainId = 70000, peer = goodPeer
+  res <- trySubmitWithDiscs admin discs do setPeerCmd 70000 goodPeer
   expectAbort "positive uint16" res
 
-  res <- trySubmit admin do
-    exerciseCmd d.mgrCid SetPeer with chainId = cantonChainId, peer = goodPeer
+  res <- trySubmitWithDiscs admin discs do setPeerCmd cantonChainId goodPeer
   expectAbort "own chain" res
 
-  res <- trySubmit admin do
-    exerciseCmd d.mgrCid SetPeer with
-      chainId = 2
-      peer = Peer with managerAddress = b32 "", transceiverAddress = b32 "cc", decimals = 8
+  res <- trySubmitWithDiscs admin discs do
+    setPeerCmd 2 (Peer with managerAddress = b32 "", transceiverAddress = b32 "cc", decimals = 8)
   expectAbort "manager address must be non-zero" res
 
-  res <- trySubmit admin do
-    exerciseCmd d.mgrCid SetPeer with
-      chainId = 2
-      peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc", decimals = 0
+  res <- trySubmitWithDiscs admin discs do
+    setPeerCmd 2 (Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc", decimals = 0)
   expectAbort "peer decimals must be a positive uint8" res
 
   -- A well-formed peer on another chain is accepted.
-  _ <- submit admin do exerciseCmd d.mgrCid SetPeer with chainId = 2, peer = goodPeer
+  _ <- submitWithDiscs admin discs do setPeerCmd 2 goodPeer
   pure ()
 
 -- | Registration pins the caller-supplied registries to this bridge instance:
@@ -670,7 +708,7 @@ testSetPeerGuards = do
 -- checks.
 testRegistrationRejectsForeignRegistries : Script ()
 testRegistrationRejectsForeignRegistries = do
-  (operator, gg, _) <- nttSetup
+  (operator, gg, csId) <- nttSetup
   admin <- allocateParty "ForeignRegAdmin"
   rogue <- allocateParty "RogueOperator"
   rogueObserver <- allocateParty "RogueRegObserver"
@@ -679,11 +717,12 @@ testRegistrationRejectsForeignRegistries = do
   [(govCid, _)] <- query @NttGovernance operator
   govDisc <- fromSome <$> queryDisclosure operator govCid
   (emReg, emRegDisc, rrReg, rrRegDisc) <- coreRegistries operator
+  csDisc <- fromSome <$> queryDisclosure operator csId
 
   shadowEmReg <- submit rogue do
     createCmd (mkInitialEmitterRegistry rogue gg rogueObserver 0)
   shadowEmRegDisc <- fromSome <$> queryDisclosure rogue shadowEmReg
-  res <- trySubmit (actAs admin <> disclose govDisc <> disclose shadowEmRegDisc <> disclose rrRegDisc) do
+  res <- trySubmit (actAs admin <> disclose govDisc <> disclose shadowEmRegDisc <> disclose rrRegDisc <> disclose csDisc) do
     exerciseCmd govCid RegisterManager with
       admin
       chainId = cantonChainId
@@ -694,15 +733,17 @@ testRegistrationRejectsForeignRegistries = do
       tokenConfig = LockUnlock
       tokenDecimals = 8
       factory
-      coreStateCid = None
+      coreStateCid = csId
+      consistencyLevel = 0
       emitterFeeAllocation = None
       claimFeeAllocation = None
+      feeAllocation = None
   expectAbort "emitter registry is not this bridge instance's" res
 
   shadowRrReg <- submit rogue do
     createCmd (mkInitialReplayRootRegistry rogue gg 0)
   shadowRrRegDisc <- fromSome <$> queryDisclosure rogue shadowRrReg
-  res <- trySubmit (actAs admin <> disclose govDisc <> disclose emRegDisc <> disclose shadowRrRegDisc) do
+  res <- trySubmit (actAs admin <> disclose govDisc <> disclose emRegDisc <> disclose shadowRrRegDisc <> disclose csDisc) do
     exerciseCmd govCid RegisterManager with
       admin
       chainId = cantonChainId
@@ -713,10 +754,315 @@ testRegistrationRejectsForeignRegistries = do
       tokenConfig = LockUnlock
       tokenDecimals = 8
       factory
-      coreStateCid = None
+      coreStateCid = csId
+      consistencyLevel = 0
       emitterFeeAllocation = None
       claimFeeAllocation = None
+      feeAllocation = None
   expectAbort "replay root registry is not this bridge instance's" res
+
+----------------------------------------------------------------------
+-- Broadcast (bundled into SetPeer / RegisterManager; accountant bookkeeping)
+----------------------------------------------------------------------
+
+-- | Happy path: 'SetPeer' publishes the encoded registration at the emitter's
+-- own sequence (1, since 'deploy' already broadcast a 'TransceiverInit' at 0),
+-- and the sequence advances.
+testSetPeerBroadcastsRegistration : Script ()
+testSetPeerBroadcastsRegistration = do
+  (operator, gg, csId) <- nttSetup
+  alice <- allocateParty "SetPeerBroadcastAlice"
+  d <- deploy operator gg alice LockUnlock csId
+  csDisc <- fromSome <$> queryDisclosure operator csId
+  emitterDisc <- fromSome <$> queryDisclosure operator d.emitterCid
+  (_, msg) <- submit (actAs alice <> disclose csDisc <> disclose emitterDisc) do
+    exerciseCmd d.mgrCid SetPeer with
+      chainId = 2
+      peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc", decimals = 8
+      transceiverEmitterCid = d.emitterCid
+      coreStateCid = csId
+      consistencyLevel = 0
+      payer = alice
+      feeAllocation = None
+  msg.payload === encodeTransceiverRegistration TransceiverRegistration with
+    peerChain = 2
+    peerAddress = b32 "cc"
+  msg.sequence === 1
+  [(_, em)] <- query @Emitter gg
+  em.sequence === 2
+
+-- | A foreign deployment's emitter is rejected, mirroring 'testTransceiverIsDeploymentBound'.
+testSetPeerRejectsForeignTransceiver : Script ()
+testSetPeerRejectsForeignTransceiver = do
+  (operator, gg, csId) <- nttSetup
+  alice <- allocateParty "SetPeerForeignAlice"
+  bob <- allocateParty "SetPeerForeignBob"
+  dA <- deploy operator gg alice LockUnlock csId
+  dB <- deploy operator gg bob LockUnlock csId
+  csDisc <- fromSome <$> queryDisclosure operator csId
+  emitterBDisc <- fromSome <$> queryDisclosure operator dB.emitterCid
+  res <- trySubmit (actAs alice <> disclose csDisc <> disclose emitterBDisc) do
+    exerciseCmd dA.mgrCid SetPeer with
+      chainId = 2
+      peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc", decimals = 8
+      transceiverEmitterCid = dB.emitterCid
+      coreStateCid = csId
+      consistencyLevel = 0
+      payer = alice
+      feeAllocation = None
+  expectAbort "transceiver emitter is not this deployment's" res
+
+-- | Peer addresses must be exactly 32 bytes of lowercase hex:
+-- 'leftPadTo' is the identity above 32 bytes, so an unchecked oversized
+-- address would emit an over-length registration the accountant truncates
+-- and permanently mis-records into its write-once slot. Uppercase hex is
+-- REJECTED rather than normalized — the check runs on the raw field, before
+-- 'normalizePeer' lowercases, so this pins the actual behaviour rather than
+-- the alternative (normalize-then-accept). A valid 32-byte lowercase address
+-- is still accepted.
+testSetPeerRejectsMalformedAddress : Script ()
+testSetPeerRejectsMalformedAddress = do
+  (operator, gg, csId) <- nttSetup
+  admin <- allocateParty "SetPeerMalformedAdmin"
+  d <- deploy operator gg admin LockUnlock csId
+  csDisc <- fromSome <$> queryDisclosure operator csId
+  emitterDisc <- fromSome <$> queryDisclosure operator d.emitterCid
+  let valid = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc", decimals = 8
+      doSetPeer peer = exerciseCmd d.mgrCid SetPeer with
+        chainId = 2
+        peer
+        transceiverEmitterCid = d.emitterCid
+        coreStateCid = csId
+        consistencyLevel = 0
+        payer = admin
+        feeAllocation = None
+      tryPeer peer = trySubmitWithDiscs admin [csDisc, emitterDisc] do doSetPeer peer
+
+  -- Oversized (33 bytes): rejected, not silently truncated.
+  res <- tryPeer (valid with transceiverAddress = "00" <> b32 "cc")
+  expectAbort "32 bytes of lowercase hex" res
+
+  -- Short (31 bytes): rejected, not silently zero-padded.
+  res <- tryPeer (valid with transceiverAddress = T.drop 2 (b32 "cc"))
+  expectAbort "32 bytes of lowercase hex" res
+
+  -- Non-hex characters: rejected even at the correct width.
+  res <- tryPeer (valid with transceiverAddress = "zz" <> T.drop 2 (b32 "cc"))
+  expectAbort "32 bytes of lowercase hex" res
+
+  -- Odd hex-digit count: 'byteLength' truncates via integer division, so
+  -- this is caught by the width check.
+  res <- tryPeer (valid with transceiverAddress = T.take (T.length (b32 "cc") - 1) (b32 "cc"))
+  expectAbort "32 bytes of lowercase hex" res
+
+  -- Uppercase hex: rejected, not normalized.
+  res <- tryPeer (valid with transceiverAddress = T.asciiToUpper (b32 "cc"))
+  expectAbort "32 bytes of lowercase hex" res
+
+  -- A valid 32-byte lowercase address is still accepted.
+  (_, msg) <- submitWithDiscs admin [csDisc, emitterDisc] do doSetPeer valid
+  msg.payload === encodeTransceiverRegistration TransceiverRegistration with
+    peerChain = 2
+    peerAddress = b32 "cc"
+
+-- | 'consistencyLevel' is a uint8 on the wire: out of range the
+-- Canton watcher drops the message, so it is never observed or signed.
+-- Negative and >255 values are rejected; the boundary values 0 and 255 are
+-- accepted.
+testSetPeerRejectsOutOfRangeConsistencyLevel : Script ()
+testSetPeerRejectsOutOfRangeConsistencyLevel = do
+  (operator, gg, csId) <- nttSetup
+  admin <- allocateParty "SetPeerCLAdmin"
+  d <- deploy operator gg admin LockUnlock csId
+  csDisc <- fromSome <$> queryDisclosure operator csId
+  emitterDisc <- fromSome <$> queryDisclosure operator d.emitterCid
+  let doSetPeer cl = exerciseCmd d.mgrCid SetPeer with
+        chainId = 2
+        peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc", decimals = 8
+        transceiverEmitterCid = d.emitterCid
+        coreStateCid = csId
+        consistencyLevel = cl
+        payer = admin
+        feeAllocation = None
+
+  res <- trySubmitWithDiscs admin [csDisc, emitterDisc] do doSetPeer 256
+  expectAbort "consistency level must be a uint8" res
+  res <- trySubmitWithDiscs admin [csDisc, emitterDisc] do doSetPeer (-1)
+  expectAbort "consistency level must be a uint8" res
+
+  -- Boundary 0 accepted.
+  (_, msg0) <- submitWithDiscs admin [csDisc, emitterDisc] do doSetPeer 0
+  msg0.consistencyLevel === 0
+
+-- | Boundary value 255 accepted, on a separate deployment (the previous test
+-- already claims this manager's peer-chain-2 slot at consistencyLevel 0).
+testSetPeerAcceptsMaxConsistencyLevel : Script ()
+testSetPeerAcceptsMaxConsistencyLevel = do
+  (operator, gg, csId) <- nttSetup
+  admin <- allocateParty "SetPeerCLMaxAdmin"
+  d <- deploy operator gg admin LockUnlock csId
+  csDisc <- fromSome <$> queryDisclosure operator csId
+  emitterDisc <- fromSome <$> queryDisclosure operator d.emitterCid
+  (_, msg) <- submitWithDiscs admin [csDisc, emitterDisc] do
+    exerciseCmd d.mgrCid SetPeer with
+      chainId = 2
+      peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc", decimals = 8
+      transceiverEmitterCid = d.emitterCid
+      coreStateCid = csId
+      consistencyLevel = 255
+      payer = admin
+      feeAllocation = None
+  msg.consistencyLevel === 255
+
+-- | 'SetPeer' at nonzero @messageFee@: no allocation aborts with
+-- the core's fee-required message, and a properly minted allocation from the
+-- admin's own wallet succeeds, publishes the registration, and the fee lands
+-- on the fee recipient — mirroring 'testNttSend's fee mechanism.
+testSetPeerFeeRequired : Script ()
+testSetPeerFeeRequired = do
+  (operator, gg, csId, mockAdmin, inst, feeRecipient) <- nttSetupFee
+  admin <- allocateParty "SetPeerFeeAdmin"
+  d <- deploy operator gg admin LockUnlock csId
+
+  -- Governance raises the message fee to 1000 (1e-7 tokens).
+  csId <- submit operator do
+    exerciseCmd csId SubmitGovernanceVAA with
+      encodedVAA = govSetFeeVAA
+      pubKeys = [(0, devnetGuardianPubKey)]
+  csDisc <- fromSome <$> queryDisclosure operator csId
+  emitterDisc <- fromSome <$> queryDisclosure operator d.emitterCid
+  let doSetPeer feeAlloc = exerciseCmd d.mgrCid SetPeer with
+        chainId = 2
+        peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc", decimals = 8
+        transceiverEmitterCid = d.emitterCid
+        coreStateCid = csId
+        consistencyLevel = 0
+        payer = admin
+        feeAllocation = feeAlloc
+
+  -- (a) Fee due but none attached: rejected.
+  res <- trySubmitWithDiscs admin [csDisc, emitterDisc] do doSetPeer None
+  expectAbort "fee required" res
+
+  -- (b) Exact fee from admin's own wallet: succeeds, the registration
+  -- publishes, and the fee lands on the fee recipient.
+  feePay <- mintAndAllocate mockAdmin admin feeRecipient inst (feeToDecimal 1000)
+  (_, msg) <- submitWithDiscs admin [csDisc, emitterDisc] do doSetPeer (Some feePay)
+  msg.payload === encodeTransceiverRegistration TransceiverRegistration with
+    peerChain = 2
+    peerAddress = b32 "cc"
+  bal <- mockBalance mockAdmin feeRecipient inst
+  bal === feeToDecimal 1000
+
+-- | Peers stay replaceable (D3): a second 'SetPeer' for the same chain
+-- succeeds and broadcasts the NEW address, not the old one.
+testSetPeerReplacementBroadcastsAgain : Script ()
+testSetPeerReplacementBroadcastsAgain = do
+  (operator, gg, csId) <- nttSetup
+  admin <- allocateParty "SetPeerReplaceAdmin"
+  (d, discs) <- sendScaffold operator gg admin LockUnlock csId
+  (_, msg) <- submitWithDiscs admin discs do
+    exerciseCmd d.mgrCid SetPeer with
+      chainId = 2
+      peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "dd", decimals = 8
+      transceiverEmitterCid = d.emitterCid
+      coreStateCid = csId
+      consistencyLevel = 0
+      payer = admin
+      feeAllocation = None
+  msg.payload === encodeTransceiverRegistration TransceiverRegistration with
+    peerChain = 2
+    peerAddress = b32 "dd"
+
+-- | Pausing blocks value movement, not administration: 'SetPeer's broadcast still succeeds.
+testSetPeerWorksWhilePaused : Script ()
+testSetPeerWorksWhilePaused = do
+  (operator, gg, csId) <- nttSetup
+  admin <- allocateParty "SetPeerPausedAdmin"
+  d <- deploy operator gg admin LockUnlock csId
+  csDisc <- fromSome <$> queryDisclosure operator csId
+  emitterDisc <- fromSome <$> queryDisclosure operator d.emitterCid
+  pausedMgr <- submit admin do exerciseCmd d.mgrCid SetPaused with newPaused = True
+  (_, msg) <- submit (actAs admin <> disclose csDisc <> disclose emitterDisc) do
+    exerciseCmd pausedMgr SetPeer with
+      chainId = 2
+      peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc", decimals = 8
+      transceiverEmitterCid = d.emitterCid
+      coreStateCid = csId
+      consistencyLevel = 0
+      payer = admin
+      feeAllocation = None
+  msg.payload === encodeTransceiverRegistration TransceiverRegistration with
+    peerChain = 2
+    peerAddress = b32 "cc"
+
+-- | 'RegisterManager' publishes the 'TransceiverInit' once, at registration,
+-- for both modes; the stored 'tokenAddress' agrees with 'nttTokenAddressFor'.
+testRegisterManagerBroadcastsInit : Script ()
+testRegisterManagerBroadcastsInit = do
+  (operator, gg, csId) <- nttSetup
+  aliceLock <- allocateParty "RegisterInitLockAlice"
+  bobBurn <- allocateParty "RegisterInitBurnBob"
+  dLock <- deploy operator gg aliceLock LockUnlock csId
+  dBurn <- deploy operator gg bobBurn BurnMint csId
+  Some mgrLock <- queryContractId operator dLock.mgrCid
+  Some mgrBurn <- queryContractId operator dBurn.mgrCid
+
+  dLock.initMsg.payload === encodeTransceiverInit TransceiverInit with
+    nttManagerAddress = mgrLock.managerAddress
+    nttManagerMode = 0
+    tokenAddress = mgrLock.tokenAddress
+    tokenDecimals = 8
+  dLock.initMsg.sequence === 0
+  mgrLock.tokenAddress === nttTokenAddressFor dLock.instrumentId
+
+  dBurn.initMsg.payload === encodeTransceiverInit TransceiverInit with
+    nttManagerAddress = mgrBurn.managerAddress
+    nttManagerMode = 1
+    tokenAddress = mgrBurn.tokenAddress
+    tokenDecimals = 8
+  dBurn.initMsg.sequence === 0
+  mgrBurn.tokenAddress === nttTokenAddressFor dBurn.instrumentId
+
+-- | 'RegisterManager''s init broadcast also bounds 'consistencyLevel' to a
+-- uint8: out of range is terminal there (no re-broadcast path),
+-- so it is rejected before anything is minted. Boundary 255 is accepted; 0
+-- is already exercised by every other 'deploy' call in this file.
+testRegisterManagerRejectsOutOfRangeConsistencyLevel : Script ()
+testRegisterManagerRejectsOutOfRangeConsistencyLevel = do
+  (operator, gg, csId) <- nttSetup
+  admin <- allocateParty "RegisterCLAdmin"
+  fc <- submit gg do createCmd MockTransferFactory with admin = gg, pending = False, skim = 0.0
+  let factory = TransferFactoryCid (toInterfaceContractId @TransferFactory fc)
+  [(govCid, _)] <- query @NttGovernance operator
+  govDisc <- fromSome <$> queryDisclosure operator govCid
+  (emReg, emRegDisc, rrReg, rrRegDisc) <- coreRegistries operator
+  csDisc <- fromSome <$> queryDisclosure operator csId
+  let register cl = exerciseCmd govCid RegisterManager with
+        admin
+        chainId = cantonChainId
+        emitterRegistryCid = emReg
+        replayRootRegistryCid = rrReg
+        instrumentId = bridgedInstrument gg
+        instrumentNonce = 0
+        tokenConfig = LockUnlock
+        tokenDecimals = 8
+        factory
+        coreStateCid = csId
+        consistencyLevel = cl
+        emitterFeeAllocation = None
+        claimFeeAllocation = None
+        feeAllocation = None
+      discs = actAs admin <> disclose govDisc <> disclose emRegDisc <> disclose rrRegDisc <> disclose csDisc
+
+  res <- trySubmit discs do register 256
+  expectAbort "consistency level must be a uint8" res
+  res <- trySubmit discs do register (-1)
+  expectAbort "consistency level must be a uint8" res
+
+  -- Boundary 255 accepted.
+  (_, _, _, _, msg) <- submit discs do register 255
+  msg.consistencyLevel === 255
 
 ----------------------------------------------------------------------
 -- The locked ledger
@@ -726,9 +1072,9 @@ testRegistrationRejectsForeignRegistries = do
 -- can move the balance (the controller set is all three).
 testLockedLedgerCap : Script ()
 testLockedLedgerCap = do
-  (operator, gg, _) <- nttSetup
+  (operator, gg, csId) <- nttSetup
   alice <- allocateParty "LedgerAlice"
-  d <- deploy operator gg alice LockUnlock
+  d <- deploy operator gg alice LockUnlock csId
   let trio = actAs operator <> actAs alice <> actAs gg
   lcid <- submit trio do
     exerciseCmd (fromSome d.ledgerCid) Credit with amount = 5.0, newCustodyHint = None
@@ -757,13 +1103,21 @@ sendScaffold
   : Party -> Party -> Party -> NttTokenConfig -> ContractId CoreState
   -> Script (Deployment, [Disclosure])
 sendScaffold operator gg admin config csId = do
-  d <- deploy operator gg admin config
-  mgrCid <- submit admin do
+  d <- deploy operator gg admin config csId
+  csDisc <- fromSome <$> queryDisclosure operator csId
+  peerEmitterDisc <- fromSome <$> queryDisclosure operator d.emitterCid
+  (mgrCid, _) <- submit (actAs admin <> disclose csDisc <> disclose peerEmitterDisc) do
     exerciseCmd d.mgrCid SetPeer with
       chainId = 2
       peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc", decimals = 8
-  csDisc <- fromSome <$> queryDisclosure operator csId
-  emitterDisc <- fromSome <$> queryDisclosure operator d.emitterCid
+      transceiverEmitterCid = d.emitterCid
+      coreStateCid = csId
+      consistencyLevel = 0
+      payer = admin
+      feeAllocation = None
+  Some mgr <- queryContractId operator mgrCid
+  emitterCid <- resolveEmitter gg mgr.transceiverEmitterId
+  emitterDisc <- fromSome <$> queryDisclosure operator emitterCid
   factoryDisc <- case config of
     BurnMint -> discloseBurnMintFactory gg
     LockUnlock -> discloseTransferFactory gg
@@ -772,7 +1126,7 @@ sendScaffold operator gg admin config csId = do
       ld <- fromSome <$> queryDisclosure operator lcid
       pure [ld]
     None -> pure []
-  pure ((d with mgrCid), csDisc :: emitterDisc :: factoryDisc :: ledgerDiscs)
+  pure ((d with mgrCid, emitterCid), csDisc :: emitterDisc :: factoryDisc :: ledgerDiscs)
 
 -- | Submit as @p@ with a list of disclosures attached.
 submitWithDiscs : Party -> [Disclosure] -> Commands a -> Script a
@@ -816,7 +1170,7 @@ testTransferLockAccounting = do
   [(ledgerCid, ledger)] <- query @LockedLedger operator
   ledger.balance === 0.01
   [(_, em)] <- query @Emitter gg
-  em.sequence === 1
+  em.sequence === 3   -- deploy's TransceiverInit (0), SetPeer's registration (1), this Transfer (2)
   custody <- cip56HoldingsOwnedBy gg alice
   potCid <- case custody of
     [(cid, h)] -> do
@@ -870,11 +1224,25 @@ testTransferTrimsToPeerDecimals = do
   (operator, gg, csId) <- nttSetup
   alice <- allocateParty "DustAlice"
   (d, discs) <- sendScaffold operator gg alice LockUnlock csId
-  mgrCid <- submit alice do
+  (mgrCid, _) <- submitWithDiscs alice discs do
     exerciseCmd d.mgrCid SetPeer with
       chainId = 5
       peer = Peer with managerAddress = b32 "b5", transceiverAddress = b32 "c5", decimals = 3
-  let d' = d with mgrCid
+      transceiverEmitterCid = d.emitterCid
+      coreStateCid = csId
+      consistencyLevel = 0
+      payer = alice
+      feeAllocation = None
+  Some mgr <- queryContractId operator mgrCid
+  emitterCid <- resolveEmitter gg mgr.transceiverEmitterId   -- this SetPeer's own broadcast churned it
+  csDisc <- fromSome <$> queryDisclosure operator csId
+  emitterDisc <- fromSome <$> queryDisclosure operator emitterCid
+  factoryDisc <- discloseTransferFactory gg
+  ledgerDisc <- fromSome <$> queryDisclosure operator (fromSome d.ledgerCid)
+  let d' = d with mgrCid, emitterCid
+      -- Rebuilt from scratch: 'discs' (from 'sendScaffold') still carries the
+      -- pre-churn emitter disclosure, which Canton rejects outright as stale.
+      discs' = [csDisc, emitterDisc, factoryDisc, ledgerDisc]
       sendTo chainId rawAmount holding =
         exerciseCmd d'.mgrCid Transfer with
           user = alice
@@ -893,13 +1261,13 @@ testTransferTrimsToPeerDecimals = do
 
   -- 0.00158434 at 8 decimals cannot be represented at 3 decimals: rejected.
   dustHolding <- mkHolding gg alice d.instrumentId 0.00158434
-  res <- trySubmitWithDiscs alice discs do sendTo 5 158434 dustHolding
+  res <- trySubmitWithDiscs alice discs' do sendTo 5 158434 dustHolding
   expectAbort "dust the peer cannot represent" res
 
   -- 0.001 is representable at 3 decimals: locked, and the ledger is credited
   -- by exactly that amount.
   roundHolding <- mkHolding gg alice d.instrumentId 0.001
-  _ <- submitWithDiscs alice discs do sendTo 5 100000 roundHolding
+  _ <- submitWithDiscs alice discs' do sendTo 5 100000 roundHolding
   [(_, ledger)] <- query @LockedLedger operator
   ledger.balance === 0.001
 
@@ -930,7 +1298,7 @@ testPauseHaltsRelease = do
   (operator, gg, csId) <- nttSetup
   admin <- allocateParty "PauseRelAdmin"
   recipient <- allocateParty "PauseRelRecipient"
-  (mgrCid, _, ledgerCid) <- setupFixedManager operator gg admin LockUnlock
+  (mgrCid, _, ledgerCid) <- setupFixedManager operator gg admin LockUnlock csId
   Some mgr <- queryContractId operator mgrCid
   pausedMgr <- submit admin do exerciseCmd mgrCid SetPaused with newPaused = True
   (nodeCid, _) <- coveringDisclosure operator gg mgr.namespace nttTransferDigest
@@ -1100,9 +1468,9 @@ testSetFactory = do
 -- not just at registration.
 testSetFactoryGgMintedRequiresGg : Script ()
 testSetFactoryGgMintedRequiresGg = do
-  (operator, gg, _) <- nttSetup
+  (operator, gg, csId) <- nttSetup
   admin <- allocateParty "SFGgAdmin"
-  d <- deploy operator gg admin BurnMint
+  d <- deploy operator gg admin BurnMint csId
   freshFc <- submit gg do createCmd MockBurnMintFactory with admin = gg, instrument = d.instrumentId
   let freshFactory = BurnMintFactoryCid (toInterfaceContractId @BurnMintFactory freshFc)
   -- Admin alone cannot rotate a gg-minted factory.
@@ -1211,7 +1579,7 @@ testReplaySurvivesAdminTransfer = do
   (operator, gg, csId) <- nttSetup
   alice <- allocateParty "ReplaySurviveAlice"
   newAdmin <- allocateParty "ReplaySurviveNewAdmin"
-  d <- deploy operator gg alice LockUnlock
+  d <- deploy operator gg alice LockUnlock csId
   Some mgrBefore <- queryContractId operator d.mgrCid
   let feeDigest = (parseVAA govSetFeeVAA).hash
   (rootBefore, _) <- coveringDisclosure operator gg mgrBefore.namespace feeDigest
@@ -1285,7 +1653,7 @@ testOutboundTransferAfterAdminTransfer = do
   ledgerDisc  <- fromSome <$> queryDisclosure operator ledgerCid
   msg <- submitWithDiscs bob [csDisc, emitterDisc, factoryDisc, mgrDisc, ledgerDisc] do
     sendTransfer bob d' csId [holdingCid]
-  msg.sequence === 0
+  msg.sequence === 2   -- deploy's TransceiverInit (0) and SetPeer's registration (1) precede this Transfer
 
   [(_, ledger)] <- query @LockedLedger operator
   ledger.balance === 0.01
@@ -1296,10 +1664,10 @@ testOutboundTransferAfterAdminTransfer = do
 -- not see the successor.
 testLedgerObserverFollowsAdmin : Script ()
 testLedgerObserverFollowsAdmin = do
-  (operator, gg, _) <- nttSetup
+  (operator, gg, csId) <- nttSetup
   alice <- allocateParty "ObsAlice"
   newAdmin <- allocateParty "ObsNewAdmin"
-  d <- deploy operator gg alice LockUnlock
+  d <- deploy operator gg alice LockUnlock csId
   Some ledger <- queryContractId alice (fromSome d.ledgerCid)
   ledger.admin === alice
   (_, Some ledgerCid') <- submit (actAs alice <> actAs newAdmin) do
@@ -1415,7 +1783,7 @@ testTransferAdminAuthority = do
 
   -- Burn/mint: no reserve, no ledger; the role still transfers.
   bob <- allocateParty "XferAuthBob"
-  dB <- deploy operator gg bob BurnMint
+  dB <- deploy operator gg bob BurnMint csId
   (_, None) <- submit (actAs bob <> actAs gg) do
     exerciseCmd dB.mgrCid TransferAdmin with
       newAdmin = gg
@@ -1445,10 +1813,21 @@ testGgAdminnedOps = do
     exerciseCmd mgrCid SetPeer with
       chainId = 3
       peer = Peer with managerAddress = b32 "b1", transceiverAddress = b32 "c1", decimals = 8
+      transceiverEmitterCid = d.emitterCid
+      coreStateCid = csId
+      consistencyLevel = 0
+      payer = alice
+      feeAllocation = None
+  -- gg is a signatory of both the Emitter and CoreState, so no disclosure is needed here.
   _ <- submit gg do
     exerciseCmd mgrCid SetPeer with
       chainId = 3
       peer = Peer with managerAddress = b32 "b1", transceiverAddress = b32 "c1", decimals = 8
+      transceiverEmitterCid = d.emitterCid
+      coreStateCid = csId
+      consistencyLevel = 0
+      payer = gg
+      feeAllocation = None
   pure ()
 
 -- | The propose-accept handoff: the current admin leaves a standing
@@ -1598,9 +1977,9 @@ testDepositPreapprovalCreatesStanding = do
 -- the pre-approval contract itself.
 testDepositMintSucceeds : Script ()
 testDepositMintSucceeds = do
-  (operator, gg, _) <- nttSetup
+  (operator, gg, csId) <- nttSetup
   alice <- allocateParty "MintAlice"
-  d <- deploy operator gg alice BurnMint
+  d <- deploy operator gg alice BurnMint csId
   preCid <- submit alice do
     createCmd DepositPreapproval with owner = alice, instrumentId = d.instrumentId
 
@@ -1619,9 +1998,9 @@ testDepositMintSucceeds = do
 -- stale cid then fails.
 testRevokedPreapprovalFails : Script ()
 testRevokedPreapprovalFails = do
-  (operator, gg, _) <- nttSetup
+  (operator, gg, csId) <- nttSetup
   alice <- allocateParty "RevokeAlice"
-  d <- deploy operator gg alice BurnMint
+  d <- deploy operator gg alice BurnMint csId
   preCid <- submit alice do
     createCmd DepositPreapproval with owner = alice, instrumentId = d.instrumentId
   submit alice do exerciseCmd preCid Revoke
@@ -1646,14 +2025,22 @@ testNttSend : Script ()
 testNttSend = do
   (operator, gg, csId, mockAdmin, inst, feeRecipient) <- nttSetupFee
   alice <- allocateParty "SendAlice"
-  d <- deploy operator gg alice LockUnlock
+  d <- deploy operator gg alice LockUnlock csId
   holdingCid <- mkHolding gg alice d.instrumentId 0.01
-  _ <- submit alice do
+  csDisc0 <- fromSome <$> queryDisclosure operator csId
+  emitterDisc0 <- fromSome <$> queryDisclosure operator d.emitterCid
+  (mgrCid, _) <- submit (actAs alice <> disclose csDisc0 <> disclose emitterDisc0) do
     exerciseCmd d.mgrCid SetPeer with
       chainId = 2
       peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc", decimals = 8
-  [(mgrCid, _)] <- query @NttManager operator
-  let d' = d with mgrCid
+      transceiverEmitterCid = d.emitterCid
+      coreStateCid = csId
+      consistencyLevel = 0
+      payer = alice
+      feeAllocation = None
+  Some mgr <- queryContractId operator mgrCid
+  emitterCid <- resolveEmitter gg mgr.transceiverEmitterId   -- SetPeer's own broadcast churned it
+  let d' = d with mgrCid, emitterCid
 
   -- Governance raises the message fee to 1000 (1e-7 tokens).
   csId <- submit operator do
@@ -1661,7 +2048,7 @@ testNttSend = do
       encodedVAA = govSetFeeVAA
       pubKeys = [(0, devnetGuardianPubKey)]
   csDisc <- fromSome <$> queryDisclosure operator csId
-  emitterDisc <- fromSome <$> queryDisclosure operator d.emitterCid
+  emitterDisc <- fromSome <$> queryDisclosure operator d'.emitterCid
   factoryDisc <- discloseTransferFactory gg
   ledgerDisc <- fromSome <$> queryDisclosure operator (fromSome d.ledgerCid)
   let discs = [csDisc, emitterDisc, factoryDisc, ledgerDisc]
@@ -1688,10 +2075,10 @@ testNttSend = do
   -- Exact fee from alice's wallet: succeeds, fee lands on the fee recipient.
   feePay <- mintAndAllocate mockAdmin alice feeRecipient inst (feeToDecimal 1000)
   msg <- submitWithDiscs alice discs do doTransfer (Some feePay)
-  msg.sequence === 0
+  msg.sequence === 2   -- deploy's TransceiverInit (0) and SetPeer's registration (1) precede this Transfer
 
   [(_, em)] <- query @Emitter gg
-  em.sequence === 1
+  em.sequence === 3
   [(_, ledger)] <- query @LockedLedger operator
   ledger.balance === 0.01
   custody <- cip56HoldingsOwnedBy gg alice
@@ -1721,12 +2108,21 @@ testNttTransferByDifferentUser = do
   (operator, gg, csId, mockAdmin, inst, feeRecipient) <- nttSetupFee
   admin <- allocateParty "TransferAdmin"
   bob <- allocateParty "TransferBob"
-  d <- deploy operator gg admin LockUnlock
+  d <- deploy operator gg admin LockUnlock csId
   holdingCid <- mkHolding gg bob d.instrumentId 0.01
-  mgrCid <- submit admin do
+  csDisc0 <- fromSome <$> queryDisclosure operator csId
+  emitterDisc0 <- fromSome <$> queryDisclosure operator d.emitterCid
+  (mgrCid, _) <- submit (actAs admin <> disclose csDisc0 <> disclose emitterDisc0) do
     exerciseCmd d.mgrCid SetPeer with
       chainId = 2
       peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc", decimals = 8
+      transceiverEmitterCid = d.emitterCid
+      coreStateCid = csId
+      consistencyLevel = 0
+      payer = admin
+      feeAllocation = None
+  Some mgrPostSetPeer <- queryContractId operator mgrCid
+  emitterCid <- resolveEmitter gg mgrPostSetPeer.transceiverEmitterId   -- SetPeer's own broadcast churned it
   -- TransferAdmin recreates the ledger (its admin observer moves to gg);
   -- track the successor cid, the old one is archived.
   (mgrCid, ledgerCid') <- submit (actAs admin <> actAs gg) do
@@ -1735,7 +2131,7 @@ testNttTransferByDifferentUser = do
       ledgerCid = Some (fromSome d.ledgerCid)
       vettedFactory = d.factory
       extraArgs = emptyExtraArgs
-  let d' = d with mgrCid, ledgerCid = ledgerCid'
+  let d' = d with mgrCid, ledgerCid = ledgerCid', emitterCid
 
   csId <- submit operator do
     exerciseCmd csId SubmitGovernanceVAA with
@@ -1744,7 +2140,7 @@ testNttTransferByDifferentUser = do
 
   feePay <- mintAndAllocate mockAdmin bob feeRecipient inst (feeToDecimal 1000)
   dMgr     <- fromSome <$> queryDisclosure operator mgrCid
-  dEmitter <- fromSome <$> queryDisclosure operator d.emitterCid
+  dEmitter <- fromSome <$> queryDisclosure operator d'.emitterCid
   dFactory <- discloseTransferFactory gg
   dCs      <- fromSome <$> queryDisclosure operator csId
   dLedger  <- fromSome <$> queryDisclosure operator (fromSome d'.ledgerCid)
@@ -1765,7 +2161,7 @@ testNttTransferByDifferentUser = do
       extraArgs = emptyExtraArgs
 
   [(_, em)] <- query @Emitter gg
-  em.sequence === 1
+  em.sequence === 3   -- deploy's TransceiverInit (0), SetPeer's registration (1), this Transfer (2)
   custody <- cip56HoldingsOwnedBy gg gg
   case custody of
     [(_, h)] -> h.amount === 0.01
@@ -1780,11 +2176,18 @@ testNttTransferRequiresUserAuthority = do
   (operator, gg, csId) <- nttSetup
   admin <- allocateParty "ReqAdmin"
   bob <- allocateParty "ReqBob"
-  d <- deploy operator gg admin LockUnlock
-  mgrCid <- submit admin do
+  d <- deploy operator gg admin LockUnlock csId
+  csDisc <- fromSome <$> queryDisclosure operator csId
+  emitterDisc <- fromSome <$> queryDisclosure operator d.emitterCid
+  (mgrCid, _) <- submit (actAs admin <> disclose csDisc <> disclose emitterDisc) do
     exerciseCmd d.mgrCid SetPeer with
       chainId = 2
       peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc", decimals = 8
+      transceiverEmitterCid = d.emitterCid
+      coreStateCid = csId
+      consistencyLevel = 0
+      payer = admin
+      feeAllocation = None
   let doTransfer = exerciseCmd mgrCid Transfer with
         user = bob
         transceiverEmitterCid = d.emitterCid
@@ -1824,17 +2227,17 @@ nttTransferDigest = (parseVAA nttTransferVAA).hash
 -- cannot reproduce, so the manager (and, for lock/unlock, its ledger) is
 -- created directly with all three signatures rather than registered.
 setupFixedManager
-  : Party -> Party -> Party -> NttTokenConfig
+  : Party -> Party -> Party -> NttTokenConfig -> ContractId CoreState
   -> Script (ContractId NttManager, NttFactory, Optional (ContractId LockedLedger))
-setupFixedManager operator gg admin config =
-  setupFixedManagerOn operator gg admin config cantonChainId
+setupFixedManager operator gg admin config csId =
+  setupFixedManagerOn operator gg admin config cantonChainId csId
 
 -- | 'setupFixedManager' with an explicit local chain id, for the inbound
 -- destination-chain check.
 setupFixedManagerOn
-  : Party -> Party -> Party -> NttTokenConfig -> Int
+  : Party -> Party -> Party -> NttTokenConfig -> Int -> ContractId CoreState
   -> Script (ContractId NttManager, NttFactory, Optional (ContractId LockedLedger))
-setupFixedManagerOn operator gg admin config chainId = do
+setupFixedManagerOn operator gg admin config chainId csId = do
   let instrumentId = bridgedInstrument gg
       namespace = nttNamespaceFor instrumentId admin 999
   factory <- case config of
@@ -1844,6 +2247,18 @@ setupFixedManagerOn operator gg admin config chainId = do
     LockUnlock -> do
       fc <- submit gg do createCmd MockTransferFactory with admin = gg, pending = False, skim = 0.0
       pure (TransferFactoryCid (toInterfaceContractId @TransferFactory fc))
+  -- A fixed-address deployment bypasses 'RegisterManager', so it needs its own
+  -- directly-created transceiver Emitter for SetPeer's broadcast leg.
+  observer <- allocateParty "FixedMgrEmitterObserver"
+  emitterCid <- submit (actAs operator <> actAs gg) do
+    createCmd Emitter with
+      operator
+      guardianGovernance = gg
+      owner = gg
+      guardianObserver = observer
+      emitterId = 999
+      emitterAddress = b32 "cc"
+      sequence = 0
   mgrCid <- submit (actAs operator <> actAs admin <> actAs gg) do
     createCmd NttManager with
       operator
@@ -1857,15 +2272,24 @@ setupFixedManagerOn operator gg admin config chainId = do
       instrumentId
       tokenConfig = config
       tokenDecimals = 8
+      tokenAddress = nttTokenAddressFor instrumentId
       peers = Map.empty
       factory
       paused = False
       factoryEpoch = 0
+      peerEpoch = 0
       minter = None
-  mgrCid <- submit admin do
+  csDisc <- fromSome <$> queryDisclosure operator csId
+  emitterDisc <- fromSome <$> queryDisclosure operator emitterCid
+  (mgrCid, _) <- submit (actAs admin <> disclose csDisc <> disclose emitterDisc) do
     exerciseCmd mgrCid SetPeer with
       chainId = 2
       peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc", decimals = 8
+      transceiverEmitterCid = emitterCid
+      coreStateCid = csId
+      consistencyLevel = 0
+      payer = admin
+      feeAllocation = None
   ledgerCid <- case config of
     LockUnlock -> Some <$> submit (actAs operator <> actAs admin <> actAs gg) do
       createCmd LockedLedger with
@@ -1890,7 +2314,7 @@ testReceiveByExecutorRecipientMismatchFails = do
   admin <- allocateParty "RecvAdmin"
   relayer <- allocateParty "Relayer"
   wrongRecipient <- allocateParty "WrongRecipient"
-  (mgrCid, _, ledgerCid) <- setupFixedManager operator gg admin LockUnlock
+  (mgrCid, _, ledgerCid) <- setupFixedManager operator gg admin LockUnlock csId
   Some mgr <- queryContractId operator mgrCid
   (nodeCid, nodeDisc) <- coveringDisclosure operator gg mgr.namespace nttTransferDigest
   dMgr <- fromSome <$> queryDisclosure operator mgrCid
@@ -1922,7 +2346,7 @@ testReceiveWrongChainRejected = do
   relayer <- allocateParty "WrongChainRelayer"
   recipient <- allocateParty "WrongChainRecipient"
   -- Same fixed deployment, but its own chain id is 99, not the fixture's 72.
-  (mgrCid, _, ledgerCid) <- setupFixedManagerOn operator gg admin LockUnlock 99
+  (mgrCid, _, ledgerCid) <- setupFixedManagerOn operator gg admin LockUnlock 99 csId
   Some mgr <- queryContractId operator mgrCid
   (nodeCid, nodeDisc) <- coveringDisclosure operator gg mgr.namespace nttTransferDigest
   dMgr <- fromSome <$> queryDisclosure operator mgrCid
@@ -1959,7 +2383,7 @@ testReleaseReplayPathAfterAdminTransfer = do
   newAdmin <- allocateParty "ReleaseReplayNewAdmin"
   relayer <- allocateParty "ReleaseReplayRelayer"
   wrongRecipient <- allocateParty "ReleaseReplayWrongRecipient"
-  (mgrCid, factory, ledgerCid) <- setupFixedManager operator gg admin LockUnlock
+  (mgrCid, factory, ledgerCid) <- setupFixedManager operator gg admin LockUnlock csId
   Some mgrBefore <- queryContractId operator mgrCid
   (rootBefore, _) <- coveringDisclosure operator gg mgrBefore.namespace nttTransferDigest
 
@@ -1999,7 +2423,7 @@ testReleaseReplayPathAfterAdminTransfer = do
 -- under a throwaway gg party; it fails the pin before any verification runs.
 testReceivePinsGuardianGovernance : Script ()
 testReceivePinsGuardianGovernance = do
-  (operator, gg, _) <- nttSetup
+  (operator, gg, csId) <- nttSetup
   admin <- allocateParty "PinAdmin"
   recipient <- allocateParty "PinRecipient"
   rogueGov <- allocateParty "RogueGovernance"
@@ -2008,7 +2432,7 @@ testReceivePinsGuardianGovernance = do
   fakeCsId <- submit (actAs operator <> actAs rogueGov) do
     createCmd (mkInitialCoreState operator rogueGov solanaGovernanceChainId defaultGovernanceContract
                  ["1111111111111111111111111111111111111111"] rogueObserver rogueInst rogueGov)
-  (mgrCid, _, ledgerCid) <- setupFixedManager operator gg admin LockUnlock
+  (mgrCid, _, ledgerCid) <- setupFixedManager operator gg admin LockUnlock csId
   Some mgr <- queryContractId operator mgrCid
   (nodeCid, _) <- coveringDisclosure operator gg mgr.namespace nttTransferDigest
 
@@ -2034,7 +2458,7 @@ testReleaseRejectsForeignLedger = do
   admin <- allocateParty "ForeignAdmin"
   other <- allocateParty "ForeignOther"
   recipient <- allocateParty "ForeignRecipient"
-  (mgrCid, _, _) <- setupFixedManager operator gg admin LockUnlock
+  (mgrCid, _, _) <- setupFixedManager operator gg admin LockUnlock csId
   Some mgr <- queryContractId operator mgrCid
   (nodeCid, _) <- coveringDisclosure operator gg mgr.namespace nttTransferDigest
   -- A second deployment's ledger, owned by the same parties except the address.
@@ -2088,7 +2512,7 @@ integrationNttReceiveMatchSetup = do
   (operator, gg, csId) <- nttSetup
   admin <- allocateParty "MatchAdmin"
   recipient <- allocateParty "MatchRecipient"
-  (mgrId, factory, _) <- setupFixedManager operator gg admin BurnMint
+  (mgrId, factory, _) <- setupFixedManager operator gg admin BurnMint csId
   -- The recipient opts in once (a single self-signed create), then can stay
   -- offline.
   depositPreapprovalCid <- submit recipient do
@@ -2178,8 +2602,16 @@ acceptAdminHappyVAA = "010000000001009391f78297b7bd3fd25a52651e2b18216b625228226
 acceptAdminWrongModuleVAA : Bytes
 acceptAdminWrongModuleVAA = "010000000001006502d6d60ebb2c2452a430ac4510f0a5d13ad25a27a30fc54e062f9c9c88efaf3ef37c4db3b82a602cdbbfc95e663b4de642a28e5181c37434497287a3bede56006553f100000000000001000000000000000000000000000000000000000000000000000000000000000400000000000000020000000000000000000000000000000000000000000000000000000000436f726501004800000000000000000000000000000000000000000000000000000000000000aa0000000000000000"
 
+-- | Action byte 9 -- unassigned on BOTH lineages that define NTT governance
+-- actions: this branch uses 1 (AcceptAdminToGovernance) and 4
+-- (SetPeerByGovernance); the sibling ntt-token-factory/ntt-governance-vaa
+-- lineage (PR #48/#51) uses 1, 2 (RegisterBurnMintManager), and 3
+-- (RotateToCanonicalFactory). Action 2 was used here previously, but the
+-- sibling lineage assigns it, which would make this fixture start parsing
+-- successfully (and this test silently stop testing the unsupported-action
+-- path) the moment the two lineages merge.
 acceptAdminWrongActionVAA : Bytes
-acceptAdminWrongActionVAA = "01000000000100fff2b32d5777d24ee1a95a7eca6d8ec8600da55b70b1b2f825e300a41e369a9d0c8ba1e548c9da19cae990d5216fa058f2e80710e6e251d623f522d5145d92b6016553f100000000000001000000000000000000000000000000000000000000000000000000000000000400000000000000030000000000000000000000000000000000000000000000000000000000004e747402004800000000000000000000000000000000000000000000000000000000000000aa0000000000000000"
+acceptAdminWrongActionVAA = "010000000001004069f5c53af32a7e95f4e40ea9cddf48174b94cb8b3a2bfe58f3d9731544e05d62cfa08777f794fc2a2dd3338af225a9025be44c6da0cfa62cab7e361b90b539016553f100000000000001000000000000000000000000000000000000000000000000000000000000000400000000000000030000000000000000000000000000000000000000000000000000000000004e747409004800000000000000000000000000000000000000000000000000000000000000aa0000000000000000"
 
 acceptAdminWrongChainVAA : Bytes
 acceptAdminWrongChainVAA = "010000000001000c33a3788f18cfab0c4c88b141cee4d606138df7042cb13aeedc124e444462f4616adb4a026e5accd0569d276696d457ea754f996b571a006a712c48f2d8a989016553f100000000000001000000000000000000000000000000000000000000000000000000000000000400000000000000040000000000000000000000000000000000000000000000000000000000004e747401000200000000000000000000000000000000000000000000000000000000000000aa0000000000000000"
@@ -2222,9 +2654,9 @@ data AcceptAdminFixture = AcceptAdminFixture with
     namespace : Text
   deriving (Eq, Show)
 
-acceptAdminFixture : Party -> Party -> Party -> NttTokenConfig -> Script AcceptAdminFixture
-acceptAdminFixture operator gg admin config = do
-  (mgrCid, factory, ledgerCid) <- setupFixedManager operator gg admin config
+acceptAdminFixture : Party -> Party -> Party -> NttTokenConfig -> ContractId CoreState -> Script AcceptAdminFixture
+acceptAdminFixture operator gg admin config csId = do
+  (mgrCid, factory, ledgerCid) <- setupFixedManager operator gg admin config csId
   Some mgr <- queryContractId operator mgrCid
   propCid <- submit admin do
     createCmd AdminTransferProposal with
@@ -2274,7 +2706,7 @@ testAcceptAdminByVaaHappyPath = do
   (operator, gg, csId) <- nttSetup
   admin <- allocateParty "AcceptHappyAdmin"
   relayer <- allocateParty "AcceptHappyRelayer"
-  fx <- acceptAdminFixture operator gg admin BurnMint
+  fx <- acceptAdminFixture operator gg admin BurnMint csId
   (nodeCid, discs) <- acceptAdminDiscs operator gg admin csId fx (parseVAA acceptAdminHappyVAA).hash
 
   (mgrCid', ledgerCid') <- submitWithDiscs relayer discs do
@@ -2294,7 +2726,7 @@ testAcceptAdminByVaaLockUnlock = do
   (operator, gg, csId) <- nttSetup
   admin <- allocateParty "AcceptLockAdmin"
   relayer <- allocateParty "AcceptLockRelayer"
-  fx <- acceptAdminFixture operator gg admin LockUnlock
+  fx <- acceptAdminFixture operator gg admin LockUnlock csId
   let lcid = fromSome fx.ledgerCid
   (nodeCid, discs) <- acceptAdminDiscs operator gg admin csId fx (parseVAA acceptAdminHappyVAA).hash
 
@@ -2319,7 +2751,7 @@ testAcceptAdminByVaaWorksWhilePaused = do
   (operator, gg, csId) <- nttSetup
   admin <- allocateParty "AcceptPausedAdmin"
   relayer <- allocateParty "AcceptPausedRelayer"
-  fx <- acceptAdminFixture operator gg admin BurnMint
+  fx <- acceptAdminFixture operator gg admin BurnMint csId
   pausedMgrCid <- submit admin do exerciseCmd fx.mgrCid SetPaused with newPaused = True
   let fxP = fx with mgrCid = pausedMgrCid
   (nodeCid, discs) <- acceptAdminDiscs operator gg admin csId fxP (parseVAA acceptAdminHappyVAA).hash
@@ -2333,15 +2765,16 @@ testAcceptAdminByVaaWorksWhilePaused = do
 
 -- | Wrong governance payload — module, action, chain, managerAddress — each
 -- rejected at 'parseNttGovernance' or the post-parse field checks, never
--- reaching the proposal. 'acceptAdminWrongActionVAA' happens to parse as a
--- well-formed 'RegisterBurnMintManager', so it exercises the exhaustive
--- constructor dispatch, not merely a parse failure.
+-- reaching the proposal. 'acceptAdminWrongActionVAA' carries action id 9,
+-- genuinely unassigned (1-4 are all real), so it fails at the parser itself;
+-- 'testAcceptAdminByVaaRejectsRegisterAndRotateActions' covers the
+-- exhaustive constructor dispatch against real actions 2/3.
 testAcceptAdminByVaaRejectsWrongPayload : Script ()
 testAcceptAdminByVaaRejectsWrongPayload = do
   (operator, gg, csId) <- nttSetup
   admin <- allocateParty "AcceptWrongPayloadAdmin"
   relayer <- allocateParty "AcceptWrongPayloadRelayer"
-  fx <- acceptAdminFixture operator gg admin BurnMint
+  fx <- acceptAdminFixture operator gg admin BurnMint csId
   let tryVaa vaaBytes = do
         (nodeCid, discs) <- acceptAdminDiscs operator gg admin csId fx (parseVAA vaaBytes).hash
         trySubmitWithDiscs relayer discs do
@@ -2350,11 +2783,29 @@ testAcceptAdminByVaaRejectsWrongPayload = do
   res <- tryVaa acceptAdminWrongModuleVAA
   expectAbort "not the Ntt module" res
   res <- tryVaa acceptAdminWrongActionVAA
-  expectAbort "not an accept-admin action" res
+  expectAbort "unsupported action" res
   res <- tryVaa acceptAdminWrongChainVAA
   expectAbort "wrong target chain" res
   res <- tryVaa acceptAdminWrongManagerVAA
   expectAbort "wrong manager address" res
+
+-- | Cross-action dispatch: a genuinely well-formed,
+-- guardian-signed action-4 ('SetPeerByGovernance') VAA fed to
+-- 'AcceptAdminTransferByVaa' hits the dedicated wrong-action abort, not the
+-- generic proposal or parse-failure paths — exactly the confusion the
+-- sum-type refactor exists to prevent. Uses 'setPeerHappyVAA' (defined in the
+-- SetPeerByVaa section below; Daml top-level order doesn't matter), which
+-- targets the same fixed address/chain 'acceptAdminFixture' builds.
+testAcceptAdminByVaaRejectsSetPeerAction : Script ()
+testAcceptAdminByVaaRejectsSetPeerAction = do
+  (operator, gg, csId) <- nttSetup
+  admin <- allocateParty "AcceptWrongActionKindAdmin"
+  relayer <- allocateParty "AcceptWrongActionKindRelayer"
+  fx <- acceptAdminFixture operator gg admin BurnMint csId
+  (nodeCid, discs) <- acceptAdminDiscs operator gg admin csId fx (parseVAA setPeerHappyVAA).hash
+  res <- trySubmitWithDiscs relayer discs do
+    acceptAdminByVaaCmd relayer fx csId nodeCid setPeerHappyVAA
+  expectAbort "wrong action for AcceptAdminTransferByVaa" res
 
 -- | Wrong emitter chain / address — the governance-hardening checks mirroring
 -- 'Wormhole.Core.State.SubmitGovernanceVAA'.
@@ -2363,7 +2814,7 @@ testAcceptAdminByVaaRejectsWrongEmitter = do
   (operator, gg, csId) <- nttSetup
   admin <- allocateParty "AcceptWrongEmitterAdmin"
   relayer <- allocateParty "AcceptWrongEmitterRelayer"
-  fx <- acceptAdminFixture operator gg admin BurnMint
+  fx <- acceptAdminFixture operator gg admin BurnMint csId
 
   (nodeCid1, discs1) <- acceptAdminDiscs operator gg admin csId fx (parseVAA acceptAdminWrongEmitterChainVAA).hash
   res <- trySubmitWithDiscs relayer discs1 do
@@ -2384,7 +2835,7 @@ testAcceptAdminByVaaRequiresCurrentGuardianSet = do
   Some cs <- queryContractId operator csId
   admin <- allocateParty "AcceptStaleSetAdmin"
   relayer <- allocateParty "AcceptStaleSetRelayer"
-  fx <- acceptAdminFixture operator gg admin BurnMint
+  fx <- acceptAdminFixture operator gg admin BurnMint csId
 
   staleCsId <- submit (actAs operator <> actAs gg) do
     createCmd cs with
@@ -2408,7 +2859,7 @@ testAcceptAdminByVaaEpochBindsFactory = do
   (operator, gg, csId) <- nttSetup
   admin <- allocateParty "AcceptEpochAdmin"
   relayer <- allocateParty "AcceptEpochRelayer"
-  fx <- acceptAdminFixture operator gg admin BurnMint
+  fx <- acceptAdminFixture operator gg admin BurnMint csId
 
   freshFc <- submit gg do
     createCmd MockBurnMintFactory with admin = gg, instrument = bridgedInstrument gg
@@ -2433,7 +2884,7 @@ testAcceptAdminByVaaReplayRejected = do
   (operator, gg, csId) <- nttSetup
   admin <- allocateParty "AcceptReplayAdmin"
   relayer <- allocateParty "AcceptReplayRelayer"
-  fx <- acceptAdminFixture operator gg admin BurnMint
+  fx <- acceptAdminFixture operator gg admin BurnMint csId
 
   (nodeCid, discs) <- acceptAdminDiscs operator gg admin csId fx (parseVAA acceptAdminHappyVAA).hash
   (mgrCid', _) <- submitWithDiscs relayer discs do
@@ -2469,7 +2920,7 @@ testAcceptAdminByVaaProposalChecks = do
   admin <- allocateParty "AcceptProposalChecksAdmin"
   outsider <- allocateParty "AcceptProposalChecksOutsider"
   relayer <- allocateParty "AcceptProposalChecksRelayer"
-  (mgrCid, factory, ledgerCid) <- setupFixedManager operator gg admin BurnMint
+  (mgrCid, factory, ledgerCid) <- setupFixedManager operator gg admin BurnMint csId
   Some mgr <- queryContractId operator mgrCid
 
   wrongNewAdminProp <- submit admin do
@@ -2515,7 +2966,7 @@ testAcceptAdminByVaaProposalChecks = do
 -- any VAA verification runs.
 testAcceptAdminByVaaPinsGuardianGovernance : Script ()
 testAcceptAdminByVaaPinsGuardianGovernance = do
-  (operator, gg, _) <- nttSetup
+  (operator, gg, csId) <- nttSetup
   admin <- allocateParty "AcceptPinAdmin"
   rogueGov <- allocateParty "AcceptPinRogueGovernance"
   rogueObserver <- allocateParty "AcceptPinRogueObserver"
@@ -2523,13 +2974,314 @@ testAcceptAdminByVaaPinsGuardianGovernance = do
   fakeCsId <- submit (actAs operator <> actAs rogueGov) do
     createCmd (mkInitialCoreState operator rogueGov solanaGovernanceChainId defaultGovernanceContract
                  ["1111111111111111111111111111111111111111"] rogueObserver rogueInst rogueGov)
-  fx <- acceptAdminFixture operator gg admin BurnMint
+  fx <- acceptAdminFixture operator gg admin BurnMint csId
   (nodeCid, _) <- coveringDisclosure operator gg fx.namespace (parseVAA acceptAdminHappyVAA).hash
   dProp <- fromSome <$> queryDisclosure admin fx.propCid
 
   res <- trySubmit (actAs operator <> disclose dProp) do
     acceptAdminByVaaCmd operator fx fakeCsId nodeCid acceptAdminHappyVAA
   expectAbort "committed guardian trust anchor" res
+
+----------------------------------------------------------------------
+-- SetPeerByVaa (NTT governance action 4)
+--
+-- Mirrors the accept-admin-by-VAA section above step for step: a gg-adminned
+-- 'setupFixedManagerOn' deployment (admin = gg directly), a guardian-signed
+-- action-4 VAA against its fixed address (0x00..aa, chain 72), targeting peer
+-- chain 3 (0x00..dd / 0x00..ee / 9 decimals) — distinct from the fixture's
+-- built-in chain-2 peer, so the happy path proves a real map edit. Fixtures
+-- signed by the same devnet guardian key as the accept-admin fixtures above;
+-- see that section's header for the signer/provenance note. All fixtures
+-- carry peerEpoch = 1: 'setupFixedManagerOn's own chain-2 'SetPeer' call
+-- already bumps the fresh manager's peerEpoch from 0 to 1 before any test runs.
+----------------------------------------------------------------------
+
+setPeerHappyVAA : Bytes
+setPeerHappyVAA = "010000000001000468e8da4d2da344abc56d5cec2cad48d27c9c6602f3c96cc924d7e44ee2c3454e4fabb1584be81e4e09b1f911c804f0660822780b76d313404dd830584ecc00016553f100000000000001000000000000000000000000000000000000000000000000000000000000000400000000000000650000000000000000000000000000000000000000000000000000000000004e747404004800000000000000000000000000000000000000000000000000000000000000aa0000000000000001000300000000000000000000000000000000000000000000000000000000000000dd00000000000000000000000000000000000000000000000000000000000000ee09"
+
+setPeerWrongChainVAA : Bytes
+setPeerWrongChainVAA = "01000000000100643c55d198fa60e0b3f8c5d6593922f4414082e8ea019db3bef0f7862c76a8e2218aa6aaef69aafb42eeb126afe323c0caefd00aa7c3d5b7ac2636890f60e5a3016553f100000000000001000000000000000000000000000000000000000000000000000000000000000400000000000000680000000000000000000000000000000000000000000000000000000000004e747404000200000000000000000000000000000000000000000000000000000000000000aa0000000000000001000300000000000000000000000000000000000000000000000000000000000000dd00000000000000000000000000000000000000000000000000000000000000ee09"
+
+setPeerWrongManagerVAA : Bytes
+setPeerWrongManagerVAA = "01000000000100d60aee71588e3a6a10bec70875e1f22f6e46ad2c7d0797182dfbeb4f6485303162f34e8f7561e9498afb39d37b6bc8aa8b6dbd64fbb558d59a11cd4f4c7beace016553f100000000000001000000000000000000000000000000000000000000000000000000000000000400000000000000690000000000000000000000000000000000000000000000000000000000004e747404004800000000000000000000000000000000000000000000000000000000000000ab0000000000000001000300000000000000000000000000000000000000000000000000000000000000dd00000000000000000000000000000000000000000000000000000000000000ee09"
+
+setPeerWrongEmitterChainVAA : Bytes
+setPeerWrongEmitterChainVAA = "0100000000010086fe05fc99eb9cedb0c82c49db91e171981c471eb4177ad316c046d10476453011c135c21ec89ae2e0b218ac93ef23e29519cb40715755170d38e901cf911c40016553f1000000000000020000000000000000000000000000000000000000000000000000000000000004000000000000006b0000000000000000000000000000000000000000000000000000000000004e747404004800000000000000000000000000000000000000000000000000000000000000aa0000000000000001000300000000000000000000000000000000000000000000000000000000000000dd00000000000000000000000000000000000000000000000000000000000000ee09"
+
+setPeerWrongEmitterAddressVAA : Bytes
+setPeerWrongEmitterAddressVAA = "01000000000100a93323e15d5a1a053dd927a2d99b5593b01974a2f00e8533d6c959c6a8ae93573a2ab5b9c05273c46ad28cc3d7b101e2d9c4c7aba8156d972d576d6508610705016553f1000000000000010000000000000000000000000000000000000000000000000000000000000005000000000000006c0000000000000000000000000000000000000000000000000000000000004e747404004800000000000000000000000000000000000000000000000000000000000000aa0000000000000001000300000000000000000000000000000000000000000000000000000000000000dd00000000000000000000000000000000000000000000000000000000000000ee09"
+
+-- | The gg-adminned fixed manager every 'SetPeerByVaa' test builds on. Admin
+-- is gg directly (no TransferAdmin ceremony needed to reach the state
+-- 'SetPeerByVaa' requires).
+data SetPeerByVaaFixture = SetPeerByVaaFixture with
+    mgrCid     : ContractId NttManager
+    emitterCid : ContractId Emitter
+    namespace  : Text
+  deriving (Eq, Show)
+
+setPeerByVaaFixture : Party -> Party -> ContractId CoreState -> Script SetPeerByVaaFixture
+setPeerByVaaFixture operator gg csId = do
+  (mgrCid, _, _) <- setupFixedManagerOn operator gg gg BurnMint cantonChainId csId
+  Some mgr <- queryContractId operator mgrCid
+  emitterCid <- resolveEmitter gg mgr.transceiverEmitterId
+  pure SetPeerByVaaFixture with mgrCid, emitterCid, namespace = mgr.namespace
+
+-- | Disclosures a stakeholder-less @executor@ needs to relay 'SetPeerByVaa':
+-- the manager, the core state, the transceiver (for the nested 'SetPeer'),
+-- and the covering replay node for @digest@.
+setPeerByVaaDiscs
+  : Party -> Party -> ContractId CoreState -> SetPeerByVaaFixture -> Text
+  -> Script (ContractId ReplayNode, [Disclosure])
+setPeerByVaaDiscs operator gg csId fx digest = do
+  dMgr <- fromSome <$> queryDisclosure operator fx.mgrCid
+  dCs <- fromSome <$> queryDisclosure operator csId
+  dEmitter <- fromSome <$> queryDisclosure operator fx.emitterCid
+  (nodeCid, dNode) <- coveringDisclosure operator gg fx.namespace digest
+  pure (nodeCid, [dMgr, dCs, dEmitter, dNode])
+
+-- | The 'SetPeerByVaa' exercise command against a 'SetPeerByVaaFixture'.
+setPeerByVaaCmd
+  : Party -> SetPeerByVaaFixture -> ContractId CoreState -> ContractId ReplayNode -> Bytes
+  -> Commands (ContractId NttManager, WormholeMessage)
+setPeerByVaaCmd executor fx csId nodeCid vaaBytes =
+  exerciseCmd fx.mgrCid SetPeerByVaa with
+    executor
+    coreStateCid = csId
+    replayNodeCid = nodeCid
+    vaaBytes
+    pubKeys = [(0, devnetGuardianPubKey)]
+    transceiverEmitterCid = fx.emitterCid
+    consistencyLevel = 0
+    feeAllocation = None
+
+-- | Happy path: the peer lands in the map and the returned message is the
+-- encoded registration for that peer.
+testSetPeerByVaaBroadcasts : Script ()
+testSetPeerByVaaBroadcasts = do
+  (operator, gg, csId) <- nttSetup
+  relayer <- allocateParty "SetPeerByVaaRelayer"
+  fx <- setPeerByVaaFixture operator gg csId
+  (nodeCid, discs) <- setPeerByVaaDiscs operator gg csId fx (parseVAA setPeerHappyVAA).hash
+
+  (mgrCid', msg) <- submitWithDiscs relayer discs do
+    setPeerByVaaCmd relayer fx csId nodeCid setPeerHappyVAA
+
+  Some mgr <- queryContractId operator mgrCid'
+  Map.lookup 3 mgr.peers
+    === Some (Peer with managerAddress = b32 "dd", transceiverAddress = b32 "ee", decimals = 9)
+  msg.payload === encodeTransceiverRegistration TransceiverRegistration with
+    peerChain = 3
+    peerAddress = b32 "ee"
+
+-- | Wrong emitter chain — the governance-hardening check mirroring
+-- 'Wormhole.Core.State.SubmitGovernanceVAA'.
+testSetPeerByVaaRejectsWrongEmitterChain : Script ()
+testSetPeerByVaaRejectsWrongEmitterChain = do
+  (operator, gg, csId) <- nttSetup
+  relayer <- allocateParty "SetPeerByVaaWrongEmitterChainRelayer"
+  fx <- setPeerByVaaFixture operator gg csId
+  (nodeCid, discs) <- setPeerByVaaDiscs operator gg csId fx (parseVAA setPeerWrongEmitterChainVAA).hash
+  res <- trySubmitWithDiscs relayer discs do
+    setPeerByVaaCmd relayer fx csId nodeCid setPeerWrongEmitterChainVAA
+  expectAbort "wrong emitter chain" res
+
+-- | Wrong emitter address — same hardening, the other half.
+testSetPeerByVaaRejectsWrongEmitterAddress : Script ()
+testSetPeerByVaaRejectsWrongEmitterAddress = do
+  (operator, gg, csId) <- nttSetup
+  relayer <- allocateParty "SetPeerByVaaWrongEmitterAddressRelayer"
+  fx <- setPeerByVaaFixture operator gg csId
+  (nodeCid, discs) <- setPeerByVaaDiscs operator gg csId fx (parseVAA setPeerWrongEmitterAddressVAA).hash
+  res <- trySubmitWithDiscs relayer discs do
+    setPeerByVaaCmd relayer fx csId nodeCid setPeerWrongEmitterAddressVAA
+  expectAbort "wrong emitter address" res
+
+-- | A VAA signed under a superseded-but-unexpired guardian set fails the
+-- current-set-only hardening, mirroring 'testAcceptAdminByVaaRequiresCurrentGuardianSet':
+-- a 'CoreState' at @guardianSetIndex = 1@ with the devnet guardian key present
+-- under both indices 0 and 1 accepts the fixture VAA's signature in
+-- 'VerifyAndConsumeVAA' but 'SetPeerByVaa' still rejects it.
+testSetPeerByVaaRequiresCurrentGuardianSet : Script ()
+testSetPeerByVaaRequiresCurrentGuardianSet = do
+  (operator, gg, csId) <- nttSetup
+  Some cs <- queryContractId operator csId
+  relayer <- allocateParty "SetPeerByVaaStaleSetRelayer"
+  fx <- setPeerByVaaFixture operator gg csId
+  staleCsId <- submit (actAs operator <> actAs gg) do
+    createCmd cs with
+      guardianSetIndex = 1
+      guardianSets = Map.fromList
+        [ (0, GuardianSet with keys = [devnetGuardian], expirationTime = None)
+        , (1, GuardianSet with keys = [devnetGuardian], expirationTime = None)
+        ]
+  (nodeCid, discs) <- setPeerByVaaDiscs operator gg staleCsId fx (parseVAA setPeerHappyVAA).hash
+  res <- trySubmitWithDiscs relayer discs do
+    setPeerByVaaCmd relayer fx staleCsId nodeCid setPeerHappyVAA
+  expectAbort "not signed by current guardian set" res
+
+-- | Wrong target chain in the packet — rejected before the nested 'SetPeer'.
+testSetPeerByVaaRejectsWrongChain : Script ()
+testSetPeerByVaaRejectsWrongChain = do
+  (operator, gg, csId) <- nttSetup
+  relayer <- allocateParty "SetPeerByVaaWrongChainRelayer"
+  fx <- setPeerByVaaFixture operator gg csId
+  (nodeCid, discs) <- setPeerByVaaDiscs operator gg csId fx (parseVAA setPeerWrongChainVAA).hash
+  res <- trySubmitWithDiscs relayer discs do
+    setPeerByVaaCmd relayer fx csId nodeCid setPeerWrongChainVAA
+  expectAbort "wrong target chain" res
+
+-- | Wrong manager address in the packet — a VAA vetted for a different
+-- deployment can never be relayed here.
+testSetPeerByVaaRejectsWrongManagerAddress : Script ()
+testSetPeerByVaaRejectsWrongManagerAddress = do
+  (operator, gg, csId) <- nttSetup
+  relayer <- allocateParty "SetPeerByVaaWrongManagerRelayer"
+  fx <- setPeerByVaaFixture operator gg csId
+  (nodeCid, discs) <- setPeerByVaaDiscs operator gg csId fx (parseVAA setPeerWrongManagerVAA).hash
+  res <- trySubmitWithDiscs relayer discs do
+    setPeerByVaaCmd relayer fx csId nodeCid setPeerWrongManagerVAA
+  expectAbort "wrong manager address" res
+
+-- | Cross-action dispatch, the other direction: a genuinely
+-- well-formed, guardian-signed action-1 ('AcceptAdminToGovernance') VAA fed
+-- to 'SetPeerByVaa' hits the dedicated wrong-action abort. A reversed pair
+-- here would let an admin-acceptance VAA drive a peer edit.
+testSetPeerByVaaRejectsAcceptAdminAction : Script ()
+testSetPeerByVaaRejectsAcceptAdminAction = do
+  (operator, gg, csId) <- nttSetup
+  relayer <- allocateParty "SetPeerByVaaWrongActionKindRelayer"
+  fx <- setPeerByVaaFixture operator gg csId
+  (nodeCid, discs) <- setPeerByVaaDiscs operator gg csId fx (parseVAA acceptAdminHappyVAA).hash
+  res <- trySubmitWithDiscs relayer discs do
+    setPeerByVaaCmd relayer fx csId nodeCid acceptAdminHappyVAA
+  expectAbort "wrong action for SetPeerByVaa" res
+
+-- | Cross-action dispatch against the two newer actions: a genuinely well-formed action-2
+-- ('RegisterBurnMintManager') or action-3 ('RotateToCanonicalFactory') VAA
+-- fed to 'SetPeerByVaa' hits the dedicated wrong-action abort too, not just
+-- action 1.
+testSetPeerByVaaRejectsRegisterAndRotateActions : Script ()
+testSetPeerByVaaRejectsRegisterAndRotateActions = do
+  (operator, gg, csId) <- nttSetup
+  relayer <- allocateParty "SetPeerByVaaWrongActionKind2Relayer"
+  fx <- setPeerByVaaFixture operator gg csId
+
+  (nodeCid1, discs1) <- setPeerByVaaDiscs operator gg csId fx (parseVAA registerHappyVAA).hash
+  res1 <- trySubmitWithDiscs relayer discs1 do
+    setPeerByVaaCmd relayer fx csId nodeCid1 registerHappyVAA
+  expectAbort "wrong action for SetPeerByVaa" res1
+
+  (nodeCid2, discs2) <- setPeerByVaaDiscs operator gg csId fx (parseVAA rotateHappyVAA).hash
+  res2 <- trySubmitWithDiscs relayer discs2 do
+    setPeerByVaaCmd relayer fx csId nodeCid2 rotateHappyVAA
+  expectAbort "wrong action for SetPeerByVaa" res2
+
+-- | Replay: the same VAA relayed twice is rejected on digest membership
+-- alone, mirroring 'testAcceptAdminByVaaReplayRejected'.
+testSetPeerByVaaReplayRejected : Script ()
+testSetPeerByVaaReplayRejected = do
+  (operator, gg, csId) <- nttSetup
+  relayer <- allocateParty "SetPeerByVaaReplayRelayer"
+  fx <- setPeerByVaaFixture operator gg csId
+  (nodeCid, discs) <- setPeerByVaaDiscs operator gg csId fx (parseVAA setPeerHappyVAA).hash
+  (mgrCid', _) <- submitWithDiscs relayer discs do
+    setPeerByVaaCmd relayer fx csId nodeCid setPeerHappyVAA
+
+  Some mgr' <- queryContractId operator mgrCid'
+  emitterCid' <- resolveEmitter gg mgr'.transceiverEmitterId
+  let fx2 = fx with mgrCid = mgrCid', emitterCid = emitterCid'
+  (nodeCid2, discs2) <- setPeerByVaaDiscs operator gg csId fx2 (parseVAA setPeerHappyVAA).hash
+  res <- trySubmitWithDiscs relayer discs2 do
+    setPeerByVaaCmd relayer fx2 csId nodeCid2 setPeerHappyVAA
+  expectAbort "digest already consumed" res
+
+-- | A manager still admin-owned (not gg) rejects even a perfectly valid VAA:
+-- the quorum only governs deployments it has taken custody of. Without this
+-- guard the nested 'SetPeer' would succeed regardless of who holds admin,
+-- since a nonconsuming choice body carries all of the manager's signatures —
+-- see 'SetPeerByVaa's doc comment.
+testSetPeerByVaaRequiresGovernanceAdmin : Script ()
+testSetPeerByVaaRequiresGovernanceAdmin = do
+  (operator, gg, csId) <- nttSetup
+  admin <- allocateParty "SetPeerByVaaNonGgAdmin"
+  relayer <- allocateParty "SetPeerByVaaNonGgRelayer"
+  (mgrCid, _, _) <- setupFixedManagerOn operator gg admin BurnMint cantonChainId csId
+  Some mgr <- queryContractId operator mgrCid
+  emitterCid <- resolveEmitter gg mgr.transceiverEmitterId
+  let fx = SetPeerByVaaFixture with mgrCid, emitterCid, namespace = mgr.namespace
+  (nodeCid, discs) <- setPeerByVaaDiscs operator gg csId fx (parseVAA setPeerHappyVAA).hash
+  res <- trySubmitWithDiscs relayer discs do
+    setPeerByVaaCmd relayer fx csId nodeCid setPeerHappyVAA
+  expectAbort "manager is not governance-adminned" res
+
+-- | The freshness pin (supersession scenario): after the quorum signs
+-- 'setPeerHappyVAA' at 'setPeerByVaaFixture's post-setup peerEpoch (1), gg
+-- lands a DIFFERENT peer edit (chain 5) BEFORE the VAA is relayed, bumping
+-- peerEpoch to 2. The epoch-1 VAA is now stale and is rejected, even though
+-- every other field (module, action, chain, managerAddress) still matches —
+-- mirroring 'testAcceptAdminByVaaEpochBindsFactory' for action 4.
+testSetPeerByVaaRejectsStaleEpoch : Script ()
+testSetPeerByVaaRejectsStaleEpoch = do
+  (operator, gg, csId) <- nttSetup
+  relayer <- allocateParty "SetPeerByVaaStaleEpochRelayer"
+  fx <- setPeerByVaaFixture operator gg csId
+  -- gg is a signatory of both the Emitter and CoreState, so no disclosure is needed here.
+  (mgrCid', _) <- submit gg do
+    exerciseCmd fx.mgrCid SetPeer with
+      chainId = 5
+      peer = Peer with managerAddress = b32 "11", transceiverAddress = b32 "22", decimals = 7
+      transceiverEmitterCid = fx.emitterCid
+      coreStateCid = csId
+      consistencyLevel = 0
+      payer = gg
+      feeAllocation = None
+  Some mgr' <- queryContractId operator mgrCid'
+  emitterCid' <- resolveEmitter gg mgr'.transceiverEmitterId   -- SetPeer's own broadcast churned it
+  let fx' = fx with mgrCid = mgrCid', emitterCid = emitterCid'
+
+  (nodeCid, discs) <- setPeerByVaaDiscs operator gg csId fx' (parseVAA setPeerHappyVAA).hash
+  res <- trySubmitWithDiscs relayer discs do
+    setPeerByVaaCmd relayer fx' csId nodeCid setPeerHappyVAA
+  expectAbort "wrong peer epoch" res
+
+-- | 'SetPeerByVaa' at nonzero @messageFee@: the executor self-funds the fee allocation (@payer =
+-- executor@) with no gg signature involved, proving a relayer can still
+-- submit the governance path without any guardian-quorum fee ceremony.
+testSetPeerByVaaFeeExecutorSelfFunds : Script ()
+testSetPeerByVaaFeeExecutorSelfFunds = do
+  (operator, gg, csId, mockAdmin, inst, feeRecipient) <- nttSetupFee
+  relayer <- allocateParty "SetPeerByVaaFeeRelayer"
+  fx <- setPeerByVaaFixture operator gg csId
+
+  -- Governance raises the message fee to 1000 (1e-7 tokens) AFTER the
+  -- fixture's own (fee-0) chain-2 SetPeer, mirroring 'testNttSend'.
+  csId <- submit operator do
+    exerciseCmd csId SubmitGovernanceVAA with
+      encodedVAA = govSetFeeVAA
+      pubKeys = [(0, devnetGuardianPubKey)]
+  (nodeCid, discs) <- setPeerByVaaDiscs operator gg csId fx (parseVAA setPeerHappyVAA).hash
+  feePay <- mintAndAllocate mockAdmin relayer feeRecipient inst (feeToDecimal 1000)
+
+  (mgrCid', msg) <- submitWithDiscs relayer discs do
+    exerciseCmd fx.mgrCid SetPeerByVaa with
+      executor = relayer
+      coreStateCid = csId
+      replayNodeCid = nodeCid
+      vaaBytes = setPeerHappyVAA
+      pubKeys = [(0, devnetGuardianPubKey)]
+      transceiverEmitterCid = fx.emitterCid
+      consistencyLevel = 0
+      feeAllocation = Some feePay
+
+  Some mgr <- queryContractId operator mgrCid'
+  Map.lookup 3 mgr.peers
+    === Some (Peer with managerAddress = b32 "dd", transceiverAddress = b32 "ee", decimals = 9)
+  msg.payload === encodeTransceiverRegistration TransceiverRegistration with
+    peerChain = 3
+    peerAddress = b32 "ee"
+  bal <- mockBalance mockAdmin feeRecipient inst
+  bal === feeToDecimal 1000
 
 ----------------------------------------------------------------------
 -- Accept-admin-by-VAA, live two-step harness (dynamic managerAddress)
@@ -2558,7 +3310,7 @@ integrationAcceptAdminSetup : Script AcceptAdminSetup
 integrationAcceptAdminSetup = do
   (operator, gg, csId) <- nttSetup
   admin <- allocateParty "IntegrationAcceptAdminAdmin"
-  d <- deploy operator gg admin BurnMint
+  d <- deploy operator gg admin BurnMint csId
   Some mgr <- queryContractId operator d.mgrCid
   propCid <- submit admin do
     createCmd AdminTransferProposal with
@@ -2710,7 +3462,7 @@ testAcceptAdminByVaaRejectsRegisterAndRotateActions = do
   (operator, gg, csId) <- nttSetup
   admin <- allocateParty "AcceptCrossActionAdmin"
   relayer <- allocateParty "AcceptCrossActionRelayer"
-  fx <- acceptAdminFixture operator gg admin BurnMint
+  fx <- acceptAdminFixture operator gg admin BurnMint csId
 
   (nodeCid1, discs1) <- acceptAdminDiscs operator gg admin csId fx (parseVAA registerHappyVAA).hash
   res <- trySubmitWithDiscs relayer discs1 do
@@ -2746,7 +3498,7 @@ registerByVaaFixture operator gg csId = do
 
 registerManagerByVaaCmd
   : Party -> RegisterByVaaFixture -> ContractId CoreState -> Int -> NttFactory -> Bytes
-  -> Commands (ContractId NttGovernance, ContractId NttManager, ContractId Emitter, Optional (ContractId LockedLedger))
+  -> Commands (ContractId NttGovernance, ContractId NttManager, ContractId Emitter, Optional (ContractId LockedLedger), WormholeMessage)
 registerManagerByVaaCmd admin fx csId nonce factory vaaBytes =
   exerciseCmd fx.govCid RegisterManagerByVaa with
     admin
@@ -2755,8 +3507,10 @@ registerManagerByVaaCmd admin fx csId nonce factory vaaBytes =
     instrumentNonce = nonce
     factory
     coreStateCid = csId
+    consistencyLevel = 0
     emitterFeeAllocation = None
     claimFeeAllocation = None
+    feeAllocation = None
     vaaBytes
     pubKeys = [(0, devnetGuardianPubKey)]
     extraArgs = emptyExtraArgs
@@ -2841,8 +3595,10 @@ testRegisterManagerByVaaReplayRejected = do
       instrumentNonce = 0
       factory = dummyFactory
       coreStateCid = csId
+      consistencyLevel = 0
       emitterFeeAllocation = None
       claimFeeAllocation = None
+      feeAllocation = None
       vaaBytes = registerHappyVAA
       pubKeys = [(0, devnetGuardianPubKey)]
       extraArgs = emptyExtraArgs
@@ -2905,7 +3661,7 @@ testSetFactoryByVaaHappyPath : Script ()
 testSetFactoryByVaaHappyPath = do
   (operator, gg, csId) <- nttSetup
   admin <- allocateParty "RotateHappyAdmin"
-  (mgrCid, _, _) <- setupFixedManager operator gg admin BurnMint
+  (mgrCid, _, _) <- setupFixedManager operator gg admin BurnMint csId
   Some mgr <- queryContractId operator mgrCid
   realFactoryCid <- nttCoinFactorySetup gg
   let newFactory = BurnMintFactoryCid (toInterfaceContractId @BurnMintFactory realFactoryCid)
@@ -2931,7 +3687,7 @@ testSetFactoryByVaaWrongEpoch : Script ()
 testSetFactoryByVaaWrongEpoch = do
   (operator, gg, csId) <- nttSetup
   admin <- allocateParty "RotateWrongEpochAdmin"
-  (mgrCid, _, _) <- setupFixedManager operator gg admin BurnMint
+  (mgrCid, _, _) <- setupFixedManager operator gg admin BurnMint csId
   Some mgr <- queryContractId operator mgrCid
   realFactoryCid <- nttCoinFactorySetup gg
   let newFactory = BurnMintFactoryCid (toInterfaceContractId @BurnMintFactory realFactoryCid)
@@ -2948,7 +3704,7 @@ testSetFactoryByVaaRejectsNonCanonicalFactory : Script ()
 testSetFactoryByVaaRejectsNonCanonicalFactory = do
   (operator, gg, csId) <- nttSetup
   admin <- allocateParty "RotateNonCanonicalAdmin"
-  (mgrCid, _, _) <- setupFixedManager operator gg admin BurnMint
+  (mgrCid, _, _) <- setupFixedManager operator gg admin BurnMint csId
   Some mgr <- queryContractId operator mgrCid
   mockFc <- submit gg do createCmd MockBurnMintFactory with admin = gg, instrument = bridgedInstrument gg
   let newFactory = BurnMintFactoryCid (toInterfaceContractId @BurnMintFactory mockFc)
@@ -2967,7 +3723,7 @@ testSetFactoryByVaaRejectsLockUnlock : Script ()
 testSetFactoryByVaaRejectsLockUnlock = do
   (operator, gg, csId) <- nttSetup
   admin <- allocateParty "RotateLockUnlockAdmin"
-  (mgrCid, _, _) <- setupFixedManager operator gg admin LockUnlock
+  (mgrCid, _, _) <- setupFixedManager operator gg admin LockUnlock csId
   csDisc <- fromSome <$> queryDisclosure operator csId
   realFactoryCid <- nttCoinFactorySetup gg
   let newFactory = BurnMintFactoryCid (toInterfaceContractId @BurnMintFactory realFactoryCid)
@@ -3001,10 +3757,12 @@ testSetFactoryByVaaRejectsExternalMinter = do
       instrumentId
       tokenConfig = BurnMint
       tokenDecimals = 8
+      tokenAddress = nttTokenAddressFor instrumentId
       peers = Map.empty
       factory
       paused = False
       factoryEpoch = 0
+      peerEpoch = 0
       minter = Some external
   _ <- registerReplayRoot operator gg namespace defaultSplitThreshold
   csDisc <- fromSome <$> queryDisclosure operator csId
@@ -3014,13 +3772,13 @@ testSetFactoryByVaaRejectsExternalMinter = do
     rotateByVaaCmd mgrCid newFactory csId (coerceContractId mgrCid) rotateHappyVAA
   expectAbort "only for gg-minted burn/mint deployments" res
 
--- | An action-1 (accept-admin) VAA aborts on the exhaustive constructor
--- dispatch.
+-- | An action-1 (accept-admin) or action-4 (set-peer) VAA aborts on the
+-- exhaustive constructor dispatch.
 testSetFactoryByVaaRejectsWrongConstructor : Script ()
 testSetFactoryByVaaRejectsWrongConstructor = do
   (operator, gg, csId) <- nttSetup
   admin <- allocateParty "RotateWrongCtorAdmin"
-  (mgrCid, _, _) <- setupFixedManager operator gg admin BurnMint
+  (mgrCid, _, _) <- setupFixedManager operator gg admin BurnMint csId
   Some mgr <- queryContractId operator mgrCid
   realFactoryCid <- nttCoinFactorySetup gg
   let newFactory = BurnMintFactoryCid (toInterfaceContractId @BurnMintFactory realFactoryCid)
@@ -3029,6 +3787,11 @@ testSetFactoryByVaaRejectsWrongConstructor = do
   res <- trySubmitWithDiscs admin [csDisc, dNode] do
     rotateByVaaCmd mgrCid newFactory csId nodeCid acceptAdminHappyVAA
   expectAbort "not a rotate-to-canonical-factory action" res
+
+  (nodeCid2, dNode2) <- coveringDisclosure operator gg mgr.namespace (parseVAA setPeerHappyVAA).hash
+  res2 <- trySubmitWithDiscs admin [csDisc, dNode2] do
+    rotateByVaaCmd mgrCid newFactory csId nodeCid2 setPeerHappyVAA
+  expectAbort "not a rotate-to-canonical-factory action" res2
 
 ----------------------------------------------------------------------
 -- RegisterManagerByVaa / SetFactoryByVaa, live three-step harness
@@ -3089,7 +3852,7 @@ integrationRegisterByVaa : RegisterByVaaInput -> Script RegisterByVaaResult
 integrationRegisterByVaa input = do
   let factory = BurnMintFactoryCid (toInterfaceContractId @BurnMintFactory input.factoryCid)
       actors = actAs input.operator <> actAs input.admin <> actAs input.gg
-  (govCid', mgrCid, _emitterCid, ledgerCid) <- submit actors do
+  (govCid', mgrCid, _emitterCid, ledgerCid, _msg) <- submit actors do
     exerciseCmd input.govCid RegisterManagerByVaa with
       admin = input.admin
       emitterRegistryCid = input.emReg
@@ -3097,8 +3860,10 @@ integrationRegisterByVaa input = do
       instrumentNonce = input.nonce
       factory
       coreStateCid = input.coreStateCid
+      consistencyLevel = 0
       emitterFeeAllocation = None
       claimFeeAllocation = None
+      feeAllocation = None
       vaaBytes = input.vaaBytes
       pubKeys = [(0, devnetGuardianPubKey)]
       extraArgs = emptyExtraArgs
@@ -3124,8 +3889,10 @@ integrationRegisterByVaa input = do
       instrumentNonce = input.nonce
       factory
       coreStateCid = input.coreStateCid
+      consistencyLevel = 0
       emitterFeeAllocation = None
       claimFeeAllocation = None
+      feeAllocation = None
       vaaBytes = input.vaaBytes
       pubKeys = [(0, devnetGuardianPubKey)]
       extraArgs = emptyExtraArgs

--- a/canton/test/daml/Test/TestNttCoin.daml
+++ b/canton/test/daml/Test/TestNttCoin.daml
@@ -20,7 +20,7 @@ import Token.CIP0056.CoinFactory
 import Wormhole.Core.Fees (emptyExtraArgs)
 import Wormhole.Ntt.Deposit (DepositPreapproval(..), Deposit(..))
 import Wormhole.Ntt.Manager
-import Test.TestNtt (nttSetup, nttCoinFactorySetup, b32)
+import Test.TestNtt (nttSetup, nttCoinFactorySetup, b32, resolveEmitter)
 import Test.TestFactoryAuthority (registerBurnMint)
 
 -- | The interface-typed handle tests exercise choices on.
@@ -51,16 +51,16 @@ mintCoin factoryCid gg instrumentId owner amount = do
 -- proving genuine sharing, not per-deployment duplication.
 testNttCoinFactoryServesTwoDistinctAdmins : Script ()
 testNttCoinFactoryServesTwoDistinctAdmins = do
-  (operator, gg, _) <- nttSetup
+  (operator, gg, csId) <- nttSetup
   factoryCid <- nttCoinFactorySetup gg
   alice <- allocateParty "CoinSharedAlice"
   bob <- allocateParty "CoinSharedBob"
   let instA = InstrumentId with admin = gg, id = nttInstrumentIdFor alice 0
       instB = InstrumentId with admin = gg, id = nttInstrumentIdFor bob 0
 
-  (discsA, registerA) <- registerBurnMint operator alice instA (asBurnMintFactory factoryCid)
+  (discsA, registerA) <- registerBurnMint operator alice instA (asBurnMintFactory factoryCid) csId
   (mgrA, _) <- submit (actAs alice <> actAs gg <> mconcat (map disclose discsA)) registerA
-  (discsB, registerB) <- registerBurnMint operator bob instB (asBurnMintFactory factoryCid)
+  (discsB, registerB) <- registerBurnMint operator bob instB (asBurnMintFactory factoryCid) csId
   (mgrB, _) <- submit (actAs bob <> actAs gg <> mconcat (map disclose discsB)) registerB
 
   Some ma <- queryContractId operator mgrA
@@ -83,12 +83,23 @@ testNttCoinEndToEndRoundTrip = do
   alice <- allocateParty "CoinRoundTripAlice"
   let instrumentId = InstrumentId with admin = gg, id = nttInstrumentIdFor alice 0
 
-  (discsReg, register) <- registerBurnMint operator alice instrumentId (asBurnMintFactory factoryCid)
-  (mgrCid, emitterCid) <- submit (actAs alice <> actAs gg <> mconcat (map disclose discsReg)) register
-  mgrCid' <- submit alice do
+  (discsReg, register) <- registerBurnMint operator alice instrumentId (asBurnMintFactory factoryCid) csId
+  (mgrCid, _emitterCid) <- submit (actAs alice <> actAs gg <> mconcat (map disclose discsReg)) register
+  Some mgr <- queryContractId operator mgrCid
+  emitterCid <- resolveEmitter gg mgr.transceiverEmitterId   -- RegisterManager's own init broadcast churned it
+  csDisc0 <- fromSome <$> queryDisclosure operator csId
+  emitterDisc0 <- fromSome <$> queryDisclosure operator emitterCid
+  (mgrCid', _) <- submit (actAs alice <> disclose csDisc0 <> disclose emitterDisc0) do
     exerciseCmd mgrCid SetPeer with
       chainId = 2
       peer = Peer with managerAddress = b32 "bb", transceiverAddress = b32 "cc", decimals = 8
+      transceiverEmitterCid = emitterCid
+      coreStateCid = csId
+      consistencyLevel = 0
+      payer = alice
+      feeAllocation = None
+  Some mgr' <- queryContractId operator mgrCid'
+  emitterCid <- resolveEmitter gg mgr'.transceiverEmitterId   -- SetPeer's own broadcast churned it
 
   coinCid <- mintCoin factoryCid gg instrumentId alice 0.01
 

--- a/canton/test/daml/Test/TestNttVectors.daml
+++ b/canton/test/daml/Test/TestNttVectors.daml
@@ -13,6 +13,8 @@ module Test.TestNttVectors where
 import Daml.Script
 import DA.Assert ((===))
 
+import Splice.Api.Token.HoldingV1 (InstrumentId (..))
+
 import Wormhole.Core.Bytes
 import Wormhole.Ntt.Amount
 import Wormhole.Ntt.Payload
@@ -233,3 +235,104 @@ testAmountUint64Bound = do
   let maxInt = 9223372036854775807
   (trimAmount maxInt 0).amount === maxInt
   pure ()
+
+----------------------------------------------------------------------
+-- TransceiverRegistration vector (evm/test/payloads/transceiver_registration_1.txt,
+-- 38 bytes: prefix ‖ chainId=0x0017 ‖ address hex"BABABAFEFE").
+--
+-- The address is a Solidity bytes32 literal, so it is right-padded with
+-- zeros (TransceiverStructs.t.sol:48-56), same convention as vecSourceManager
+-- above: pin the full 32-byte right-padded value so 'leftPadTo' is a no-op.
+----------------------------------------------------------------------
+
+vecPeerAddress : Bytes32
+vecPeerAddress = "bababafefe000000000000000000000000000000000000000000000000000000"
+
+vecTransceiverRegistration : TransceiverRegistration
+vecTransceiverRegistration = TransceiverRegistration with
+    peerChain = 23
+    peerAddress = vecPeerAddress
+
+transceiverRegistration1 : Bytes
+transceiverRegistration1 = "18fc67c20017bababafefe000000000000000000000000000000000000000000000000000000"
+
+-- | Byte-exact encode against the fixture, plus decode round-trip.
+testVectorTransceiverRegistration : Script ()
+testVectorTransceiverRegistration = do
+  encodeTransceiverRegistration vecTransceiverRegistration === transceiverRegistration1
+  byteLength transceiverRegistration1 === 38
+  decodeTransceiverRegistration transceiverRegistration1 === vecTransceiverRegistration
+
+----------------------------------------------------------------------
+-- TransceiverInit vector (evm/test/payloads/transceiver_info_1.txt, 70 bytes:
+-- prefix ‖ manager hex"BABABABABABA" ‖ mode=LOCKING(0) ‖ token
+-- hex"DEDEDEDEDEDEDE" ‖ decimals=16). Same right-padding trap as above.
+----------------------------------------------------------------------
+
+vecTransceiverInitManager : Bytes32
+vecTransceiverInitManager = "babababababa0000000000000000000000000000000000000000000000000000"
+
+vecTransceiverInitToken : Bytes32
+vecTransceiverInitToken = "dedededededede00000000000000000000000000000000000000000000000000"
+
+vecTransceiverInit : TransceiverInit
+vecTransceiverInit = TransceiverInit with
+    nttManagerAddress = vecTransceiverInitManager
+    nttManagerMode = 0
+    tokenAddress = vecTransceiverInitToken
+    tokenDecimals = 16
+
+transceiverInit1 : Bytes
+transceiverInit1 = "9c23bd3bbabababababa000000000000000000000000000000000000000000000000000000dedededededede0000000000000000000000000000000000000000000000000010"
+
+-- | Byte-exact encode against the fixture, plus decode round-trip.
+testVectorTransceiverInit : Script ()
+testVectorTransceiverInit = do
+  encodeTransceiverInit vecTransceiverInit === transceiverInit1
+  byteLength transceiverInit1 === 70
+  decodeTransceiverInit transceiverInit1 === vecTransceiverInit
+
+----------------------------------------------------------------------
+-- NTT governance action 4 (SetPeerByGovernance) vector: module(32) ‖
+-- action(1)=04 ‖ chain(2) ‖ managerAddress(32) ‖ peerEpoch(8) ‖ peerChain(2) ‖
+-- peerManagerAddress(32) ‖ peerTransceiverAddress(32) ‖ peerDecimals(1),
+-- 142 bytes. No reference implementation (Canton-only action); pins the wire
+-- format byte-for-byte so a guardian-signed VAA and this decoder never drift.
+----------------------------------------------------------------------
+
+vecSetPeerAction : NttGovernanceAction
+vecSetPeerAction = SetPeerByGovernance with
+    chain = 72
+    managerAddress = leftPadTo 32 "aa"
+    peerEpoch = 5
+    peerChain = 2
+    peerManagerAddress = leftPadTo 32 "bb"
+    peerTransceiverAddress = leftPadTo 32 "cc"
+    peerDecimals = 8
+
+nttGovernanceSetPeer1 : Bytes
+nttGovernanceSetPeer1 = "00000000000000000000000000000000000000000000000000000000004e747404004800000000000000000000000000000000000000000000000000000000000000aa0000000000000005000200000000000000000000000000000000000000000000000000000000000000bb00000000000000000000000000000000000000000000000000000000000000cc08"
+
+-- | Byte-exact encode against the pinned hex, plus decode round-trip.
+testVectorNttGovernanceSetPeer : Script ()
+testVectorNttGovernanceSetPeer = do
+  encodeNttGovernance vecSetPeerAction === nttGovernanceSetPeer1
+  byteLength nttGovernanceSetPeer1 === 142
+  parseNttGovernance nttGovernanceSetPeer1 === vecSetPeerAction
+
+----------------------------------------------------------------------
+-- Token-address vector: Canton's InstrumentId -> Bytes32 stand-in for
+-- TransceiverInit.tokenAddress. No reference implementation to pin against,
+-- so this freezes Canton's own derivation instead.
+----------------------------------------------------------------------
+
+-- | Pins the token-address formula against fixed text, then confirms
+-- 'nttTokenAddressFor' agrees with the text form on a real 'InstrumentId'.
+testVectorTokenAddress : Script ()
+testVectorTokenAddress = do
+  nttTokenAddressFromText "vector-token-admin::1220deadbeef" "VECTOR-TOKEN"
+    -- frozen: observed value from a single run, no external reference
+    === "0eb25a08a7432d2f56bd449c5ca6e41c9c0b13d1af7e784f46d70572dff91efa"
+  admin <- allocateParty "TokenAddressVectorAdmin"
+  let inst = InstrumentId with admin, id = "VECTOR-TOKEN-2"
+  nttTokenAddressFor inst === nttTokenAddressFromText (partyToText admin) inst.id


### PR DESCRIPTION
Canton had no `TransceiverRegistration` / `TransceiverInit` broadcasts, so the
off-chain NTT Global Accountant could not discover a Canton deployment or its
peers (internal audit F5). Every other platform emits both. This adds them, and
adds a guardian-quorum path for editing peers on a gg-adminned deployment.

**Stacked on #48** — based on `canton/ntt-coin-factory`, which owns governance
actions 1-3 and the `requireCommittedCoreState` / `requireCanonicalFactory`
helpers this builds on. Merge #48 first.

## Design

Broadcasts are **bundled into the setters that authorize their content**, following
EVM/Sui rather than Solana's standalone instructions: `SetPeer` publishes the
`TransceiverRegistration`, `RegisterManager` publishes the `TransceiverInit` once at
registration. There are no standalone broadcast choices, so no caller can make the
guardians attest a configuration the deployment has not committed.

`SetPeerByVaa` is **NTT governance action 4** (142 bytes), mirroring
`AcceptAdminTransferByVaa` step for step: the disclosed `CoreState` pinned via
`requireCommittedCoreState`, the VAA verified and its digest consumed into gg's
per-deployment replay trie, current-guardian-set-only, governance emitter and
target chain/manager checks, plus `admin == guardianGovernance` so the quorum only
governs deployments it has taken custody of.

Canton has no separate transceiver contract — the wormhole-core `Emitter` *is* the
transceiver — so these live on `NttManager`, which is the only contract that can
drive it.

## Adversarial review

Six independent reviewers went over the first draft (authorization, forged-contract
and interface-view spoofing, VAA/replay, wire format, availability, plus a holistic
pass). The authority model came back sound — no escalation path, no cross-party fee
forcing, Daml-level contract forgery structurally blocked, and interface-view
forgery blocked by the core's `signatory` check on fee allocations. Seven defects
were found and are fixed here:

- **`peerEpoch`** — action-4 packets carried no freshness pin, unlike action 1's
  `factoryEpoch`. A withheld, superseded peer VAA could be relayed later to reinstate
  a compromised transceiver and mint against the reserve. `SetPeer` now bumps a
  monotonic `peerEpoch` that the packet must name.
- **Explicit `payer` on `SetPeer`** — the nested publish billed `admin`, which
  `SetPeerByVaa` requires to be gg, so at nonzero `messageFee` every quorum peer edit
  would have needed a gg-signed allocation (a threshold ceremony), defeating the
  relayer model. The executor now self-funds. Note `SetPeer` is `controller admin,
  payer`: Daml recomputes authority per exercise node, so the payer must be declared
  here for the nested `PublishMessage` to be authorized. On the admin path the set
  collapses to `{admin}`.
- **Peer address validation** — `Bytes32` is a bare `Text` and `leftPadTo 32` is the
  identity above 32 bytes, so an oversized address emitted a malformed registration
  that the accountant mis-recorded into a write-once slot. Now length- and
  alphabet-checked (uppercase hex is rejected, not silently normalized).
- **`consistencyLevel` bound** — unvalidated, and out-of-range values are dropped by
  the watcher. For `RegisterManager`'s one-shot init that is unrecoverable: the
  deployment could never register as an accountant hub.
- **Cross-action dispatch coverage** — every governance call site is now
  constructor-exhaustive and tested. Actions 1 and 3 share a byte layout, so a
  non-exhaustive match is a live replay hazard.
- **Fee-bearing tests** — no test exercised `Some feeAllocation` or the fee-required
  abort on any new leg. Both are covered, including the executor-self-funds
  regression test.
- **README corrections** — the previous claim that the accountant is "unaffected
  either way" by peer replacement was wrong: `TRANSCEIVER_PEER` is read on every
  transfer observation, so after a rotation the accountant keeps the first
  registration forever and the corridor's accounting is permanently wrong. Peer
  rotation is documented as a deployment-level event, as it is on EVM. The
  contention section is updated too — config edits now share the `Emitter` with
  transfer traffic, so an urgent peer change should pause first.

## Notable

`RegisterManagerByVaa` gained the `WormholeMessage` in its return tuple, since the
shared registration body now always broadcasts. Flagging it as a signature change to
a choice this PR did not otherwise own — happy to have it discard the message
internally instead.

## Follow-up (not in this PR)

`RegisterManager` still returns a pre-publish `Emitter` cid, which the bundled
broadcast archives. Fixed at the source in wormholelabs-xyz/wormhole#53 (merged):
`PublishMessage` now returns the successor cid. Adopting it needs the 0.4.0 core DAR
re-vendored, which is sequenced after #48 merges so there is one re-vendor, not two.

## Test

`dpm build --all` clean; `dpm test` **260/260 green**, including byte-exact vectors
for both payloads pinned against the EVM cross-language fixtures, the 142-byte
action-4 packet, and the stale-epoch rejection.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wormholelabs-xyz/codesmith/native-token-transfers/pr/54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788043701&installation_model_id=15502&pr_number=54&repository=wormholelabs-xyz%2Fnative-token-transfers&return_to=https%3A%2F%2Fgithub.com%2Fwormholelabs-xyz%2Fnative-token-transfers%2Fpull%2F54&signature=9cdbb9f0ab2e2eaef2f04227302ab22dde5ea5a466cf987ff48e708eb5276ebf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->