### PR TITLE
canton: pin NttCoinAllocation's instrument to its transfer leg so the interface view cannot outrun its signatories

### DIFF
--- a/canton/ntt/daml/Wormhole/Ntt/CoinAllocation.daml
+++ b/canton/ntt/daml/Wormhole/Ntt/CoinAllocation.daml
@@ -3,18 +3,24 @@
 module Wormhole.Ntt.CoinAllocation where
 
 import Splice.Api.Token.AllocationV1
-import Splice.Api.Token.HoldingV1 (Holding, InstrumentId)
+import Splice.Api.Token.HoldingV1 (Holding)
 import Splice.Api.Token.MetadataV1 (emptyMetadata)
 import Wormhole.Ntt.Coin
 
 -- | A single-contract allocation: value and the allocation record folded
 -- together; 'holdingCids' is empty since there's no separate locked holding.
+--
+-- The instrument is read from @allocation.transferLeg@ and nowhere else. It is
+-- deliberately not a separate field: the signatory admin and the instrument
+-- published in 'AllocationView' must be the same instrument, or a party could
+-- self-sign an allocation naming its own admin while advertising someone
+-- else's instrument in the view -- authentic-looking to any consumer that
+-- trusts the view, since a genuine allocation also reports @holdingCids = []@.
 template NttCoinAllocation
   with
-    instrumentId : InstrumentId
-    allocation   : AllocationSpecification
+    allocation : AllocationSpecification
   where
-    signatory instrumentId.admin, allocation.transferLeg.sender
+    signatory allocation.transferLeg.instrumentId.admin, allocation.transferLeg.sender
     observer allocation.transferLeg.receiver, allocation.settlement.executor
 
     interface instance Allocation for NttCoinAllocation where
@@ -24,20 +30,22 @@ template NttCoinAllocation
         now <- getTime
         assertMsg "ntt: settlement window (settleBefore) has passed" (now < allocation.settlement.settleBefore)
         rcid <- toInterfaceContractId @Holding <$>
-          createCoinIn instrumentId (basicAccountV2 allocation.transferLeg.receiver) allocation.transferLeg.amount
+          createCoinIn allocation.transferLeg.instrumentId
+            (basicAccountV2 allocation.transferLeg.receiver) allocation.transferLeg.amount
         pure Allocation_ExecuteTransferResult with
           senderHoldingCids = [], receiverHoldingCids = [rcid], meta = emptyMetadata
 
       allocation_cancelImpl _self _arg = do
-        cid <- returnAllocationToSender instrumentId allocation
+        cid <- returnAllocationToSender allocation
         pure Allocation_CancelResult with senderHoldingCids = [cid], meta = emptyMetadata
 
       allocation_withdrawImpl _self _arg = do
-        cid <- returnAllocationToSender instrumentId allocation
+        cid <- returnAllocationToSender allocation
         pure Allocation_WithdrawResult with senderHoldingCids = [cid], meta = emptyMetadata
 
 -- | v1 allocations are party-based, not account-based; returned via a basic account.
-returnAllocationToSender : InstrumentId -> AllocationSpecification -> Update (ContractId Holding)
-returnAllocationToSender instrumentId allocation =
+returnAllocationToSender : AllocationSpecification -> Update (ContractId Holding)
+returnAllocationToSender allocation =
   toInterfaceContractId @Holding <$>
-    createCoinIn instrumentId (basicAccountV2 allocation.transferLeg.sender) allocation.transferLeg.amount
+    createCoinIn allocation.transferLeg.instrumentId
+      (basicAccountV2 allocation.transferLeg.sender) allocation.transferLeg.amount

--- a/canton/ntt/daml/Wormhole/Ntt/CoinFactory.daml
+++ b/canton/ntt/daml/Wormhole/Ntt/CoinFactory.daml
@@ -160,7 +160,7 @@ template NttCoinFactory
         senderChangeCids <-
           debitInputs "allocation" leg.instrumentId (basicAccountV2 leg.sender) leg.amount arg.inputHoldingCids
         allocationCid <- toInterfaceContractId @Allocation <$> create NttCoinAllocation with
-          instrumentId = leg.instrumentId, allocation = spec
+          allocation = spec
         pure AllocationInstructionResult with
           output = AllocationInstructionResult_Completed with allocationCid
           senderChangeCids

--- a/canton/test/daml/Test/TestNttCoinAuthenticity.daml
+++ b/canton/test/daml/Test/TestNttCoinAuthenticity.daml
@@ -22,6 +22,7 @@ import Splice.Api.Token.TransferInstructionV1 qualified as TIV1
 import Splice.Api.Token.TransferInstructionV2 qualified as TIV2
 import Wormhole.Core.Fees (emptyExtraArgs)
 import Wormhole.Ntt.Coin
+import Wormhole.Ntt.CoinAllocation (NttCoinAllocation(..))
 import Wormhole.Ntt.CoinFactory
 import Wormhole.Ntt.CoinTransfer (NttTransferInstruction, TransferPreapproval(..))
 import Test.TestNtt (nttCoinFactorySetup, expectAbort)
@@ -770,3 +771,47 @@ testV1UpdateAborts = do
     exerciseCmd transferInstructionCid TIV1.TransferInstruction_Update with
       extraActors = [], extraArgs = emptyExtraArgs
   expectAbort "does not support registry-internal Update steps" updated
