### PR TITLE
canton: guardian observe credentials + observer reconnect/liveness

### DIFF
--- a/canton/testing/cli/cmd/ntt-playground/cmd_wiring_test.go
+++ b/canton/testing/cli/cmd/ntt-playground/cmd_wiring_test.go
@@ -319,6 +319,57 @@ func TestCmd_ObserveStream_UnknownDeployment(t *testing.T) {
 }
 
 // ----------------------------------------------------------------------
+// observe credentials
+// ----------------------------------------------------------------------
+
+// TestCmd_ObserveCredentials_RegisteredWithFlags pins the wiring: `observe credentials` is
+// registered under the `observe` parent command with --json and --token-ttl flags.
+func TestCmd_ObserveCredentials_RegisteredWithFlags(t *testing.T) {
+	root := newRootCmd()
+	cmd, _, err := root.Find([]string{"observe", "credentials"})
+	if err != nil {
+		t.Fatalf("expected `observe credentials` to be registered: %v", err)
+	}
+	if cmd.Flags().Lookup("json") == nil {
+		t.Fatalf("expected a --json flag")
+	}
+	tokenTTL := cmd.Flags().Lookup("token-ttl")
+	if tokenTTL == nil {
+		t.Fatalf("expected a --token-ttl flag")
+	}
+	if tokenTTL.DefValue != "2h0m0s" {
+		t.Fatalf("expected --token-ttl to default to 2h, got %q", tokenTTL.DefValue)
+	}
+}
+
+func TestCmd_ObserveCredentials_RequiresLocalNetProfile(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "playground.state.json")
+	_, _, err := runPlayground(t, append(baseFlags(stateFile), "observe", "credentials")...)
+	if err == nil || !contains(err.Error(), "requires the localnet profile") {
+		t.Fatalf("expected a requires-localnet-profile error, got %v", err)
+	}
+}
+
+func TestCmd_ObserveCredentials_MissingState(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "playground.state.json")
+	_, _, err := runPlayground(t, append(append(baseFlags(stateFile), "--profile", "localnet"),
+		"observe", "credentials")...)
+	if err == nil || !contains(err.Error(), "run `init` first") {
+		t.Fatalf("expected a missing-state error, got %v", err)
+	}
+}
+
+func TestCmd_ObserveCredentials_NoGuardianObserverInState(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "playground.state.json")
+	seedStateFile(t, stateFile, state.New())
+	_, _, err := runPlayground(t, append(append(baseFlags(stateFile), "--profile", "localnet"),
+		"observe", "credentials")...)
+	if err == nil || !contains(err.Error(), "no guardianObserver party in state") {
+		t.Fatalf("expected a no-guardianObserver error, got %v", err)
+	}
+}
+
+// ----------------------------------------------------------------------
 // balance: required flags + unknown deployment
 // ----------------------------------------------------------------------
 

--- a/canton/testing/cli/cmd/ntt-playground/observe_credentials.go
+++ b/canton/testing/cli/cmd/ntt-playground/observe_credentials.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// observeCredentialsOutput is `observe credentials`'s output shape: everything an external
+// process needs to subscribe to the guardian-observer participant's gRPC Ledger API as
+// guardianObserver, read-only. This is the cross-repo seam plan §5.3 describes -- the
+// Wormhole guardian node's LocalNet integration test shells this instead of knowing anything
+// about Splice.
+type observeCredentialsOutput struct {
+	GRPCAddress      string `json:"grpcAddress"`
+	GuardianObserver string `json:"guardianObserver"`
+	ReaderToken      string `json:"readerToken"`
+	JSONAPIBaseURL   string `json:"jsonApiBaseUrl"`
+}
+
+// newObserveCredentialsCmd builds `observe credentials`, attached alongside `observe stream`
+// under the `observe` parent command.
+func newObserveCredentialsCmd(a *app) *cobra.Command {
+	var tokenTTL time.Duration
+	var asJSON bool
+
+	cmd := &cobra.Command{
+		Use:   "credentials",
+		Short: "Print the guardian-observer participant's gRPC address and a read-only guardianObserver reader token",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			ep, s, err := resolveGuardianObserverEndpoint(a, "observe credentials")
+			if err != nil {
+				return err
+			}
+			token, err := mintGuardianReaderToken(ctx, a, cmd, "observe credentials", ep, s.GuardianObserver, tokenTTL)
+			if err != nil {
+				return err
+			}
+			out := observeCredentialsOutput{
+				GRPCAddress:      fmt.Sprintf("%s:%d", ep.LedgerHost, ep.LedgerPort),
+				GuardianObserver: s.GuardianObserver,
+				ReaderToken:      token,
+				JSONAPIBaseURL:   ep.JSONAPIBaseURL,
+			}
+			if asJSON {
+				raw, err := json.Marshal(out)
+				if err != nil {
+					return err
+				}
+				// Exactly the JSON object, nothing else -- callers pipe this straight into a
+				// JSON parser (see plan §5.3); all narration goes to stderr via a.vlogf.
+				fmt.Fprintln(cmd.OutOrStdout(), string(raw))
+				return nil
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "grpcAddress=%s guardianObserver=%s readerToken=%s jsonApiBaseUrl=%s\n",
+				out.GRPCAddress, out.GuardianObserver, out.ReaderToken, out.JSONAPIBaseURL)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&asJSON, "json", false, "print a single JSON object instead of key=value")
+	cmd.Flags().DurationVar(&tokenTTL, "token-ttl", 2*time.Hour, "lifetime of the minted reader token (long enough for an integration test run)")
+	return cmd
+}