+
+----------------------------------------------------------------------
+-- Forged v1 allocation: the advertised instrument must be a signatory
+----------------------------------------------------------------------
+
+-- | 'NttCoinAllocation' reads its instrument from @allocation.transferLeg@
+-- alone, so the instrument published in 'AllocationView' is always the one
+-- whose admin signed. Advertising gg's instrument therefore needs gg's
+-- authority to create. Were the template to carry a second, independent
+-- instrument field driving @signatory@, an attacker could self-sign an
+-- unfunded allocation whose view names gg's instrument -- indistinguishable
+-- from a genuine one to any consumer that trusts the view, since a real
+-- allocation also reports @holdingCids = []@.
+testForgedV1AllocationRequiresInstrumentAdmin : Script ()
+testForgedV1AllocationRequiresInstrumentAdmin = do
+  gg <- allocateParty "AuthAllocForgeGg"
+  mallory <- allocateParty "AuthAllocForgeMallory"
+  victim <- allocateParty "AuthAllocForgeVictim"
+  executor <- allocateParty "AuthAllocForgeExecutor"
+  t0 <- getTime
+  let ggInstrument = InstrumentId with admin = gg, id = "NTT-AUTH-ALLOC-FORGE"
+
+  -- Unfunded allocation advertising gg's instrument: gg must sign, mallory cannot.
+  forged <- trySubmit (actAs mallory) do
+    createCmd NttCoinAllocation with
+      allocation = v1AllocSpec t0 executor mallory victim 1000000.0 ggInstrument
+  case forged of
+    Right _ -> abort "ntt: mallory forged an allocation advertising gg's instrument"
+    Left _ -> pure ()
+
+  -- Nor can any gg-instrument coin be conjured along the way.
+  supply <- query @NttCoin gg
+  supply === []
+
+  -- A self-admin allocation stays creatable: its view honestly advertises
+  -- mallory's own instrument, so no consumer is misled.
+  let ownInstrument = InstrumentId with admin = mallory, id = "MALLORY-OWN"
+  ownCid <- submit mallory do
+    createCmd NttCoinAllocation with
+      allocation = v1AllocSpec t0 executor mallory victim 1000000.0 ownInstrument
+  seen <- queryContractId victim ownCid
+  case seen of
+    Some c -> c.allocation.transferLeg.instrumentId.admin === mallory
+    None -> abort "ntt: expected the self-admin allocation to be visible to the receiver"


### PR DESCRIPTION
`NttCoinAllocation` carried the instrument twice: an `instrumentId` field that
drove `signatory`, and `allocation.transferLeg.instrumentId`, which is what the
`Allocation` interface view publishes. Nothing tied them together.

Because the signatory set is computed from payload fields the creator chooses,
a party could set `instrumentId.admin` to itself — collapsing the signatory set
to `{attacker}` — while pointing `allocation.transferLeg.instrumentId` at
guardianGovernance's real NTT instrument. The result is an unfunded allocation,
creatable in a single `createCmd` with no involvement from gg, whose published
view advertises gg's instrument for any amount. It lands unsolicited on the
counterparty's ACS, since receiver and executor are observers.

Nothing in the view exposes the divergence: the signatory-bearing field never
appears there, and a genuine allocation also reports `holdingCids = []`, so
there is no funding tell either. A consumer following the standard's view-trust
model cannot distinguish it from an authentic allocation without separately
inspecting the contract's signatories.

`Allocation_ExecuteTransfer` requires all of executor, sender, and receiver
(the controller list is conjunctive), so in a real settlement the receiver's
authority is present inside the choice body, and `allocation_executeTransferImpl`
mints using the *template* field. The counterparty settles their own leg against
the advertised gg allocation and receives coins of the attacker's own worthless
instrument. NTT supply is never inflated — minting gg's instrument still needs
gg — so what is stolen is the counter-asset in a DvP, not NTT.

## Fix

Delete the redundant field and derive the instrument from
`allocation.transferLeg` alone. The one field now both determines the signatory
and is what the view publishes, so the divergence cannot be expressed: name gg's
instrument and gg must sign; name your own and the view honestly advertises your
own instrument.

An `ensure instrumentId == allocation.transferLeg.instrumentId` would be equally
secure and a smaller diff, but leaves the redundancy in place for a future code
path to read one field where it meant the other. Removing the field kills the
bug class rather than guarding the instance.

Behaviour is unchanged for every legitimate path — `allocationFactory_allocateImpl`
already set `instrumentId = leg.instrumentId`.

## Scope

`NttCoinAllocationV2` is **not** affected. Its signatory is
`allocation.admin :: accountControlParties authorizerAccount`, and
`allocation.admin` is the same field the view publishes; it also already carries
`ensure authorizerAccount == allocation.authorizer`. Instruments there are built
as `InstrumentId with admin = allocation.admin`, so the admin is always a
signatory.

In-repo consumers were never exposed: `Wormhole.Core.Fees` pins
``instrument.admin `elem` signatory alloc``, which the forgery fails. The gap was
for external consumers of our `Allocation` implementation.

## Test

`testForgedV1AllocationRequiresInstrumentAdmin` in `TestNttCoinAuthenticity`:
an attacker's attempt to create an allocation advertising gg's instrument is
rejected, no gg-instrument coin appears, and a self-admin allocation stays
creatable with a view that honestly names the attacker as admin.

`dpm build --all` clean; `dpm test` 234 scripts pass, no failures.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wormholelabs-xyz/codesmith/native-token-transfers/pr/55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788360538&installation_model_id=15502&pr_number=55&repository=wormholelabs-xyz%2Fnative-token-transfers&return_to=https%3A%2F%2Fgithub.com%2Fwormholelabs-xyz%2Fnative-token-transfers%2Fpull%2F55&signature=c9944d672c1b0071ed7cae9c61c01624fb4f8b56b55c1c3a9e475ac2b27c1bfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->