--- a/canton/testing/cli/cmd/ntt-playground/observe_shared.go
+++ b/canton/testing/cli/cmd/ntt-playground/observe_shared.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/wormholelabs-xyz/native-token-transfers/canton/testing/cli/internal/network"
+	"github.com/wormholelabs-xyz/native-token-transfers/canton/testing/cli/internal/profile"
+	"github.com/wormholelabs-xyz/native-token-transfers/canton/testing/cli/internal/state"
+)
+
+// resolveGuardianObserverEndpoint resolves the guardian-observer participant's endpoint and
+// loads state, applying the two guards every `observe` subcommand needs: the profile must be
+// localnet (guardian-observer has no JSON API on the sandbox), and state must already have a
+// guardianObserver party (from `init`). cmdName prefixes returned errors, matching each
+// caller's own command name.
+func resolveGuardianObserverEndpoint(a *app, cmdName string) (profile.Endpoint, *state.State, error) {
+	prof, err := a.resolvedProfile()
+	if err != nil {
+		return profile.Endpoint{}, nil, err
+	}
+	// The guardian observation genuinely happens on the guardians' own node: GO is an
+	// observer of Emitter/CoreState, so its OWN participant is what receives those
+	// projections and must serve the stream (plan §3's "observe stream" routing).
+	ep, err := prof.Endpoint("guardian-observer")
+	if err != nil {
+		return profile.Endpoint{}, nil, err
+	}
+	if ep.JSONAPIBaseURL == "" {
+		return profile.Endpoint{}, nil, fmt.Errorf("%s: requires the localnet profile", cmdName)
+	}
+	s, err := a.loadState()
+	if err != nil {
+		return profile.Endpoint{}, nil, err
+	}
+	if s.GuardianObserver == "" {
+		return profile.Endpoint{}, nil, fmt.Errorf("%s: no guardianObserver party in state -- run `init` first", cmdName)
+	}
+	return ep, s, nil
+}
+
+// mintGuardianReaderToken ensures guardianWatcherUser exists on ep's participant with ONLY
+// CanReadAs(guardianObserver) -- never actAs -- then mints a fresh token for it with the
+// given ttl. This is the CLI's one non-`dpm script` ledger surface, and it is strictly
+// read-only: no command on this path submits anything.
+func mintGuardianReaderToken(ctx context.Context, a *app, cmd *cobra.Command, cmdName string, ep profile.Endpoint, guardianObserver string, ttl time.Duration) (string, error) {
+	adminToken, err := network.MintUnsafeToken(network.LocalNetAdminUser, time.Hour)
+	if err != nil {
+		return "", err
+	}
+	a.vlogf(cmd, "%s: ensuring reader user %q exists with ONLY CanReadAs(%s)", cmdName, guardianWatcherUser, guardianObserver)
+	if err := network.CreateLedgerUser(ctx, ep.JSONAPIBaseURL, adminToken, guardianWatcherUser, []string{guardianObserver}, nil); err != nil {
+		return "", fmt.Errorf("%s: create reader user: %w", cmdName, err)
+	}
+	return network.MintUnsafeToken(guardianWatcherUser, ttl)
+}

--- a/canton/testing/cli/cmd/ntt-playground/observe_stream.go
+++ b/canton/testing/cli/cmd/ntt-playground/observe_stream.go
@@ -102,7 +102,7 @@ func newObserveStreamCmd(a *app) *cobra.Command {
 			defer cancel()
 
 			var results []observedOutput
-			streamErr := observer.Stream(streamCtx, observer.Config{
+			streamErr := observer.StreamWithReconnect(streamCtx, observer.Config{
 				JSONAPIBaseURL: ep.JSONAPIBaseURL,
 				Token:          watcherToken,
 				ObserverParty:  s.GuardianObserver,
@@ -120,7 +120,7 @@ func newObserveStreamCmd(a *app) *cobra.Command {
 				return fmt.Errorf("observe stream: %w", streamErr)
 			}
 			if len(results) < count {
-				return fmt.Errorf("observe stream: timed out after %s waiting for %d message(s) (observed %d)", timeout, count, len(results))
+				return fmt.Errorf("observe stream: timed out after %s waiting for %d message(s) (observed %d): %v", timeout, count, len(results), streamErr)
 			}
 
 			raw, err := json.Marshal(results)

--- a/canton/testing/cli/cmd/ntt-playground/observe_stream.go
+++ b/canton/testing/cli/cmd/ntt-playground/observe_stream.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/wormholelabs-xyz/native-token-transfers/canton/testing/cli/internal/network"
 	"github.com/wormholelabs-xyz/native-token-transfers/canton/testing/cli/internal/observer"
 	"github.com/wormholelabs-xyz/native-token-transfers/canton/testing/cli/internal/wire"
 )
@@ -62,26 +61,9 @@ func newObserveStreamCmd(a *app) *cobra.Command {
 		Short: "Read the real Ledger API v2 update stream as the guardianObserver reader (read-only)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			prof, err := a.resolvedProfile()
+			ep, s, err := resolveGuardianObserverEndpoint(a, "observe stream")
 			if err != nil {
 				return err
-			}
-			// The guardian observation genuinely happens on the guardians' own node: GO is an
-			// observer of Emitter/CoreState, so its OWN participant is what receives those
-			// projections and must serve the stream (plan §3's "observe stream" routing).
-			ep, err := prof.Endpoint("guardian-observer")
-			if err != nil {
-				return err
-			}
-			if ep.JSONAPIBaseURL == "" {
-				return fmt.Errorf("observe stream: requires the localnet profile")
-			}
-			s, err := a.loadState()
-			if err != nil {
-				return err
-			}
-			if s.GuardianObserver == "" {
-				return fmt.Errorf("observe stream: no guardianObserver party in state -- run `init` first")
 			}
 
 			var wantAddress string
@@ -93,18 +75,7 @@ func newObserveStreamCmd(a *app) *cobra.Command {
 				wantAddress = d.TransceiverAddress
 			}
 
-			adminToken, err := network.MintUnsafeToken(network.LocalNetAdminUser, time.Hour)
-			if err != nil {
-				return err
-			}
-			// The reader user carries ONLY CanReadAs(guardianObserver) -- no actAs, ever.
-			// This is the CLI's one non-`dpm script` ledger surface, and it is strictly
-			// read-only: no command on this path submits anything.
-			a.vlogf(cmd, "observe stream: ensuring reader user %q exists with ONLY CanReadAs(%s)", guardianWatcherUser, s.GuardianObserver)
-			if err := network.CreateLedgerUser(ctx, ep.JSONAPIBaseURL, adminToken, guardianWatcherUser, []string{s.GuardianObserver}, nil); err != nil {
-				return fmt.Errorf("observe stream: create reader user: %w", err)
-			}
-			watcherToken, err := network.MintUnsafeToken(guardianWatcherUser, timeout+time.Hour)
+			watcherToken, err := mintGuardianReaderToken(ctx, a, cmd, "observe stream", ep, s.GuardianObserver, timeout+time.Hour)
 			if err != nil {
 				return err
 			}

--- a/canton/testing/cli/cmd/ntt-playground/query.go
+++ b/canton/testing/cli/cmd/ntt-playground/query.go
@@ -126,7 +126,7 @@ func newObserveCmd(a *app) *cobra.Command {
 			return fmt.Errorf("observe: deployment %q (managerId %d) not found on ledger", deployment, local.ManagerID)
 		},
 	}
-	cmd.AddCommand(newObserveStreamCmd(a))
+	cmd.AddCommand(newObserveStreamCmd(a), newObserveCredentialsCmd(a))
 	cmd.Flags().StringVar(&deployment, "deployment", "", "deployment name")
 	_ = cmd.MarkFlagRequired("deployment")
 	return cmd

--- a/canton/testing/cli/internal/observer/observer.go
+++ b/canton/testing/cli/internal/observer/observer.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -32,6 +33,16 @@ type Config struct {
 	Token          string // JWT for the reading user (guardian-watcher)
 	ObserverParty  string // guardianObserver party id -- the event-format filter party
 	BeginExclusive int64
+
+	// PingInterval controls Stream's keepalive cadence: zero (or negative) uses
+	// defaultPingInterval. The read deadline (pongWait) is derived from it rather than being a
+	// second knob -- see pongWaitMultiplier.
+	PingInterval time.Duration
+
+	// ReconnectMinBackoff is StreamWithReconnect's initial (and post-success) retry delay; zero
+	// (or negative) uses defaultReconnectMinBackoff. The cap is fixed at
+	// reconnectBackoffCapFactor times this value, not a separate knob.
+	ReconnectMinBackoff time.Duration
 
 	// Logf, when non-nil, narrates connection/request/frame events. Nil-safe.
 	Logf func(format string, args ...any)
@@ -121,6 +132,28 @@ type updateFrame struct {
 	} `json:"update"`
 }
 
+// ErrDecode is the sentinel every DecodeUpdateFrame failure wraps. These are deterministic
+// wire-shape/programming errors (malformed JSON, a shape drift against the pinned Ledger API
+// schema): retrying the same frame after a reconnect would just reproduce the same failure
+// forever, so StreamWithReconnect uses errors.Is(err, ErrDecode) to treat them as terminal
+// rather than retryable.
+var ErrDecode = errors.New("observer: decode")
+
+// decodeErr carries ErrDecode plus the underlying parse error through Unwrap, while Error()
+// reproduces the historical formatted message (including the raw offending bytes) unchanged --
+// callers that only ever did strings.Contains(err.Error(), ...) keep working verbatim.
+type decodeErr struct {
+	msg string
+	err error
+}
+
+func (e *decodeErr) Error() string   { return e.msg }
+func (e *decodeErr) Unwrap() []error { return []error{ErrDecode, e.err} }
+
+func newDecodeErr(err error, format string, args ...any) error {
+	return &decodeErr{msg: fmt.Sprintf(format, args...), err: err}
+}
+
 // DecodeUpdateFrame parses one raw update-stream frame (a WS text frame, or one element of
 // the `POST /v2/updates` blocking-list array) into zero or more Observed messages -- one per
 // consuming `PublishMessage` ExercisedEvent the frame's transaction carries. Returns (nil,
@@ -128,7 +161,7 @@ type updateFrame struct {
 func DecodeUpdateFrame(raw []byte) ([]Observed, error) {
 	var frame updateFrame
 	if err := json.Unmarshal(raw, &frame); err != nil {
-		return nil, fmt.Errorf("observer: parse update frame: %w\nraw: %s", err, raw)
+		return nil, newDecodeErr(err, "observer: parse update frame: %v\nraw: %s", err, raw)
 	}
 	if frame.Update.Transaction == nil {
 		return nil, nil
@@ -143,7 +176,7 @@ func DecodeUpdateFrame(raw []byte) ([]Observed, error) {
 		}
 		var msg wormholeMessage
 		if err := json.Unmarshal(ex.ExerciseResult, &msg); err != nil {
-			return nil, fmt.Errorf("observer: parse PublishMessage exerciseResult: %w\nraw: %s", err, ex.ExerciseResult)
+			return nil, newDecodeErr(err, "observer: parse PublishMessage exerciseResult: %v\nraw: %s", err, ex.ExerciseResult)
 		}
 		addr := wire.DerivedAddress(wire.EmitterAddressTag, msg.Registrar, msg.Owner, uint64(msg.EmitterID))
 		out = append(out, Observed{
@@ -243,6 +276,21 @@ func buildGetUpdatesRequest(beginExclusive int64, observerParty string) getUpdat
 	return req
 }
 
+// Liveness/reconnect defaults and derivations. pongWaitMultiplier and reconnectBackoffCapFactor
+// are deliberately not separate Config knobs -- one dial per concern keeps the surface small.
+const (
+	defaultPingInterval = 30 * time.Second
+	pongWaitMultiplier  = 2.5 // pongWait = pingInterval * pongWaitMultiplier
+
+	// pingWriteDeadline bounds the control-frame write gorilla/websocket issues for each
+	// keepalive ping; short because a ping that can't be written promptly means the socket
+	// is already in trouble and the read deadline will catch it regardless.
+	pingWriteDeadline = 5 * time.Second
+
+	defaultReconnectMinBackoff = 500 * time.Millisecond
+	reconnectBackoffCapFactor  = 20 // backoff cap = ReconnectMinBackoff * reconnectBackoffCapFactor
+)
+
 // toWebsocketURL converts an http(s):// JSON API base URL to its ws(s):// equivalent.
 func toWebsocketURL(httpBaseURL string) string {
 	switch {
@@ -291,16 +339,44 @@ func Stream(ctx context.Context, cfg Config, yield func(Observed) bool) error {
 	}
 	cfg.logf("observer: subscribed, streaming updates as %s", cfg.ObserverParty)
 
+	pingInterval := cfg.PingInterval
+	if pingInterval <= 0 {
+		pingInterval = defaultPingInterval
+	}
+	pongWait := time.Duration(float64(pingInterval) * pongWaitMultiplier)
+
+	// A dead-but-unclosed TCP connection (NAT timeout, participant restart without FIN) would
+	// otherwise block ReadMessage forever, indistinguishable from "no traffic". The read
+	// deadline is refreshed by every pong and every successful data read, so it only fires
+	// once nothing -- not even a keepalive pong -- has come back for pongWait.
+	if err := conn.SetReadDeadline(time.Now().Add(pongWait)); err != nil {
+		return fmt.Errorf("observer: set initial read deadline: %w", err)
+	}
+	conn.SetPongHandler(func(string) error {
+		return conn.SetReadDeadline(time.Now().Add(pongWait))
+	})
+
 	// gorilla/websocket's Conn.ReadMessage has no context parameter; close the connection
 	// when ctx ends so a blocked Read unblocks with an error instead of leaking the goroutine
-	// past the caller's deadline/cancellation.
+	// past the caller's deadline/cancellation. The same goroutine drives the keepalive ping:
+	// WriteControl is documented safe to call concurrently with reads and with other writes to
+	// the same connection, and the only other write (the subscription frame above) already
+	// happened before this goroutine starts, so there is no write/write race either.
 	done := make(chan struct{})
 	defer close(done)
 	go func() {
-		select {
-		case <-ctx.Done():
-			_ = conn.Close()
-		case <-done:
+		ticker := time.NewTicker(pingInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				_ = conn.Close()
+				return
+			case <-done:
+				return
+			case <-ticker.C:
+				_ = conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(pingWriteDeadline))
+			}
 		}
 	}()
 
@@ -311,6 +387,9 @@ func Stream(ctx context.Context, cfg Config, yield func(Observed) bool) error {
 				return ctx.Err()
 			}
 			return fmt.Errorf("observer: read update frame: %w", err)
+		}
+		if err := conn.SetReadDeadline(time.Now().Add(pongWait)); err != nil {
+			return fmt.Errorf("observer: refresh read deadline: %w", err)
 		}
 		observed, err := DecodeUpdateFrame(raw)
 		if err != nil {
@@ -323,4 +402,84 @@ func Stream(ctx context.Context, cfg Config, yield func(Observed) bool) error {
 			}
 		}
 	}
+}
+
+// StreamWithReconnect wraps Stream with automatic re-subscription from the last yielded
+// offset, so a dropped connection self-heals instead of surfacing as a fatal error. Same
+// contract as Stream: nil once yield stops the loop, ctx.Err() on cancellation.
+//
+// Exactly-once argument: decoding one frame is all-or-nothing (DecodeUpdateFrame either
+// produces the frame's observations or returns an error, never a partial set), and every yield
+// for that frame happens with no intervening network I/O. A connection failure therefore always
+// falls strictly between frames, never mid-frame, so resuming a fresh GetUpdatesRequest with
+// beginExclusive set to the last offset this call actually yielded can never re-deliver an
+// already-yielded observation. Any transactions between that offset and the point of failure
+// that didn't match the filter are simply re-scanned and re-skipped on reconnect -- harmless.
+//
+// Decode errors are the one exception: errors.Is(err, ErrDecode) marks a deterministic
+// wire-shape/programming error, and retrying would just replay the same bad frame forever, so
+// those are returned immediately rather than retried. Retries are otherwise unbounded by
+// design -- the caller's ctx (the CLI's --timeout) is what bounds the total wait.
+//
+// If ctx ends while a stream failure is already pending retry, the returned error wraps ctx's
+// error together with that last failure's text (still satisfying errors.Is(err, ctx.Err()) via
+// %w) so the caller sees the underlying cause -- e.g. an HTTP 401 on dial -- rather than a bare
+// "context deadline exceeded". If ctx ends with no prior failure (e.g. cancelled mid-stream),
+// ctx.Err() is returned unchanged.
+func StreamWithReconnect(ctx context.Context, cfg Config, yield func(Observed) bool) error {
+	minBackoff := cfg.ReconnectMinBackoff
+	if minBackoff <= 0 {
+		minBackoff = defaultReconnectMinBackoff
+	}
+	maxBackoff := minBackoff * reconnectBackoffCapFactor
+	backoff := minBackoff
+
+	var lastOffset int64
+	haveOffset := false
+	var lastErr error // the retryable failure that triggered the most recent backoff, if any
+
+	wrappedYield := func(o Observed) bool {
+		lastOffset = o.Offset
+		haveOffset = true
+		backoff = minBackoff // reset after any successful observation
+		return yield(o)
+	}
+
+	for {
+		err := Stream(ctx, cfg, wrappedYield)
+		if err == nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctxErrWithCause(ctx.Err(), lastErr)
+		}
+		if errors.Is(err, ErrDecode) {
+			return err
+		}
+
+		lastErr = err
+		cfg.logf("observer: stream error, reconnecting in %s: %v", backoff, err)
+		select {
+		case <-ctx.Done():
+			return ctxErrWithCause(ctx.Err(), lastErr)
+		case <-time.After(backoff):
+		}
+
+		if haveOffset {
+			cfg.BeginExclusive = lastOffset
+		}
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+	}
+}
+
+// ctxErrWithCause annotates ctxErr with the last retryable stream failure that preceded it, when
+// there was one. errors.Is(result, ctxErr) keeps working since %w preserves the wrapped chain.
+func ctxErrWithCause(ctxErr, lastErr error) error {
+	if lastErr == nil {
+		return ctxErr
+	}
+	return fmt.Errorf("%w (last attempt: %v)", ctxErr, lastErr)
 }

--- a/canton/testing/cli/internal/observer/observer_ws_test.go
+++ b/canton/testing/cli/internal/observer/observer_ws_test.go
@@ -3,9 +3,11 @@ package observer
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -155,14 +157,14 @@ func TestStream_DialRejectedWithHTTPStatus(t *testing.T) {
 
 // streamFixtureFrame is exercisedUpdateFixture's shape trimmed to what Stream's decode path
 // needs -- one Transaction frame with a single consuming PublishMessage event.
-func streamFixtureFrame(sequence int) string {
+func streamFixtureFrame(sequence, offset int) string {
 	return `{
 	  "update": {
 	    "Transaction": {
 	      "value": {
 	        "updateId": "upd-stream",
 	        "effectiveAt": "2026-07-20T12:00:00Z",
-	        "offset": 1,
+	        "offset": ` + itoa(offset) + `,
 	        "events": [
 	          {
 	            "ExercisedEvent": {
@@ -206,8 +208,8 @@ func TestStream_ReceivesAndYields(t *testing.T) {
 		if _, _, err := conn.ReadMessage(); err != nil {
 			return
 		}
-		_ = conn.WriteMessage(websocket.TextMessage, []byte(streamFixtureFrame(1)))
-		_ = conn.WriteMessage(websocket.TextMessage, []byte(streamFixtureFrame(2)))
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(streamFixtureFrame(1, 1)))
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(streamFixtureFrame(2, 2)))
 		// Block until the client goes away instead of racing a close frame against the
 		// client's second read.
 		for {
@@ -245,8 +247,8 @@ func TestStream_YieldFalseStopsWithoutError(t *testing.T) {
 		if _, _, err := conn.ReadMessage(); err != nil {
 			return
 		}
-		_ = conn.WriteMessage(websocket.TextMessage, []byte(streamFixtureFrame(1)))
-		_ = conn.WriteMessage(websocket.TextMessage, []byte(streamFixtureFrame(2)))
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(streamFixtureFrame(1, 1)))
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(streamFixtureFrame(2, 2)))
 		for {
 			if _, _, err := conn.ReadMessage(); err != nil {
 				return
@@ -340,4 +342,270 @@ func TestStream_CtxCancelledUnblocksRead(t *testing.T) {
 func TestConfig_Logf_NilSafe(t *testing.T) {
 	var c Config
 	c.logf("no logger set, args=%d", 1) // must not panic
+}
+
+// ----------------------------------------------------------------------
+// Ping / read-deadline liveness
+// ----------------------------------------------------------------------
+
+func TestStream_SendsPings(t *testing.T) {
+	pings := make(chan struct{}, 32)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		if _, _, err := conn.ReadMessage(); err != nil { // drain the subscription frame
+			return
+		}
+		conn.SetPingHandler(func(string) error {
+			_ = conn.WriteControl(websocket.PongMessage, nil, time.Now().Add(time.Second))
+			select {
+			case pings <- struct{}{}:
+			default:
+			}
+			return nil
+		})
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil { // keep reading so control frames get processed
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	_ = Stream(ctx, Config{
+		JSONAPIBaseURL: srv.URL,
+		Token:          "tok",
+		ObserverParty:  "p",
+		PingInterval:   20 * time.Millisecond, // ~15 intervals fit in the 300ms ctx window
+	}, func(Observed) bool { return true })
+
+	select {
+	case <-pings:
+	default:
+		t.Fatalf("expected at least one ping to reach the server within the ctx window")
+	}
+}
+
+func TestStream_StaleConnectionTimesOut(t *testing.T) {
+	serverDone := make(chan struct{})
+	defer close(serverDone)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		if _, _, err := conn.ReadMessage(); err != nil { // drain the subscription frame
+			conn.Close()
+			return
+		}
+		// Stop reading entirely: no auto-pong, no data. Nothing on the wire will ever unblock
+		// the client -- only its own read deadline can. This is the regression case for the
+		// stale-socket gap (a dead connection the TCP stack hasn't noticed yet).
+		<-serverDone
+		conn.Close()
+	}))
+	defer srv.Close()
+
+	start := time.Now()
+	done := make(chan error, 1)
+	go func() {
+		done <- Stream(context.Background(), Config{
+			JSONAPIBaseURL: srv.URL,
+			Token:          "tok",
+			ObserverParty:  "p",
+			PingInterval:   20 * time.Millisecond, // pongWait = 50ms
+		}, func(Observed) bool { return true })
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "observer: read update frame") {
+			t.Fatalf("expected a read-update-frame (deadline) error, got %v", err)
+		}
+		// Generous upper bound (several x pongWait, not exactly pongWait) to tolerate a loaded
+		// machine; the point is that it returns at all, not the precise timing.
+		if elapsed := time.Since(start); elapsed > 2*time.Second {
+			t.Fatalf("stale connection took too long to time out: %s", elapsed)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Stream did not return within 2s of a background ctx (no deadline of its own)")
+	}
+}
+
+func TestStream_PongsKeepConnectionAlive(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		if _, _, err := conn.ReadMessage(); err != nil {
+			return
+		}
+		// gorilla's default ping handler auto-pongs; keep reading so control frames get
+		// processed, but never send a data frame of our own.
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond) // ~5x pongWait
+	defer cancel()
+
+	start := time.Now()
+	err := Stream(ctx, Config{
+		JSONAPIBaseURL: srv.URL,
+		Token:          "tok",
+		ObserverParty:  "p",
+		PingInterval:   20 * time.Millisecond, // pongWait = 50ms
+	}, func(Observed) bool { return true })
+	elapsed := time.Since(start)
+
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded once the ctx timeout elapses, got %v", err)
+	}
+	// Proves the read deadline was actually refreshed by pongs: the connection survived
+	// multiple pongWait windows (50ms) and only ended at the ctx timeout (~250ms), not early.
+	if elapsed < 150*time.Millisecond {
+		t.Fatalf("connection ended too early (%s); read deadline may not be refreshing on pongs", elapsed)
+	}
+}
+
+// ----------------------------------------------------------------------
+// StreamWithReconnect
+// ----------------------------------------------------------------------
+
+func TestStreamWithReconnect_ResumesFromLastOffset(t *testing.T) {
+	var connCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&connCount, 1)
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+
+		_, raw, err := conn.ReadMessage()
+		if err != nil {
+			conn.Close()
+			return
+		}
+		var req getUpdatesRequest
+		if err := json.Unmarshal(raw, &req); err != nil {
+			t.Errorf("unmarshal GetUpdatesRequest: %v", err)
+		}
+
+		switch n {
+		case 1:
+			if req.BeginExclusive != 0 {
+				t.Errorf("conn #1: expected beginExclusive=0, got %d", req.BeginExclusive)
+			}
+			_ = conn.WriteMessage(websocket.TextMessage, []byte(streamFixtureFrame(1, 7)))
+			conn.Close() // abrupt close, no close frame -- forces a reconnect
+		case 2:
+			if req.BeginExclusive != 7 {
+				t.Errorf("conn #2: expected beginExclusive=7 (resumed from conn #1's last offset), got %d", req.BeginExclusive)
+			}
+			defer conn.Close()
+			_ = conn.WriteMessage(websocket.TextMessage, []byte(streamFixtureFrame(2, 9)))
+			for {
+				if _, _, err := conn.ReadMessage(); err != nil {
+					return
+				}
+			}
+		default:
+			t.Errorf("unexpected connection #%d", n)
+			conn.Close()
+		}
+	}))
+	defer srv.Close()
+
+	var got []Observed
+	err := StreamWithReconnect(context.Background(), Config{
+		JSONAPIBaseURL:      srv.URL,
+		Token:               "tok",
+		ObserverParty:       "p",
+		ReconnectMinBackoff: 5 * time.Millisecond,
+	}, func(o Observed) bool {
+		got = append(got, o)
+		return len(got) < 2
+	})
+	if err != nil {
+		t.Fatalf("StreamWithReconnect: %v", err)
+	}
+	if len(got) != 2 || got[0].Sequence != 1 || got[1].Sequence != 2 {
+		t.Fatalf("expected [seq 1, seq 2], got %+v", got)
+	}
+	if n := atomic.LoadInt32(&connCount); n != 2 {
+		t.Fatalf("expected exactly 2 connections, got %d", n)
+	}
+}
+
+func TestStreamWithReconnect_DecodeErrorIsTerminal(t *testing.T) {
+	var connCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&connCount, 1)
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		if _, _, err := conn.ReadMessage(); err != nil {
+			return
+		}
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(`not json`))
+	}))
+	defer srv.Close()
+
+	err := StreamWithReconnect(context.Background(), Config{
+		JSONAPIBaseURL:      srv.URL,
+		Token:               "tok",
+		ObserverParty:       "p",
+		ReconnectMinBackoff: 5 * time.Millisecond,
+	}, func(Observed) bool { return true })
+
+	if err == nil || !errors.Is(err, ErrDecode) {
+		t.Fatalf("expected a terminal ErrDecode error, got %v", err)
+	}
+	if n := atomic.LoadInt32(&connCount); n != 1 {
+		t.Fatalf("expected exactly 1 connection (no retry on a decode error), got %d", n)
+	}
+}
+
+func TestStreamWithReconnect_CtxCancelDuringBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := StreamWithReconnect(ctx, Config{
+		JSONAPIBaseURL:      "http://127.0.0.1:1", // nobody listens here -- every dial fails
+		Token:               "tok",
+		ObserverParty:       "p",
+		ReconnectMinBackoff: time.Second, // long enough that a prompt return proves the
+		// select-against-ctx.Done() path fired, not a naturally expired backoff.
+	}, func(Observed) bool { return true })
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("StreamWithReconnect took too long to notice ctx cancellation during backoff: %s", elapsed)
+	}
+	// Pins the M1 behavior: the last dial failure that triggered the pending backoff must be
+	// visible in the returned error text, not just swallowed into a bare ctx error.
+	if !strings.Contains(err.Error(), "observer: dial") {
+		t.Fatalf("expected the last stream failure's text in the returned error, got %v", err)
+	}
 }


### PR DESCRIPTION
Two additions to the guardian-observer path of the ntt-playground CLI, rebased onto the CIP-0056 coin-DAR line.

## 1. `observe credentials` (cherry-picked from the pre-rebuild guardian-observer branch)

Adds `ntt-playground observe credentials`, emitting the JSON API base URL, the `guardianObserver` party id, and a freshly minted read-only JWT for the `guardian-watcher` user, so an external guardian node can reach LocalNet's guardian-observer participant without going through the CLI. Shared endpoint/token plumbing extracted into `observe_shared.go`.

## 2. Observer reconnect-from-last-offset + ping/read-deadline liveness

`internal/observer.Stream` was a single-shot WebSocket subscription with two gaps:

- **Stale-socket hang** — no pings, no read deadline: a silently dead TCP connection (NAT timeout, participant restart without FIN) blocked `ReadMessage` forever.
- **No reconnect** — any dropped connection was fatal, even though the ledger is a durable offset-ordered log and `beginExclusive` makes gap-free resume trivial.

Changes:

- `Stream` now sends keepalive pings (`Config.PingInterval`, default 30s) and maintains a read deadline (2.5× the ping interval) refreshed by every pong and every data frame; a dead connection surfaces as a read error within ~75s instead of hanging.
- New `StreamWithReconnect` retries `Stream` with exponential backoff (`Config.ReconnectMinBackoff`, default 500ms, cap 20×), resuming each attempt from the last yielded `Observed.Offset`. Exactly-once holds because frame decode is all-or-nothing and yields within a frame have no intervening network I/O, so failures always fall between frames (argument documented on the function).
- Decode errors wrap a new `ErrDecode` sentinel and are terminal rather than retried (retrying replays the same malformed frame forever); error text stays byte-identical via a custom `Unwrap() []error` carrier.
- On ctx expiry the last attempt's error is wrapped into the returned `ctx.Err()` so deterministic failures (e.g. HTTP 401 from a bad token) still reach the user instead of dissolving into a generic timeout.
- `observe stream` now uses `StreamWithReconnect`; no flag changes, `--timeout` still bounds the total wait, reconnects visible under `--verbose`.

## Testing

- Six new tests in `internal/observer/observer_ws_test.go` (pings sent, stale connection times out instead of hanging, pongs keep the connection alive, reconnect resumes from the last offset with `beginExclusive` asserted on the second connection, decode errors terminal, ctx cancel during backoff preserves the dial-failure cause).
- Full module: `go build ./... && go test -count=1 ./... && go vet ./...` green on this base; observer package additionally stress-tested 8× under `-race` during review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wormholelabs-xyz/codesmith/native-token-transfers/pr/60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788448243&installation_model_id=15502&pr_number=60&repository=wormholelabs-xyz%2Fnative-token-transfers&return_to=https%3A%2F%2Fgithub.com%2Fwormholelabs-xyz%2Fnative-token-transfers%2Fpull%2F60&signature=3ef1fc5fb98fa63398ce419f0a5e9d1101c7808bb3706dae7c5aca3f2ed3ba39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->