### PR TITLE
canton: contract disclosure service, strict participant isolation, and alice-solo e2e coverage

### DIFF
--- a/canton/test/daml/Playground/Deploy.daml
+++ b/canton/test/daml/Playground/Deploy.daml
@@ -183,8 +183,13 @@ deployNtt input =
         None -> abort "playground: amulet deployNtt needs a CLI-resolved transfer-factory cid -- run setupAmuletAdmin first"
         Some cid -> pure (TransferFactoryCid (coerceContractId cid))
 
-      (_, mgrCid, emitterCid, _ledgerCid) <-
-        submit (actAs input.admin <> disclose govDisc <> disclose emRegDisc <> disclose rrRegDisc) do
+      -- RegisterManager bundles the TransceiverInit broadcast, so CoreState is mandatory
+      -- (it funds the publish) and needs disclosing to admin's submit.
+      csCid <- resolveCoreState input.operator
+      csDisc <- fromSome <$> queryDisclosure input.operator csCid
+
+      (_, mgrCid, emitterCid, _ledgerCid, _msg) <-
+        submit (actAs input.admin <> disclose govDisc <> disclose emRegDisc <> disclose rrRegDisc <> disclose csDisc) do
           exerciseCmd govCid RegisterManager with
             admin = input.admin
             chainId = cantonChainId
@@ -195,12 +200,16 @@ deployNtt input =
             tokenConfig = config
             tokenDecimals = input.tokenDecimals
             factory
-            coreStateCid = None
+            coreStateCid = csCid
+            consistencyLevel = 0
             emitterFeeAllocation = None
             claimFeeAllocation = None
+            feeAllocation = None
 
       Some mgr <- queryContractId input.operator mgrCid
-      Some em <- queryContractId input.operator emitterCid
+      -- Re-resolve the transceiver by id: the bundled TransceiverInit publish is a consuming
+      -- PublishMessage, so the emitterCid RegisterManager returned is already archived.
+      (_, em) <- resolveEmitter input.operator mgr.transceiverEmitterId
       pure DeployOutput with
         managerId = mgr.managerId
         managerAddress = mgr.managerAddress
@@ -229,11 +238,11 @@ deployNtt input =
             BurnMint -> BurnMintFactoryCid (coerceContractId factoryCid)
             LockUnlock -> TransferFactoryCid (coerceContractId factoryCid)
 
-      (_, mgrCid, emitterCid, _ledgerCid) <- case config of
+      (_, mgrCid, emitterCid, _ledgerCid, _msg) <- case config of
         -- Guardian-VAA-gated: co-signed by the guardian quorum's off-chain signature instead
         -- of a live gg signature -- see this module's header. CoreState/its disclosure are
-        -- needed here (unlike the LockUnlock RegisterManager call below) because
-        -- RegisterManagerByVaa's VAA verification is mandatory regardless of fees.
+        -- needed here because RegisterManagerByVaa's VAA verification is mandatory
+        -- regardless of fees (and CoreState now also funds the TransceiverInit broadcast).
         BurnMint -> do
           csCid <- resolveCoreState input.operator
           csDisc <- fromSome <$> queryDisclosure input.operator csCid
@@ -273,16 +282,22 @@ deployNtt input =
               instrumentNonce = input.instrumentNonce
               factory
               coreStateCid = csCid
+              consistencyLevel = 0
               emitterFeeAllocation = None
               claimFeeAllocation = None
+              feeAllocation = None
               vaaBytes
               pubKeys = input.pubKeys
               extraArgs = emptyExtraArgs
           case res of
             Right r -> pure r
             Left err -> abort (show err)
-        LockUnlock ->
-          submit (actAs input.admin <> disclose govDisc <> disclose emRegDisc <> disclose rrRegDisc) do
+        LockUnlock -> do
+          -- CoreState is mandatory here too now: RegisterManager bundles the
+          -- TransceiverInit broadcast, which CoreState funds.
+          csCid <- resolveCoreState input.operator
+          csDisc <- fromSome <$> queryDisclosure input.operator csCid
+          submit (actAs input.admin <> disclose govDisc <> disclose emRegDisc <> disclose rrRegDisc <> disclose csDisc) do
             exerciseCmd govCid RegisterManager with
               admin = input.admin
               chainId = cantonChainId
@@ -293,9 +308,11 @@ deployNtt input =
               tokenConfig = config
               tokenDecimals = input.tokenDecimals
               factory
-              coreStateCid = None
+              coreStateCid = csCid
+              consistencyLevel = 0
               emitterFeeAllocation = None
               claimFeeAllocation = None
+              feeAllocation = None
 
       -- Lock/unlock: the admin is the lock's custodian/receiver (Manager.daml's admin-owned
       -- custody), so it self-creates its own standing preapproval here -- this is what makes
@@ -311,7 +328,9 @@ deployNtt input =
         BurnMint -> pure ()
 
       Some mgr <- queryContractId input.operator mgrCid
-      Some em <- queryContractId input.operator emitterCid
+      -- Re-resolve the transceiver by id: the bundled TransceiverInit publish is a consuming
+      -- PublishMessage, so the emitterCid RegisterManager returned is already archived.
+      (_, em) <- resolveEmitter input.operator mgr.transceiverEmitterId
       pure DeployOutput with
         managerId = mgr.managerId
         managerAddress = mgr.managerAddress

--- a/canton/test/daml/Playground/Deploy.daml
+++ b/canton/test/daml/Playground/Deploy.daml
@@ -131,9 +131,9 @@ data DeployInput = DeployInput with
     -- "mock" burn-mint only: a pre-fetched 'Playground.Prepare:prepareDeployNtt' RemoteSeam
     -- disclosing the committed 'Token.CIP0056.CoinFactory:CoinFactory' to @admin@ --
     -- 'RegisterManagerByVaa' (unlike plain 'RegisterManager') fetches this factory via
-    -- 'requireCanonicalFactory', and gg is its sole signatory, so admin (co-located with
-    -- operator, never with gg) needs it explicitly disclosed. 'None' on a single-participant
-    -- profile (sandbox) or for every other (mode, tokenKind) pair.
+    -- 'requireCanonicalFactory', and gg is its sole signatory, so admin needs it explicitly
+    -- disclosed. 'None' on a single-participant profile (sandbox), where 'deployNtt' resolves
+    -- the disclosure locally as gg instead, or for every other (mode, tokenKind) pair.
     remote             : Optional RemoteSeam
   deriving (Eq, Show)
 
@@ -240,12 +240,17 @@ deployNtt input =
           let vaaBytes = fromSomeNote
                 "playground: mock burn-mint deployNtt needs a guardian-signed registration VAA"
                 input.vaaBytes
-          -- The committed CoinFactory: gg's sole signatory, invisible to admin/operator's
-          -- participant -- requireCanonicalFactory fetches it via interface, so a
-          -- multi-participant profile must disclose it (see DeployInput.remote's doc
-          -- comment); a single-participant profile needs no seam at all.
+          -- The committed CoinFactory: gg's sole signatory, and requireCanonicalFactory
+          -- fetches it, so admin's submit needs it disclosed on EVERY profile -- visibility
+          -- is party-scoped, not participant-scoped, so co-location with gg does not help.
+          -- Single-participant profiles resolve the disclosure locally as gg (the same
+          -- fast path as Ops.daml's None branches); multi-participant profiles attach the
+          -- prepareDeployNtt seam (see DeployInput.remote's doc comment).
           facDiscs <- case input.remote of
-            None -> pure []
+            None -> do
+              d <- fromSome <$> queryDisclosure input.guardianGovernance
+                (coerceContractId factoryCid : ContractId CoinFactory)
+              pure [d]
             Some seam -> do
               seed <- mkSeedDisclosure input.admin
               pure (map (toDisclosureByName seed) seam.disclosed)

--- a/canton/test/daml/Playground/Disclose.daml
+++ b/canton/test/daml/Playground/Disclose.daml
@@ -36,7 +36,7 @@ import Token.CIP0056.CoinFactory (CoinFactory)
 import Wormhole.Ntt.Deposit (DepositPreapproval)
 import Wormhole.Ntt.Governance (NttGovernance)
 import Wormhole.Ntt.Ledger (LockedLedger)
-import Wormhole.Ntt.Manager (NttManager)
+import Wormhole.Ntt.Manager (NttManager, AdminTransferProposal)
 import Test.TestNtt (Cip56MockHolding, MockBurnMintFactory)
 import Playground.MockRegistry (MockPreapprovedTransferFactory, MockTransferPreapproval)
 
@@ -120,6 +120,8 @@ toDisclosureByName seed d
       mkDisclosure @ExternalPartyConfigState.ExternalPartyConfigState
   | "Wormhole.Ntt.Manager:NttManager" `isSuffixOf` d.templateId =
       mkDisclosure @NttManager
+  | "Wormhole.Ntt.Manager:AdminTransferProposal" `isSuffixOf` d.templateId =
+      mkDisclosure @AdminTransferProposal
   | "Wormhole.Ntt.Governance:NttGovernance" `isSuffixOf` d.templateId =
       mkDisclosure @NttGovernance
   | "Wormhole.Ntt.Ledger:LockedLedger" `isSuffixOf` d.templateId =
@@ -178,5 +180,9 @@ data RemoteSeam = RemoteSeam with
     replayNodeCid      : Optional (ContractId ReplayNode)
     preapprovalCid     : Optional (ContractId DepositPreapproval)      -- burn/mint recipient opt-in
     mockPreapprovalCid : Optional (ContractId MockTransferPreapproval) -- lock/unlock owner opt-in
+    -- The standing 'Wormhole.Ntt.Manager:AdminTransferProposal' offering the admin role to gg
+    -- (gg is its OBSERVER, since @newAdmin = gg@ by construction) -- 'prepareAcceptAdmin's own
+    -- addition, unused by every other 'prepare*' script (they leave it 'None').
+    proposalCid        : Optional (ContractId AdminTransferProposal)
     disclosed          : [DisclosedContractIn]
   deriving (Eq, Show)

--- a/canton/test/daml/Playground/Ops.daml
+++ b/canton/test/daml/Playground/Ops.daml
@@ -196,6 +196,27 @@ fundUser input = do
     _ -> abort "playground: fundUser could not uniquely resolve the freshly minted holding"
   pure FundUserOutput with holdingCid
 
+-- | Enumerate @owner@'s own 'Test.TestNtt.Cip56MockHolding's for @instrument@, read AS OWNER
+-- -- owner is a signatory of the template ('Test.TestNtt.Cip56MockHolding''s @signatory admin,
+-- owner@), so this query succeeds on the sender's own participant with NO disclosure at all.
+-- Mirrors 'Playground.Amulet.amuletHoldings''s reasoning for the "amulet" kind exactly (that
+-- helper reads the sender's real Amulet 'Holding's the same way, off the token-standard
+-- interface rather than over HTTP).
+--
+-- Used by 'transferOut''s Mock branch when the CLI leaves 'TransferOutInput.inputHoldingCids'
+-- empty (plan §5.5: funding was split out into `fund`, so `transfer` no longer necessarily
+-- knows the freshly minted holding's cid -- and under strict participant isolation cannot ask
+-- gg for it either).
+mockHoldings : Party -> InstrumentId -> Script [ContractId Holding]
+mockHoldings owner instrument = do
+  hs <- query @Cip56MockHolding owner
+  pure
+    [ toInterfaceContractId @Holding cid
+    | (cid, h) <- hs
+    , h.owner == owner
+    , h.instrument == instrument
+    ]
+
 ----------------------------------------------------------------------
 -- transferOut
 ----------------------------------------------------------------------
@@ -365,7 +386,20 @@ transferOut input = do
     Mock -> do
       when (isSome input.amulet) $
         abort "playground: the amulet seam must be None for a non-amulet deployment"
-      pure (mgrCid, mgr, mockExtraArgs, input.inputHoldingCids, submitOpts0)
+      -- Non-empty 'inputHoldingCids' passes through unchanged (byte-identical to before this
+      -- change: the CLI's own `fund`-then-`transfer` sequence still hands the freshly minted
+      -- holding's cid straight through). Empty means the CLI ran `transfer --no-fund` (plan
+      -- §5.5) -- enumerate the sender's own holdings in-script via 'mockHoldings' rather than
+      -- aborting; a sender with nothing to send gets a clear, actionable error instead of the
+      -- underlying 'Transfer' choice's generic input-holdings failure.
+      holdingCids <- if null input.inputHoldingCids
+        then do
+          hcids <- mockHoldings input.user mgr.instrumentId
+          if null hcids
+            then abort "playground: mock transferOut found no holdings for the sender -- run `fund` first"
+            else pure hcids
+        else pure input.inputHoldingCids
+      pure (mgrCid, mgr, mockExtraArgs, holdingCids, submitOpts0)
 
   -- Recompute the exact published payload from the emitter's PRE-exercise sequence -- see
   -- the module header; this is what `guardian sign-vaa` needs.
@@ -812,15 +846,22 @@ revoke input =
 -- The gg custody opt-in (Wormhole.Ntt.Manager's header) is now VAA-gated: the CURRENT admin
 -- self-signs a standing 'AdminTransferProposal' naming guardianGovernance (propose), and a
 -- guardian-signed 'Wormhole.Ntt.Payload.AcceptAdminToGovernance' VAA lets ANY executor
--- permissionlessly complete the handoff (accept) -- gg never signs live. Sandbox-first: both
--- scripts below only support the 'remote = None' fast path (everything resolved/queried as
--- operator/gg, exactly like receiveVaa's 'None' branch). A 'RemoteSeam' extension (routing the
--- accept step's disclosure gathering through 'Playground.Prepare' when the executor's
--- participant differs from gg's, mirroring receiveVaa/transferOut) is follow-up work, not
--- implemented here.
+-- permissionlessly complete the handoff (accept) -- gg never signs live. 'proposeAdminTransferToGg'
+-- is single-party -- it reads AND submits as the CURRENT admin alone (no operator read at all) --
+-- which is what lets the CLI route the whole call to the current admin's own participant. This
+-- matters because "current admin" is not fixed: before any handoff it is the registering admin
+-- (co-located with operator under the default topology), but after a successful
+-- 'acceptAdminTransferByVaa' it is guardianGovernance, hosted on its OWN participant -- routing
+-- this call to operator's participant regardless (the pre-fix bug) fails PERMISSION_DENIED the
+-- moment a second propose/accept cycle runs post-handoff. 'acceptAdminTransferByVaa' gets the
+-- standard 'RemoteSeam' None/Some split mirroring 'receiveVaa'/'transferOut' (see
+-- 'Playground.Prepare:prepareAcceptAdmin'): 'None' resolves/queries everything as operator/gg in
+-- one script execution, which only works when one participant hosts both -- unconditionally
+-- false on multi-participant LocalNet once guardianGovernance became its own participant;
+-- 'Some seam' takes a pre-fetched seam instead.
 
 data ProposeAdminTransferToGgInput = ProposeAdminTransferToGgInput with
-    operator  : Party
+    admin     : Party  -- the deployment's CURRENT admin, as the CLI's state file records it
     managerId : Int
   deriving (Eq, Show)
 
@@ -833,12 +874,24 @@ data ProposeAdminTransferToGgOutput = ProposeAdminTransferToGgOutput with
 -- ('Wormhole.Ntt.Manager.AdminTransferProposal') naming @guardianGovernance@ as the new
 -- admin -- the propose half of the VAA-gated custody opt-in (see
 -- 'Wormhole.Ntt.Manager.AcceptAdminTransferByVaa's doc comment and 'acceptAdminTransferByVaa'
--- below). Returns the deployment's stable @managerAddress@ and its CURRENT @factoryEpoch@,
--- exactly the two fields a guardian quorum's governance VAA must bind to (`guardian
--- sign-governance accept-admin`).
+-- below). Single-party by design (see the module header note above): @input.admin@ is both the
+-- reader that resolves the manager ('resolveManager's first argument is purely the reader,
+-- Playground.Types' own doc comment -- any manager signatory works, and admin always is one)
+-- and the submitter, so this runs entirely on @input.admin@'s own participant, no disclosure
+-- needed either way. Asserts @mgr.admin == input.admin@ first: the CLI's cached "current admin"
+-- can go stale (e.g. a handoff completed by another process), and submitting as a party that no
+-- longer holds the role would otherwise fail with a much less legible authorization error deeper
+-- in 'AdminTransferProposal's own create. Returns the deployment's stable @managerAddress@ and
+-- its CURRENT @factoryEpoch@, exactly the two fields a guardian quorum's governance VAA must
+-- bind to (`guardian sign-governance accept-admin`).
 proposeAdminTransferToGg : ProposeAdminTransferToGgInput -> Script ProposeAdminTransferToGgOutput
 proposeAdminTransferToGg input = do
-  (_mgrCid, mgr) <- resolveManager input.operator input.managerId
+  (_mgrCid, mgr) <- resolveManager input.admin input.managerId
+  assertMsg
+    ("playground: the CLI's recorded current admin (" <> partyToText input.admin <>
+     ") does not match the deployment's actual current admin (" <> partyToText mgr.admin <>
+     ") -- the CLI's recorded current admin is stale -- re-run `status` / check the deployment")
+    (mgr.admin == input.admin)
   _ <- submit mgr.admin do
     createCmd AdminTransferProposal with
       admin = mgr.admin
@@ -854,6 +907,12 @@ data AcceptAdminTransferByVaaInput = AcceptAdminTransferByVaaInput with
     executor  : Party
     vaaBytes  : Text
     pubKeys   : [(Int, Text)]
+    -- 'None' on the same-participant fast path (today's default, everything resolved/queried as
+    -- operator/gg); 'Some' when the CLI ran 'Playground.Prepare:prepareAcceptAdmin' on gg's OWN
+    -- participant first (mirrors receiveVaa/transferOut's own split) -- needed whenever the
+    -- executor's participant differs from gg's, which is unconditionally the case on
+    -- multi-participant LocalNet (no participant hosts both operator and gg there).
+    remote    : Optional RemoteSeam
   deriving (Eq, Show)
 
 data AcceptAdminTransferByVaaOutput = AcceptAdminTransferByVaaOutput with
@@ -864,69 +923,101 @@ data AcceptAdminTransferByVaaOutput = AcceptAdminTransferByVaaOutput with
 -- | Permissionlessly relay a guardian-signed accept-admin governance VAA against the
 -- deployment's standing 'AdminTransferProposal', completing the gg custody opt-in with no
 -- live gg signature (see 'Wormhole.Ntt.Manager.AcceptAdminTransferByVaa'). Mirrors
--- 'receiveVaa''s disclosure-gathering pattern: manager, core state, and the covering replay
--- node (@consumer = gg@, @namespace = mgr.namespace@, keyed off the VAA's own digest, exactly
--- as 'receiveVaa' resolves it). The proposal is queried as gg (its observer, since
--- @newAdmin = gg@ here) and disclosed to the executor. For LockUnlock, the nested
--- 'Wormhole.Ntt.Manager.TransferAdmin' pot move additionally needs the ledger, and -- only
--- when the pot is non-empty -- the pot holding, the committed factory, and gg's OWN
--- 'Playground.MockRegistry.MockTransferPreapproval' (the move's receiver is gg, and the mock
--- registry's factory requires the RECEIVER's standing pre-approval unless sender == receiver
--- -- see 'Playground.MockRegistry.MockPreapprovedTransferFactory' and transferOut/receiveVaa's
--- identical pattern for the admin/recipient side). gg must have run `preapprove` for its own
--- party first; a zero-balance ledger needs none of this (mirrors 'TransferAdmin' itself).
+-- 'receiveVaa''s 'RemoteSeam' split (see the module header): 'None' resolves/queries manager,
+-- core state, and the covering replay node (@consumer = gg@, @namespace = mgr.namespace@, keyed
+-- off the VAA's own digest) as operator/gg in one script execution, exactly as before; the
+-- proposal is queried as gg (its observer, since @newAdmin = gg@ here) and disclosed to the
+-- executor. For LockUnlock, the nested 'Wormhole.Ntt.Manager.TransferAdmin' pot move
+-- additionally needs the ledger, and -- only when the pot is non-empty -- the pot holding, the
+-- committed factory, and gg's OWN 'Playground.MockRegistry.MockTransferPreapproval' (the
+-- move's receiver is gg, and the mock registry's factory requires the RECEIVER's standing
+-- pre-approval unless sender == receiver -- see 'Playground.MockRegistry.MockPreapprovedTransferFactory'
+-- and transferOut/receiveVaa's identical pattern for the admin/recipient side). gg must have
+-- run `preapprove` for its own party first; a zero-balance ledger needs none of this (mirrors
+-- 'TransferAdmin' itself). 'Some seam' (produced by 'Playground.Prepare:prepareAcceptAdmin', run
+-- as gg on gg's OWN participant) takes the identical material pre-fetched instead of querying
+-- locally -- the executor's participant may not be able to see operator/admin/gg at all.
 acceptAdminTransferByVaa : AcceptAdminTransferByVaaInput -> Script AcceptAdminTransferByVaaOutput
 acceptAdminTransferByVaa input = do
-  (mgrCid, mgr) <- resolveManager input.operator input.managerId
-  csCid <- resolveCoreState input.operator
-  csDisc <- fromSome <$> queryDisclosure input.operator csCid
-  mgrDisc <- fromSome <$> queryDisclosure input.operator mgrCid
+  (mgrCid, mgr, csCid, nodeCid, proposalCid, ledgerCid, extraArgs, submitOpts) <- case input.remote of
+    None -> do
+      (mgrCid, mgr) <- resolveManager input.operator input.managerId
+      csCid <- resolveCoreState input.operator
+      csDisc <- fromSome <$> queryDisclosure input.operator csCid
+      mgrDisc <- fromSome <$> queryDisclosure input.operator mgrCid
 
-  let gg = mgr.guardianGovernance
-      digest = (parseVAA input.vaaBytes).hash
-  (nodeCid, nodeDisc) <- coveringDisclosure input.operator gg mgr.namespace digest
+      let gg = mgr.guardianGovernance
+          digest = (parseVAA input.vaaBytes).hash
+      (nodeCid, nodeDisc) <- coveringDisclosure input.operator gg mgr.namespace digest
 
-  -- The standing proposal: gg is its OBSERVER (newAdmin = gg), so it is queryable as gg;
-  -- disclose it to the executor, who (in the permissionless-relay case) is neither admin nor
-  -- gg. Filtering by managerAddress AND the deployment's CURRENT admin picks out the live
-  -- proposal even if a stale one (from a since-replaced admin) is also visible -- the choice
-  -- itself re-checks this, this is just so the script resolves a sensible candidate to
-  -- disclose.
-  proposals <- query @AdminTransferProposal gg
-  proposalCid <- case
-    [ cid | (cid, p) <- proposals, p.managerAddress == mgr.managerAddress, p.admin == mgr.admin ] of
-    [cid] -> pure cid
-    [] -> abort "playground: no standing AdminTransferProposal for this deployment's current admin -- run `admin propose-gg` first"
-    _ -> abort "playground: more than one AdminTransferProposal for this deployment's current admin"
-  proposalDisc <- fromSome <$> queryDisclosure gg proposalCid
+      -- The standing proposal: gg is its OBSERVER (newAdmin = gg), so it is queryable as gg;
+      -- disclose it to the executor, who (in the permissionless-relay case) is neither admin
+      -- nor gg. Filtering by managerAddress AND the deployment's CURRENT admin picks out the
+      -- live proposal even if a stale one (from a since-replaced admin) is also visible -- the
+      -- choice itself re-checks this, this is just so the script resolves a sensible candidate
+      -- to disclose.
+      proposals <- query @AdminTransferProposal gg
+      proposalCid <- case
+        [ cid | (cid, p) <- proposals, p.managerAddress == mgr.managerAddress, p.admin == mgr.admin ] of
+        [cid] -> pure cid
+        [] -> abort "playground: no standing AdminTransferProposal for this deployment's current admin -- run `admin propose-gg` first"
+        _ -> abort "playground: more than one AdminTransferProposal for this deployment's current admin"
+      proposalDisc <- fromSome <$> queryDisclosure gg proposalCid
 
-  (ledgerCid, ledgerDiscs, extraArgs) <- case mgr.tokenConfig of
-    BurnMint -> pure (None, [], emptyExtraArgs)
-    LockUnlock -> do
-      (lcid, ledger) <- resolveLedger input.operator mgr.managerAddress
-      ld <- fromSome <$> queryDisclosure input.operator lcid
-      case ledger.custodyHoldingCid of
-        None -> pure (Some lcid, [ld], emptyExtraArgs)
-        Some potCid -> do
-          potDisc <- fromSome <$> queryDisclosure gg (coerceContractId potCid : ContractId Cip56MockHolding)
-          facDisc <- case mgr.factory of
-            TransferFactoryCid cid -> fromSome <$> queryDisclosure gg (coerceContractId cid : ContractId MockPreapprovedTransferFactory)
-            BurnMintFactoryCid _ -> abort "playground: lock/unlock deployment has a burn/mint factory -- inconsistent state"
-          pres <- query @MockTransferPreapproval gg
-          preCid <- case [ cid | (cid, p) <- pres, p.owner == gg, p.instrument == mgr.instrumentId ] of
-            [cid] -> pure cid
-            [] -> abort "playground: guardianGovernance has no standing transfer pre-approval -- run `preapprove --user GuardianGovernance` first"
-            _ -> abort "playground: more than one MockTransferPreapproval for guardianGovernance"
-          preDisc <- fromSome <$> queryDisclosure gg preCid
-          let ea = ExtraArgs with
-                context = ChoiceContext with
-                  values = TextMap.fromList
-                    [(mockTransferPreapprovalContextKey, AV_ContractId (coerceContractId preCid))]
-                meta = emptyMetadata
-          pure (Some lcid, [ld, potDisc, facDisc, preDisc], ea)
+      (ledgerCid, ledgerDiscs, extraArgs) <- case mgr.tokenConfig of
+        BurnMint -> pure (None, [], emptyExtraArgs)
+        LockUnlock -> do
+          (lcid, ledger) <- resolveLedger input.operator mgr.managerAddress
+          ld <- fromSome <$> queryDisclosure input.operator lcid
+          case ledger.custodyHoldingCid of
+            None -> pure (Some lcid, [ld], emptyExtraArgs)
+            Some potCid -> do
+              potDisc <- fromSome <$> queryDisclosure gg (coerceContractId potCid : ContractId Cip56MockHolding)
+              facDisc <- case mgr.factory of
+                TransferFactoryCid cid -> fromSome <$> queryDisclosure gg (coerceContractId cid : ContractId MockPreapprovedTransferFactory)
+                BurnMintFactoryCid _ -> abort "playground: lock/unlock deployment has a burn/mint factory -- inconsistent state"
+              pres <- query @MockTransferPreapproval gg
+              preCid <- case [ cid | (cid, p) <- pres, p.owner == gg, p.instrument == mgr.instrumentId ] of
+                [cid] -> pure cid
+                [] -> abort "playground: guardianGovernance has no standing transfer pre-approval -- run `preapprove --user GuardianGovernance` first"
+                _ -> abort "playground: more than one MockTransferPreapproval for guardianGovernance"
+              preDisc <- fromSome <$> queryDisclosure gg preCid
+              let ea = ExtraArgs with
+                    context = ChoiceContext with
+                      values = TextMap.fromList
+                        [(mockTransferPreapprovalContextKey, AV_ContractId (coerceContractId preCid))]
+                    meta = emptyMetadata
+              pure (Some lcid, [ld, potDisc, facDisc, preDisc], ea)
 
-  let submitOpts = foldl (\opts d -> opts <> disclose d) (actAs input.executor)
-        ([csDisc, mgrDisc, nodeDisc, proposalDisc] ++ ledgerDiscs)
+      let submitOpts = foldl (\opts d -> opts <> disclose d) (actAs input.executor)
+            ([csDisc, mgrDisc, nodeDisc, proposalDisc] ++ ledgerDiscs)
+      pure (mgrCid, mgr, csCid, nodeCid, proposalCid, ledgerCid, extraArgs, submitOpts)
+
+    Some seam -> do
+      let mgrCid      = fromSomeNote "playground: remote seam missing mgrCid" seam.mgrCid
+          mgr         = fromSomeNote "playground: remote seam missing mgr" seam.mgr
+          csCid       = fromSomeNote "playground: remote seam missing csCid" seam.csCid
+          nodeCid     = fromSomeNote "playground: remote seam missing replayNodeCid" seam.replayNodeCid
+          proposalCid = fromSomeNote "playground: remote seam missing proposalCid" seam.proposalCid
+          ledgerCid   = seam.ledgerCid
+      -- No existing contract of @executor@'s own to queryDisclosure a seed FROM on this
+      -- participant -- create+fetch a throwaway one (Playground.Disclose.mkSeedDisclosure).
+      seed <- mkSeedDisclosure input.executor
+      let toDisc = map (toDisclosureByName seed) seam.disclosed
+          submitOpts = foldl (\opts d -> opts <> disclose d) (actAs input.executor) toDisc
+          -- The preapproval cid itself needs no query -- prepareAcceptAdmin already resolved it
+          -- (as gg, on gg's own participant); this just builds the same ExtraArgs.context shape
+          -- 'Playground.MockRegistry.MockPreapprovedTransferFactory' expects. 'None' both for
+          -- BurnMint and for a LockUnlock deployment whose pot was empty (prepareAcceptAdmin
+          -- resolves no preapproval in that case either -- see that script's own doc comment).
+          extraArgs = case seam.mockPreapprovalCid of
+            None -> emptyExtraArgs
+            Some preCid -> ExtraArgs with
+              context = ChoiceContext with
+                values = TextMap.fromList
+                  [(mockTransferPreapprovalContextKey, AV_ContractId (coerceContractId preCid))]
+              meta = emptyMetadata
+      pure (mgrCid, mgr, csCid, nodeCid, proposalCid, ledgerCid, extraArgs, submitOpts)
 
   (mgrCid', _ledgerCid') <- submit submitOpts do
     exerciseCmd mgrCid AcceptAdminTransferByVaa with
@@ -939,7 +1030,20 @@ acceptAdminTransferByVaa input = do
       ledgerCid
       extraArgs
 
-  Some mgr' <- queryContractId input.operator mgrCid'
+  -- The successor admin: the 'None' branch reads it back from the successor manager, exactly
+  -- as before -- fine there, since operator's own participant is what ran the whole script. The
+  -- 'Some seam' branch must NOT do this: 'queryContractId input.operator mgrCid'' reads as
+  -- OPERATOR, which fails on any participant that does not host operator -- the whole reason
+  -- the remote branch exists. The
+  -- successor is proposal-determined instead: 'AcceptAdminTransferByVaa' asserts
+  -- @proposal.newAdmin == guardianGovernance@ before ever consuming the proposal, so a
+  -- successful submit already proves the deployment's new admin is gg.
+  admin <- case input.remote of
+    None -> do
+      Some mgr' <- queryContractId input.operator mgrCid'
+      pure mgr'.admin
+    Some _ -> pure mgr.guardianGovernance
+
   pure AcceptAdminTransferByVaaOutput with
     managerAddress = normalizeHex mgr.managerAddress
-    admin = mgr'.admin
+    admin

--- a/canton/test/daml/Playground/Ops.daml
+++ b/canton/test/daml/Playground/Ops.daml
@@ -196,12 +196,13 @@ fundUser input = do
     _ -> abort "playground: fundUser could not uniquely resolve the freshly minted holding"
   pure FundUserOutput with holdingCid
 
--- | Enumerate @owner@'s own 'Test.TestNtt.Cip56MockHolding's for @instrument@, read AS OWNER
--- -- owner is a signatory of the template ('Test.TestNtt.Cip56MockHolding''s @signatory admin,
--- owner@), so this query succeeds on the sender's own participant with NO disclosure at all.
--- Mirrors 'Playground.Amulet.amuletHoldings''s reasoning for the "amulet" kind exactly (that
--- helper reads the sender's real Amulet 'Holding's the same way, off the token-standard
--- interface rather than over HTTP).
+-- | Enumerate @owner@'s own mock holdings for @instrument@, read AS OWNER: both
+-- 'Wormhole.Ntt.Coin.NttCoin' (what 'fundUser' mints for burn/mint via the canonical
+-- 'NttCoinFactory') and 'Test.TestNtt.Cip56MockHolding' (the lock/unlock mock instrument).
+-- Owner is a signatory of both templates, so these queries succeed on the sender's own
+-- participant with NO disclosure at all. Mirrors 'Playground.Amulet.amuletHoldings''s
+-- reasoning for the "amulet" kind exactly (that helper reads the sender's real Amulet
+-- 'Holding's the same way, off the token-standard interface rather than over HTTP).
 --
 -- Used by 'transferOut''s Mock branch when the CLI leaves 'TransferOutInput.inputHoldingCids'
 -- empty (plan §5.5: funding was split out into `fund`, so `transfer` no longer necessarily
@@ -210,11 +211,18 @@ fundUser input = do
 mockHoldings : Party -> InstrumentId -> Script [ContractId Holding]
 mockHoldings owner instrument = do
   hs <- query @Cip56MockHolding owner
-  pure
+  coins <- query @NttCoin owner
+  pure $
     [ toInterfaceContractId @Holding cid
     | (cid, h) <- hs
     , h.owner == owner
     , h.instrument == instrument
+    ]
+    <>
+    [ toInterfaceContractId @Holding cid
+    | (cid, c) <- coins
+    , c.owner == owner
+    , c.instrumentId == instrument
     ]
 
 ----------------------------------------------------------------------

--- a/canton/test/daml/Playground/Ops.daml
+++ b/canton/test/daml/Playground/Ops.daml
@@ -197,8 +197,8 @@ fundUser input = do
   pure FundUserOutput with holdingCid
 
 -- | Enumerate @owner@'s own mock holdings for @instrument@, read AS OWNER: both
--- 'Wormhole.Ntt.Coin.NttCoin' (what 'fundUser' mints for burn/mint via the canonical
--- 'NttCoinFactory') and 'Test.TestNtt.Cip56MockHolding' (the lock/unlock mock instrument).
+-- 'Token.CIP0056.Coin.Coin' (what 'fundUser' mints for burn/mint via the canonical
+-- 'CoinFactory') and 'Test.TestNtt.Cip56MockHolding' (the lock/unlock mock instrument).
 -- Owner is a signatory of both templates, so these queries succeed on the sender's own
 -- participant with NO disclosure at all. Mirrors 'Playground.Amulet.amuletHoldings''s
 -- reasoning for the "amulet" kind exactly (that helper reads the sender's real Amulet
@@ -211,7 +211,7 @@ fundUser input = do
 mockHoldings : Party -> InstrumentId -> Script [ContractId Holding]
 mockHoldings owner instrument = do
   hs <- query @Cip56MockHolding owner
-  coins <- query @NttCoin owner
+  coins <- query @Coin owner
   pure $
     [ toInterfaceContractId @Holding cid
     | (cid, h) <- hs

--- a/canton/test/daml/Playground/Ops.daml
+++ b/canton/test/daml/Playground/Ops.daml
@@ -96,14 +96,26 @@ data SetPeerOutput = SetPeerOutput with
 
 setPeer : SetPeerInput -> Script SetPeerOutput
 setPeer input = do
-  (mgrCid, _mgr) <- resolveManager input.operator input.managerId
-  _ <- submit input.admin do
+  (mgrCid, mgr) <- resolveManager input.operator input.managerId
+  -- SetPeer bundles the TransceiverRegistration broadcast, so it fetches the deployment's
+  -- own transceiver Emitter and the CoreState -- both operator/gg-signed, so the admin's
+  -- submit needs their disclosures (same pattern as publishMessage's resolution below).
+  (emCid, _em) <- resolveEmitter input.operator mgr.transceiverEmitterId
+  csCid <- resolveCoreState input.operator
+  emDisc <- fromSome <$> queryDisclosure input.operator emCid
+  csDisc <- fromSome <$> queryDisclosure input.operator csCid
+  _ <- submit (actAs input.admin <> disclose emDisc <> disclose csDisc) do
     exerciseCmd mgrCid SetPeer with
       chainId = input.chain
       peer = Peer with
         managerAddress = input.peerManager
         transceiverAddress = input.peerTransceiver
         decimals = input.decimals
+      transceiverEmitterCid = emCid
+      coreStateCid = csCid
+      consistencyLevel = 0
+      payer = input.admin
+      feeAllocation = None
   pure SetPeerOutput with managerId = input.managerId
 
 ----------------------------------------------------------------------

--- a/canton/test/daml/Playground/Prepare.daml
+++ b/canton/test/daml/Playground/Prepare.daml
@@ -35,7 +35,7 @@ import DA.Optional (fromSome)
 import Wormhole.Core.VAA (parseVAA)
 import Token.CIP0056.CoinFactory (CoinFactory)
 import Wormhole.Ntt.Deposit (DepositPreapproval)
-import Wormhole.Ntt.Manager (NttFactory (..), NttTokenConfig (..))
+import Wormhole.Ntt.Manager (AdminTransferProposal, NttFactory (..), NttTokenConfig (..))
 import Test.TestNtt (Cip56MockHolding, MockBurnMintFactory)
 import Test.TestReplay (coveringDisclosure)
 
@@ -70,6 +70,7 @@ emptyRemoteSeam = RemoteSeam with
   mgrCid = None; mgr = None; emCid = None; em = None; csCid = None
   ledgerCid = None; ledger = None
   replayNodeCid = None; preapprovalCid = None; mockPreapprovalCid = None
+  proposalCid = None
   disclosed = []
 
 ----------------------------------------------------------------------
@@ -264,6 +265,99 @@ prepareDeployNtt input = do
   d <- fromSome <$> queryDisclosure gg (coerceContractId input.factoryCid : ContractId CoinFactory)
   pure emptyRemoteSeam with
     disclosed = gated allowed "Token.CIP0056.CoinFactory:CoinFactory" d
+
+----------------------------------------------------------------------
+-- prepareAcceptAdmin (Playground.Ops:acceptAdminTransferByVaa's Mock-kind resolver half)
+----------------------------------------------------------------------
+
+data PrepareAcceptAdminInput = PrepareAcceptAdminInput with
+    guardianGovernance : Party
+    managerId          : Int
+    vaaBytes           : Text
+    discloseTemplates  : [Text]
+  deriving (Eq, Show)
+
+-- | Resolves everything a Mock-kind 'Playground.Ops:acceptAdminTransferByVaa' needs, as gg
+-- (see the module header) -- the RemoteSeam extension `admin accept-gg-vaa` previously lacked:
+-- gg's own participant is the one place that can resolve the standing
+-- 'Wormhole.Ntt.Manager:AdminTransferProposal' (gg is its OBSERVER, since @newAdmin = gg@ by
+-- construction) alongside everything 'prepareReceive' already proves it can (the manager, the
+-- core state, and the covering replay node keyed off the VAA's own digest -- identical call
+-- shape to 'prepareReceive's own). For lock/unlock with a NON-EMPTY custody pot, additionally
+-- resolves the pot holding, the committed factory, and gg's OWN standing
+-- 'Playground.MockRegistry.MockTransferPreapproval' -- the nested 'TransferAdmin' pot move's
+-- receiver is gg itself, and the mock registry's factory requires the RECEIVER's standing
+-- pre-approval (mirrors 'Playground.Ops:transferOut'/'receiveVaa's identical admin/recipient-
+-- side pattern). Aborts with the SAME messages
+-- 'Playground.Ops:acceptAdminTransferByVaa's own local-fast-path resolution would.
+prepareAcceptAdmin : PrepareAcceptAdminInput -> Script RemoteSeam
+prepareAcceptAdmin input = do
+  let gg = input.guardianGovernance
+      allowed = input.discloseTemplates
+  (mgrCid, mgr) <- resolveManager gg input.managerId
+  csCid <- resolveCoreState gg
+  dMgr <- fromSome <$> queryDisclosure gg mgrCid
+  dCs <- fromSome <$> queryDisclosure gg csCid
+  let digest = (parseVAA input.vaaBytes).hash
+  (nodeCid, nodeDisc) <- coveringDisclosure gg gg mgr.namespace digest
+
+  -- The standing proposal: gg is its OBSERVER (newAdmin = gg), so it is queryable as gg here --
+  -- same filter, same abort messages as
+  -- 'Playground.Ops:acceptAdminTransferByVaa's own local-fast-path resolution.
+  proposals <- query @AdminTransferProposal gg
+  proposalCid <- case
+    [ cid | (cid, p) <- proposals, p.managerAddress == mgr.managerAddress, p.admin == mgr.admin ] of
+    [cid] -> pure cid
+    [] -> abort "playground: no standing AdminTransferProposal for this deployment's current admin -- run `admin propose-gg` first"
+    _ -> abort "playground: more than one AdminTransferProposal for this deployment's current admin"
+  proposalDisc <- fromSome <$> queryDisclosure gg proposalCid
+
+  let baseDisclosed =
+        gated allowed "Wormhole.Ntt.Manager:NttManager" dMgr
+        <> gated allowed "Wormhole.Core.State:CoreState" dCs
+        <> gated allowed "Wormhole.Core.Replay:ReplayNode" nodeDisc
+        <> gated allowed "Wormhole.Ntt.Manager:AdminTransferProposal" proposalDisc
+      base = emptyRemoteSeam with
+        mgrCid = Some mgrCid
+        mgr = Some mgr
+        csCid = Some csCid
+        replayNodeCid = Some nodeCid
+        proposalCid = Some proposalCid
+
+  case mgr.tokenConfig of
+    BurnMint -> pure base with disclosed = baseDisclosed
+
+    LockUnlock -> do
+      (lcid, ledger) <- resolveLedger gg mgr.managerAddress
+      ledgerDisc <- fromSome <$> queryDisclosure gg lcid
+      case ledger.custodyHoldingCid of
+        None ->
+          pure base with
+            ledgerCid = Some lcid
+            ledger = Some ledger
+            disclosed = baseDisclosed <> gated allowed "Wormhole.Ntt.Ledger:LockedLedger" ledgerDisc
+
+        Some potCid -> do
+          potDisc <- fromSome <$> queryDisclosure gg (coerceContractId potCid : ContractId Cip56MockHolding)
+          facDisc <- case mgr.factory of
+            TransferFactoryCid cid -> fromSome <$> queryDisclosure gg (coerceContractId cid : ContractId MockPreapprovedTransferFactory)
+            BurnMintFactoryCid _ -> abort "playground: lock/unlock deployment has a burn/mint factory -- inconsistent state"
+          pres <- query @MockTransferPreapproval gg
+          preCid <- case [ cid | (cid, p) <- pres, p.owner == gg, p.instrument == mgr.instrumentId ] of
+            [cid] -> pure cid
+            [] -> abort "playground: guardianGovernance has no standing transfer pre-approval -- run `preapprove --user GuardianGovernance` first"
+            _ -> abort "playground: more than one MockTransferPreapproval for guardianGovernance"
+          preDisc <- fromSome <$> queryDisclosure gg preCid
+          pure base with
+            ledgerCid = Some lcid
+            ledger = Some ledger
+            mockPreapprovalCid = Some preCid
+            disclosed =
+              baseDisclosed
+              <> gated allowed "Wormhole.Ntt.Ledger:LockedLedger" ledgerDisc
+              <> gated allowed "Test.TestNtt:Cip56MockHolding" potDisc
+              <> gated allowed "Playground.MockRegistry:MockPreapprovedTransferFactory" facDisc
+              <> gated allowed "Playground.MockRegistry:MockTransferPreapproval" preDisc
 
 ----------------------------------------------------------------------
 -- preparePublish (Playground.Ops:publishMessage's resolver half)

--- a/canton/test/daml/Test/TestDisclose.daml
+++ b/canton/test/daml/Test/TestDisclose.daml
@@ -52,6 +52,7 @@ testMappedPlaygroundTemplatesResolve : Script ()
 testMappedPlaygroundTemplatesResolve = do
   results <- mapA tryToDisclosureByName
     [ "pkg:Wormhole.Ntt.Manager:NttManager"
+    , "pkg:Wormhole.Ntt.Manager:AdminTransferProposal"
     , "pkg:Wormhole.Ntt.Governance:NttGovernance"
     , "pkg:Wormhole.Ntt.Ledger:LockedLedger"
     , "pkg:Wormhole.Core.State:CoreState"
@@ -63,7 +64,7 @@ testMappedPlaygroundTemplatesResolve = do
     , "pkg:Test.TestNtt:MockBurnMintFactory"
     , "pkg:Test.TestNtt:Cip56MockHolding"
     ]
-  results === replicate 11 "mapped"
+  results === replicate 12 "mapped"
 
 -- | A genuinely unmapped templateId still aborts loudly rather than silently dropping the
 -- disclosure the submit needs.

--- a/canton/test/daml/Test/TestPlayground.daml
+++ b/canton/test/daml/Test/TestPlayground.daml
@@ -12,10 +12,13 @@ module Test.TestPlayground where
 
 import Daml.Script
 import DA.Assert ((===))
+import DA.Map qualified as Map
 import DA.Optional (fromSome)
 import DA.Text (isInfixOf)
 import DA.Time (hours, addRelTime)
 import DA.TextMap qualified as TextMap
+
+import DA.Text (isInfixOf)
 
 import Splice.Api.Token.HoldingV1 (InstrumentId (..))
 import Splice.Api.Token.MetadataV1
@@ -24,19 +27,25 @@ import Splice.Api.Token.TransferInstructionV1
   ( TransferFactory, TransferFactory_Transfer (..), Transfer (..)
   , TransferInstructionResult_Output (..) )
 import Wormhole.Core.Bytes (leftPadTo, normalizeHex)
+import Wormhole.Core.Replay (defaultSplitThreshold)
 import Wormhole.Ntt.Amount (trimAmount, trimAmountTo)
 import Token.CIP0056.Coin (Coin (..))
 import Token.CIP0056.CoinFactory (CoinFactory (..))
-import Wormhole.Ntt.Manager (NttTokenConfig (..))
+import Wormhole.Ntt.Ledger
+import Wormhole.Ntt.Manager (NttManager (..), NttTokenConfig (..), NttFactory (..), nttInstrumentIdFor, nttNamespaceFor)
 import Wormhole.Ntt.Payload
   ( decodeWormholeTransceiverMessage, decodeNttManagerMessage, decodeNativeTokenTransfer )
 
 import Test.TestCore (devnetGuardianPubKey)
-import Test.TestNtt (mkHolding, expectAbort, sendScaffold, nttSetup, registerHappyVAA)
+import Test.TestNtt
+  ( mkHolding, expectAbort, sendScaffold, nttSetup, registerHappyVAA, Cip56MockHolding
+  , setupFixedManager, acceptAdminHappyVAA, cantonChainId, bridgedInstrument, cip56HoldingsOwnedBy )
+import Test.TestReplay (registerReplayRoot)
 
 import Playground.Deploy
 import Playground.MockRegistry
 import Playground.Ops
+import Playground.Prepare (PrepareAcceptAdminInput (..), prepareAcceptAdmin)
 import Playground.Types
 
 ----------------------------------------------------------------------
@@ -253,6 +262,77 @@ testPlaygroundFundUserDeposits = do
   v.amount === 0.5
   v.owner === recipient
 
+----------------------------------------------------------------------
+-- Playground.Ops.mockHoldings: transferOut's in-script enumeration when the CLI leaves
+-- inputHoldingCids empty (plan §5.5 -- funding moved out to `fund`, and under
+-- --strict-participant-isolation the CLI cannot ask gg for the freshly minted holding's cid
+-- either way).
+----------------------------------------------------------------------
+
+-- | A sender who already holds a 'Test.TestNtt.Cip56MockHolding' for the deployment's
+-- instrument transfers successfully with an EMPTY 'TransferOutInput.inputHoldingCids' --
+-- 'Playground.Ops:mockHoldings' enumerates it in-script, read as the sender itself (owner is
+-- a signatory), with no disclosure at all.
+testPlaygroundTransferOutEnumeratesMockHoldingsWhenEmpty : Script ()
+testPlaygroundTransferOutEnumeratesMockHoldingsWhenEmpty = do
+  (operator, gg, csId) <- nttSetup
+  admin <- allocateParty "PlaygroundMockHoldingsAdmin"
+  (d, _discs) <- sendScaffold operator gg admin BurnMint csId
+  _holdingCid <- mkHolding gg admin d.instrumentId 1.0
+  Some mgr <- queryContractId operator d.mgrCid
+
+  out <- transferOut TransferOutInput with
+    operator
+    managerId = mgr.managerId
+    admin
+    tokenKind = "mock"
+    user = admin
+    recipientChain = 2
+    recipientAddress = leftPadTo 32 "ee"
+    sourceToken = leftPadTo 32 "dd"
+    rawAmount = 1000000
+    nonce = 0
+    consistencyLevel = 0
+    inputHoldingCids = [] -- the sender's own holding is enumerated in-script, not passed in
+    amulet = None
+    remote = None
+
+  out.emitterChain === 72
+
+-- | A sender with NO 'Cip56MockHolding' at all and an empty 'inputHoldingCids' aborts with a
+-- clear, actionable message rather than falling through to 'Transfer''s own generic
+-- insufficient-inputs failure -- catchable via 'tryFailureStatus' since 'transferOut' calls
+-- plain 'abort' directly in the Script do-block (not inside a submitted choice, so
+-- 'trySubmit'/'expectAbort' do not apply here; see 'Test.TestDisclose' for the same idiom).
+testPlaygroundTransferOutEmptyHoldingsAbortsWithoutFunding : Script ()
+testPlaygroundTransferOutEmptyHoldingsAbortsWithoutFunding = do
+  (operator, gg, csId) <- nttSetup
+  admin <- allocateParty "PlaygroundMockHoldingsNoneAdmin"
+  (d, _discs) <- sendScaffold operator gg admin BurnMint csId
+  Some mgr <- queryContractId operator d.mgrCid
+
+  res <- tryFailureStatus $ transferOut TransferOutInput with
+    operator
+    managerId = mgr.managerId
+    admin
+    tokenKind = "mock"
+    user = admin
+    recipientChain = 2
+    recipientAddress = leftPadTo 32 "ee"
+    sourceToken = leftPadTo 32 "dd"
+    rawAmount = 1000000
+    nonce = 0
+    consistencyLevel = 0
+    inputHoldingCids = []
+    amulet = None
+    remote = None
+
+  case res of
+    Left fs -> assertMsg
+      ("expected 'run `fund` first', got: " <> fs.message)
+      ("run `fund` first" `isInfixOf` fs.message)
+    Right _ -> abort "expected transferOut to abort with no holdings for the sender"
+
 -- | The recomputed outbound payload matches what 'Wormhole.Ntt.Manager.Transfer' actually
 -- publishes, and the recomputed sequence matches the pre-exercise 'Emitter.sequence' --
 -- 'transferOut''s whole reason for existing (there is no event stream to read the
@@ -412,3 +492,174 @@ testPlaygroundSetPausedRoundTrip = do
     remote = None
 
   pure ()
+
+----------------------------------------------------------------------
+-- Playground.Ops.acceptAdminTransferByVaa: the 'remote = Some seam' round trip
+-- ('Playground.Prepare:prepareAcceptAdmin'), the RemoteSeam extension accept-gg-vaa previously
+-- lacked -- both BurnMint (no ledger at all) and LockUnlock with a
+-- NON-EMPTY custody pot (the harder path the e2e suite's own "gg custody opt-in via governance
+-- VAA (lock-unlock)" subtest exercises live: the nested TransferAdmin pot move's receiver is gg
+-- itself, so prepareAcceptAdmin additionally resolves the pot holding, the committed factory,
+-- and gg's OWN standing MockTransferPreapproval). The 'remote = None' fast path is untouched by
+-- this change (Ops.daml's 'None' branch is byte-identical to before it) and stays pinned by
+-- Test.TestNtt's own 'testAcceptAdminByVaaHappyPath'/'testAcceptAdminByVaaLockUnlock' (the
+-- Wormhole.Ntt.Manager choice itself) and the CLI's e2e suite (the Playground.Ops wrapper, same
+-- deployment/executor shape 'admin accept-gg-vaa' drives in production).
+----------------------------------------------------------------------
+
+-- | The templates 'prepareAcceptAdmin' can disclose -- the full allow-list, mirroring how a
+-- real --topology-config would name every template the CLI's disclosure service ever fetches
+-- (internal/disclosure.DefaultDisclose, canton/testing/cli), not just the subset a given
+-- deployment happens to need.
+acceptAdminDiscloseTemplates : [Text]
+acceptAdminDiscloseTemplates =
+  [ "Wormhole.Ntt.Manager:NttManager"
+  , "Wormhole.Ntt.Manager:AdminTransferProposal"
+  , "Wormhole.Ntt.Governance:NttGovernance"
+  , "Wormhole.Ntt.Ledger:LockedLedger"
+  , "Wormhole.Core.State:CoreState"
+  , "Wormhole.Core.State:Emitter"
+  , "Wormhole.Core.Replay:ReplayNode"
+  , "Wormhole.Ntt.Deposit:DepositPreapproval"
+  , "Playground.MockRegistry:MockTransferPreapproval"
+  , "Playground.MockRegistry:MockPreapprovedTransferFactory"
+  , "Test.TestNtt:MockBurnMintFactory"
+  , "Test.TestNtt:Cip56MockHolding"
+  ]
+
+-- | BurnMint: 'prepareAcceptAdmin' resolves only the manager/core-state/replay-node/proposal --
+-- no ledger at all, mirroring 'acceptAdminTransferByVaa's own BurnMint branch, which needs
+-- neither. Reuses 'Test.TestNtt.setupFixedManager' (the fixed managerAddress 0x00..aa, chainId
+-- 72, factoryEpoch 0 that 'Test.TestNtt.acceptAdminHappyVAA' targets) and that same pinned VAA
+-- fixture -- a Daml Script test cannot itself produce a guardian-signed VAA, so every
+-- accept-admin test in this repo (Test.TestNtt's own included) reuses this one static fixture
+-- rather than signing one live.
+testPlaygroundAcceptAdminByVaaRemoteSeamBurnMint : Script ()
+testPlaygroundAcceptAdminByVaaRemoteSeamBurnMint = do
+  (operator, gg, _csId) <- nttSetup
+  admin <- allocateParty "AcceptSeamBurnMintAdmin"
+  executor <- allocateParty "AcceptSeamBurnMintExecutor"
+  (mgrCid, _factory, _ledgerCid) <- setupFixedManager operator gg admin BurnMint
+  Some mgr <- queryContractId operator mgrCid
+
+  _ <- proposeAdminTransferToGg ProposeAdminTransferToGgInput with
+    admin
+    managerId = mgr.managerId
+
+  seam <- prepareAcceptAdmin PrepareAcceptAdminInput with
+    guardianGovernance = gg
+    managerId = mgr.managerId
+    vaaBytes = acceptAdminHappyVAA
+    discloseTemplates = acceptAdminDiscloseTemplates
+
+  out <- acceptAdminTransferByVaa AcceptAdminTransferByVaaInput with
+    operator
+    managerId = mgr.managerId
+    executor
+    vaaBytes = acceptAdminHappyVAA
+    pubKeys = [(0, devnetGuardianPubKey)]
+    remote = Some seam
+
+  out.admin === gg
+  (_, mgrAfter) <- resolveManager operator mgr.managerId
+  mgrAfter.admin === gg
+
+-- | LockUnlock with a NON-EMPTY custody pot -- the harder path. Built directly rather than via
+-- 'Test.TestNtt.setupFixedManager', which backs its own LockUnlock fixture with
+-- 'Test.TestNtt.MockTransferFactory' -- a template distinct from this package's own
+-- 'Playground.MockRegistry.MockPreapprovedTransferFactory', the one the nested pot move
+-- actually needs (only the latter understands the 'mockTransferPreapprovalContextKey'
+-- extra-args convention 'Playground.MockRegistry's factory relies on -- see that module's
+-- header). Otherwise mirrors 'setupFixedManager's own recipe exactly: the fixed
+-- managerAddress 0x00..aa / chainId 72 / factoryEpoch 0 'acceptAdminHappyVAA' targets and a
+-- claimed replay-trie root, plus a pre-funded admin-owned custody pot seeded directly via the
+-- ledger's own 'Credit' choice (mirrors the accounting 'Test.TestNtt.testTransferAdminToGg's
+-- own fixture ends up in, minus the full lock/transfer round trip needed to get there for
+-- real) and gg's own standing 'MockTransferPreapproval' (the pot move's receiver).
+testPlaygroundAcceptAdminByVaaRemoteSeamLockUnlockNonEmptyPot : Script ()
+testPlaygroundAcceptAdminByVaaRemoteSeamLockUnlockNonEmptyPot = do
+  (operator, gg, _csId) <- nttSetup
+  admin <- allocateParty "AcceptSeamLockUnlockAdmin"
+  executor <- allocateParty "AcceptSeamLockUnlockExecutor"
+
+  let instrumentId = bridgedInstrument gg
+      managerAddress = leftPadTo 32 "aa"
+      managerId = 999
+      namespace = nttNamespaceFor instrumentId admin managerId
+
+  facCid <- submit gg do createCmd MockPreapprovedTransferFactory with admin = gg
+  let factory = TransferFactoryCid (toInterfaceContractId @TransferFactory facCid)
+
+  _ <- submit (actAs operator <> actAs admin <> actAs gg) do
+    createCmd NttManager with
+      operator
+      namespace
+      admin
+      guardianGovernance = gg
+      chainId = cantonChainId
+      managerId
+      managerAddress
+      transceiverEmitterId = 999
+      instrumentId
+      tokenConfig = LockUnlock
+      tokenDecimals = 8
+      peers = Map.empty
+      factory
+      paused = False
+      factoryEpoch = 0
+  _ <- registerReplayRoot operator gg namespace defaultSplitThreshold
+
+  -- A pre-funded admin-owned custody pot: the ledger's own 'Credit' choice (controller
+  -- operator, guardianGovernance) alone seeds a non-empty balance without a full lock/transfer
+  -- round trip.
+  potCid <- mkHolding gg admin instrumentId 0.5
+  lcid <- submit (actAs operator <> actAs gg) do
+    createCmd LockedLedger with
+      operator
+      guardianGovernance = gg
+      admin
+      managerAddress
+      balance = 0.0
+      custodyHoldingCid = None
+  _ <- submit (actAs operator <> actAs gg) do
+    exerciseCmd lcid Credit with amount = 0.5, newCustodyHint = Some potCid
+
+  -- gg's own standing pre-approval: the nested pot move's receiver is gg, and the mock
+  -- registry's factory requires the RECEIVER's standing pre-approval unless sender == receiver
+  -- (which doesn't apply here -- the sender is the deployment's admin).
+  _ <- submit gg do
+    createCmd MockTransferPreapproval with owner = gg, registryAdmin = gg, instrument = instrumentId
+
+  _ <- proposeAdminTransferToGg ProposeAdminTransferToGgInput with
+    admin
+    managerId
+
+  seam <- prepareAcceptAdmin PrepareAcceptAdminInput with
+    guardianGovernance = gg
+    managerId
+    vaaBytes = acceptAdminHappyVAA
+    discloseTemplates = acceptAdminDiscloseTemplates
+
+  out <- acceptAdminTransferByVaa AcceptAdminTransferByVaaInput with
+    operator
+    managerId
+    executor
+    vaaBytes = acceptAdminHappyVAA
+    pubKeys = [(0, devnetGuardianPubKey)]
+    remote = Some seam
+
+  out.admin === gg
+  (_, mgrAfter) <- resolveManager operator managerId
+  mgrAfter.admin === gg
+  (_, ledgerAfter) <- resolveLedger operator managerAddress
+  ledgerAfter.balance === 0.5
+
+  -- The reserve moved to gg INTACT: gg now holds exactly what the admin held before the
+  -- handoff, and the old admin holds none of it any more (mirrors the e2e suite's own
+  -- balance-conservation assertion for this same handoff).
+  ggCustody <- cip56HoldingsOwnedBy gg gg
+  case ggCustody of
+    [(_, h)] -> h.amount === 0.5
+    _ -> abort ("expected exactly one gg-owned custody holding, got: " <> show ggCustody)
+  adminCustody <- cip56HoldingsOwnedBy gg admin
+  adminCustody === []

--- a/canton/test/daml/Test/TestPlayground.daml
+++ b/canton/test/daml/Test/TestPlayground.daml
@@ -34,7 +34,8 @@ import Token.CIP0056.CoinFactory (CoinFactory (..))
 import Wormhole.Ntt.Ledger
 import Wormhole.Ntt.Manager (NttManager (..), NttTokenConfig (..), NttFactory (..), nttInstrumentIdFor, nttNamespaceFor)
 import Wormhole.Ntt.Payload
-  ( decodeWormholeTransceiverMessage, decodeNttManagerMessage, decodeNativeTokenTransfer )
+  ( decodeWormholeTransceiverMessage, decodeNttManagerMessage, decodeNativeTokenTransfer
+  , nttTokenAddressFor )
 
 import Test.TestCore (devnetGuardianPubKey)
 import Test.TestNtt
@@ -536,10 +537,10 @@ acceptAdminDiscloseTemplates =
 -- rather than signing one live.
 testPlaygroundAcceptAdminByVaaRemoteSeamBurnMint : Script ()
 testPlaygroundAcceptAdminByVaaRemoteSeamBurnMint = do
-  (operator, gg, _csId) <- nttSetup
+  (operator, gg, csId) <- nttSetup
   admin <- allocateParty "AcceptSeamBurnMintAdmin"
   executor <- allocateParty "AcceptSeamBurnMintExecutor"
-  (mgrCid, _factory, _ledgerCid) <- setupFixedManager operator gg admin BurnMint
+  (mgrCid, _factory, _ledgerCid) <- setupFixedManager operator gg admin BurnMint csId
   Some mgr <- queryContractId operator mgrCid
 
   _ <- proposeAdminTransferToGg ProposeAdminTransferToGgInput with
@@ -603,10 +604,12 @@ testPlaygroundAcceptAdminByVaaRemoteSeamLockUnlockNonEmptyPot = do
       instrumentId
       tokenConfig = LockUnlock
       tokenDecimals = 8
+      tokenAddress = nttTokenAddressFor instrumentId
       peers = Map.empty
       factory
       paused = False
       factoryEpoch = 0
+      peerEpoch = 0
       minter = None
   _ <- registerReplayRoot operator gg namespace defaultSplitThreshold
 

--- a/canton/test/daml/Test/TestPlayground.daml
+++ b/canton/test/daml/Test/TestPlayground.daml
@@ -607,6 +607,7 @@ testPlaygroundAcceptAdminByVaaRemoteSeamLockUnlockNonEmptyPot = do
       factory
       paused = False
       factoryEpoch = 0
+      minter = None
   _ <- registerReplayRoot operator gg namespace defaultSplitThreshold
 
   -- A pre-funded admin-owned custody pot: the ledger's own 'Credit' choice (controller

--- a/canton/testing/cli/README.md
+++ b/canton/testing/cli/README.md
@@ -102,7 +102,8 @@ instead of per-service compose state.
 | `emitter register --name NAME --owner HINT` | Register a standalone core-bridge `Emitter` (not tied to an NTT deployment), keyed under a CLI-local name in state. |
 | `publish --emitter NAME --payload HEX [--nonce N] [--consistency-level N] [--sign]` | Publish an arbitrary message from a registered emitter via `Emitter.PublishMessage`; `--sign` also signs the resulting VAA with the playground's guardian key. |
 | `peer set --deployment NAME --chain N --manager HEX --transceiver HEX --decimals N` | Configure (or replace) a peer for a remote chain. `--decimals` (required, 1-255) is the peer chain token's decimals: outbound transfers to that peer trim to `min(8, tokenDecimals, peerDecimals)` and reject any amount that doesn't round-trip exactly at that precision ("dust the peer cannot represent"). |
-| `transfer --deployment NAME --user HINT --chain N --recipient-address HEX --amount N [--sign] [--tap-usd USD]` | Outbound `NttManager.Transfer`. For `mock`, ensures the sender has a standing pre-approval (`preapprove`) and funds it (`fundUser`) before transferring. Prints the recomputed published message (bit-exact — same encoders the manager used internally); `--sign` also signs the resulting VAA with the playground's guardian key. For `amulet` the sender is onboarded as a real validator wallet user and tapped (`--tap-usd`, default `"100"`, `"0"` skips) before the real transfer-factory is resolved; the receiver is the deployment's admin (custody is admin-owned). Rejected while the deployment is paused ("deployment is paused"), and rejected if `--amount` doesn't round-trip exactly at the destination peer's configured decimals (dust). |
+| `transfer --deployment NAME --user HINT --chain N --recipient-address HEX --amount N [--sign] [--tap-usd USD] [--no-fund]` | Outbound `NttManager.Transfer`. For `mock`, ensures the sender has a standing pre-approval (`preapprove`) and funds it (`fundUser`) before transferring, unless `--no-fund` (always implied by `--strict-participant-isolation`) is set, in which case the sender's own holdings are enumerated in-script instead — see [Disclosure service](#disclosure-service). Prints the recomputed published message (bit-exact — same encoders the manager used internally); `--sign` also signs the resulting VAA with the playground's guardian key. For `amulet` the sender is onboarded as a real validator wallet user and tapped (`--tap-usd`, default `"100"`, `"0"` skips) before the real transfer-factory is resolved; the receiver is the deployment's admin (custody is admin-owned). Rejected while the deployment is paused ("deployment is paused"), and rejected if `--amount` doesn't round-trip exactly at the destination peer's configured decimals (dust). |
+| `fund --deployment NAME --user HINT --amount N` | Mock-kind-only faucet: ensure the recipient's standing pre-approval, then mint via `Playground.Ops:fundUser` (`guardian-governance`-submitted — gg is the mint's sole signatory). The `preapprove`+`fundUser` block that used to be welded into `transfer`, split out as its own operator-side command — see [Disclosure service](#disclosure-service). |
 | `receive --deployment NAME --vaa HEX --recipient HINT --pubkey HEX [--executor HINT]` | Relay a signed VAA through `NttManager.Mint`/`Release`, executor-only. A replayed VAA exits non-zero. The recipient must have run `preapprove` first — for both burn-mint and lock-unlock `mock` deployments — else the delivery is rejected and the VAA stays deliverable. Rejected outright for `amulet` (receiving against real Amulet is out of scope), and rejected while the deployment is paused. |
 | `preapprove --deployment NAME --user HINT` | Opt a recipient in to inbound deliveries: a standing `DepositPreapproval` (burn-mint `mock`) or `MockTransferPreapproval` (lock-unlock `mock`), created self-signed by the recipient. Idempotent. For `amulet` this is a ledger-surfaced no-op (`preapproved=false`); real Amulet's own `TransferPreapproval` is out of scope here. |
 | `preapprove revoke --deployment NAME --user HINT` | Tear down a recipient's standing pre-approval (owner-only `Revoke`, either template). |
@@ -120,6 +121,7 @@ instead of per-service compose state.
 | `observe --deployment NAME` | Print one deployment's current outbound sequence, `chainId`, peers (with `decimals`), and `paused` state. |
 | `observe stream --deployment NAME [--from-offset N] [--count N] [--timeout DUR] [--print-offset] [--any-emitter]` | LocalNet only. Read the REAL Ledger API v2 update stream as a dedicated `guardian-watcher` reader user (granted only `CanReadAs(guardianObserver)`, never `actAs`) and print every observed `WormholeMessage` as JSON. `--print-offset` prints the current ledger end (`ledgerEnd=<n>`) and exits, for recording a starting point before a transfer. Filters by the deployment's derived transceiver address unless `--any-emitter`. |
 | `balance --party HINT --deployment NAME` | Print a party's mock/CIP-56 holdings for a deployment, or (for `amulet`) its real Amulet holdings (`amuletHoldingTotal=...`). Custody is admin-owned, so a deployment's own admin hint (the config's `adminHint`, or `<name>-admin` by default) resolves the custodian's own balance — it's a wallet user's real party for `amulet`, an ordinary CLI-allocated party otherwise. |
+| `disclosure serve [--listen ADDR] [--participant ROLE]` | Serve the read-only disclosure service (`GET /v1/healthz`, `GET /v1/disclosures?template=...`, `POST /v1/seam/{transferOut,receive,publish,acceptAdminTransfer}`) fronting one participant (default `--participant guardian-governance`). Only meaningful on `localnet` (the sandbox profile has a single participant, so there is never a cross-participant fetch to serve, and its generic `/v1/disclosures` endpoint 503s there for lack of a JSON Ledger API). Binds `127.0.0.1:7599` by default; a non-loopback `--listen` prints a startup warning rather than silently exposing allow-listed contract payloads — see [Disclosure service](#disclosure-service). |
 
 Every command accepts `--verbose`: each sub-step — network bring-up details,
 party allocation/actAs grants, every `dpm script` invocation with its input and
@@ -229,14 +231,22 @@ the same VAA fails as a replay (the digest was already consumed in `gg`'s
 replay trie), and `receive` against the deployment continues to work
 unchanged — the handoff repoints custody only, nothing on the wire.
 
-Both `admin` subcommands run the sandbox-first `remote = None` path
-`Playground.Ops:acceptAdminTransferByVaa` supports today: this works
-unmodified on the single-participant `sandbox` profile. On a multi-participant
-`localnet` topology, `admin accept-gg-vaa` needs the executing participant to
-see operator/admin/`gg`'s contracts directly, so pass an `--executor` hint
-already co-located with them (the default, no `--executor`, stays on the
-operator's own participant). A `RemoteSeam` extension mirroring `receive`'s
-(see [Topology](#topology)) is follow-up work.
+`admin propose-gg` is single-party (it reads and submits as the deployment's
+CURRENT admin alone), so it never needs a `RemoteSeam` — instead the CLI routes
+the whole call to that admin's own participant, which is operator's under the
+default topology pre-handoff, and `gg`'s own once a prior `accept-gg-vaa` has
+completed. `admin accept-gg-vaa` gets the same `RemoteSeam` treatment `transfer`/`receive`
+already have (see [Topology](#topology)): on the single-participant `sandbox`
+profile it takes the unmodified `remote = None` fast path
+`Playground.Ops:acceptAdminTransferByVaa` has always supported; on a
+multi-participant `localnet` topology, whenever the relaying `--executor`'s
+participant differs from `gg`'s (unconditionally the case there, since gg is
+its own participant), the CLI fetches a `RemoteSeam` via
+`Playground.Prepare:prepareAcceptAdmin` first — either by running that script
+directly against `gg`'s own participant, or, with `--disclosure-service-url`
+set, over HTTP against the disclosure service (see
+[Disclosure service](#disclosure-service)) — exactly like `transfer`/`receive`
+do.
 
 ### Real Amulet (`amulet`)
 
@@ -277,7 +287,7 @@ Canton Coin locks/unlocks, not a mock registry. Requires `--profile localnet`
 
 ## Topology
 
-On the `localnet` profile the playground runs across **five participants**,
+On the `localnet` profile the playground runs across **six participants**,
 not one — this is what makes Daml's privacy model observable: a party only
 sees the contracts it is a stakeholder or disclosure-recipient on, and only
 its own home participant can act as it.
@@ -289,15 +299,19 @@ its own home participant can act as it.
 | `bob` | Bob | 5901 | 5975 | 5903 |
 | `guardian-governance` | GuardianGovernance | 6901 | 6975 | 6903 |
 | `guardian-observer` | GuardianObserver | 7901 | 7975 | 7903 |
+| `alice-solo` | whichever hint a `--topology-config` explicitly routes there (e.g. `Zoe` in `testdata/topology-alice-solo.json`) — not part of the built-in `partyHosting` default, so no hint lands here unless a config says so | 8901 | 8975 | 8903 |
 
 `app-provider` and `app-user` are participants the Splice LocalNet bundle
-already runs; `bob`, `guardian-governance`, and `guardian-observer` are added
-by a compose override the CLI writes into the LocalNet directory (alongside
-the existing Postgres-container override) — the vendored bundle itself is
-never edited. Every participant runs the same unsafe shared-secret HS256
-auth as `app-provider` and is reachable through the same `ledger-api-user`
-admin user, so `party list`, `balance --party`, and every other per-party
-command transparently target the right participant.
+already runs; `bob`, `guardian-governance`, `guardian-observer`, and
+`alice-solo` are added by a compose override the CLI writes into the
+LocalNet directory (alongside the existing Postgres-container override) —
+the vendored bundle itself is never edited. Every participant runs the same
+unsafe shared-secret HS256 auth as `app-provider` and is reachable through
+the same `ledger-api-user` admin user, so `party list`, `balance --party`,
+and every other per-party command transparently target the right
+participant. `alice-solo` exists to prove a fresh participant hosting no
+playground party but the one the test allocates can still transact — see
+[Disclosure service](#disclosure-service).
 
 `--topology-config` (see below) controls which party hint lands on which
 participant; the table above is the built-in default when no config file
@@ -318,11 +332,12 @@ explicit disclosure for before a cross-participant submit (`disclose`).
 Default path when the flag is omitted: `playground.topology.json` next to
 the state file. A missing file is not an error — it resolves to the
 built-in `partyHosting` default (the table above) and a built-in `disclose`
-default covering every template a `mock` deployment's `transfer`/`receive`
-path needs (`NttManager`, `NttGovernance`, `LockedLedger`, `CoreState`,
-`Emitter`, the covering `ReplayNode`, `DepositPreapproval`,
-`MockTransferPreapproval`, `MockPreapprovedTransferFactory`,
-`CoinFactory`, `Cip56MockHolding`) — otherwise the CLI's basic
+default covering every template a `mock` deployment's `transfer`/`receive`/
+`admin accept-gg-vaa` path needs (`NttManager`, `NttGovernance`,
+`LockedLedger`, `CoreState`, `Emitter`, the covering `ReplayNode`,
+`DepositPreapproval`, `MockTransferPreapproval`,
+`MockPreapprovedTransferFactory`, `CoinFactory`, `Cip56MockHolding`,
+`AdminTransferProposal`) — otherwise the CLI's basic
 `deploy`/`transfer`/`receive` flow would fail out of the box on LocalNet with
 no config file at all. The "everything fails closed" posture (no disclosures
 ever fetched, so any submit that needs to read a contract off another
@@ -398,6 +413,92 @@ topology split delivers: an operator acting alone cannot produce a
 `CoreState` GuardianGovernance never saw and never authorized, and vice
 versa.
 
+## Disclosure service
+
+`ntt-playground disclosure serve` runs a small, stateless, read-only HTTP
+service that fronts one participant (default `guardian-governance`) and owns
+the disclosure allow-list on the server side, rather than trusting whichever
+CLI happens to be asking. It exposes:
+
+- `GET /v1/healthz` — `{"participant":"...","templates":[...],"ledgerEnd":<offset>}`.
+- `GET /v1/disclosures?template=<Module:Entity>[&template=...]` — a generic
+  ACS export over the JSON Ledger API v2 (`includeCreatedEventBlob: true`),
+  returning each allow-listed contract's id, hex-encoded blob, and decoded
+  create argument at the offset the read was pinned to. A template not on
+  the service's own allow-list is refused with 403, naming the offender,
+  rather than silently served.
+- `POST /v1/seam/{transferOut|receive|publish|acceptAdminTransfer}` — runs the
+  same `Playground.Prepare:prepare*` script `transfer`/`receive`/`publish`/
+  `admin accept-gg-vaa` already run locally, and returns the resulting
+  `RemoteSeam` JSON verbatim. The service injects its own `discloseTemplates`
+  allow-list into the script input server-side, ignoring whatever the client
+  sent — the server, not the caller, decides what gets disclosed.
+
+**Why.** Before this service existed, a consumer's CLI had to hold the data
+owner's participant credentials (an admin JWT for `guardian-governance`) to
+fetch a `RemoteSeam` — it could read gg's entire ACS and submit as gg. With
+the service, a consumer holds only its own participant's credentials and can
+obtain nothing beyond the allow-listed templates, read-only. This is a
+privilege reduction, not new functionality: the same `RemoteSeam`/
+`Disclosure` mechanism ([Topology](#topology) above) is retained end to end;
+only who holds which credentials to fetch it changes.
+
+**Client side.** Two root persistent flags:
+
+- `--disclosure-service-url URL` — when set, any command that would
+  otherwise run a `prepare*` script directly against the data owner's own
+  participant instead fetches the `RemoteSeam` over HTTP from the disclosure
+  service at `URL`. Empty (the default) is byte-identical to pre-service
+  behavior.
+- `--strict-participant-isolation` — an opt-in guard: any step that would
+  target a participant other than the actor's own fails immediately, naming
+  both roles, instead of silently succeeding because the CLI happens to hold
+  every participant's credentials. It is the negative control that proves a
+  flow genuinely needs `--disclosure-service-url` rather than admin access it
+  should not have. Commands that legitimately span participants by design —
+  `init`, `deploy`, `fund`, `party` — never set an isolation baseline, so the
+  guard can never fire for them regardless of this flag; they are simply
+  incompatible with the isolation model, not broken by it.
+
+**`fund`.** `fund --deployment NAME --user HINT --amount N` is the mock
+faucet (`preapprove` + `Playground.Ops:fundUser`) split out of `transfer`,
+because minting is a `guardian-governance`-side submit — gg is the mint's
+sole signatory — that no disclosure service can stand in for (a
+`DisclosedContract` grants visibility, never authority). It is correctly an
+operator/faucet action, run by whoever legitimately holds gg's credentials.
+`transfer --no-fund` (implied automatically by
+`--strict-participant-isolation`) skips that block and leaves the transfer's
+input holdings empty; `Playground.Ops:transferOut`'s Mock branch then
+enumerates the sender's own holdings in-script, which needs no
+cross-participant disclosure at all.
+
+**Security posture — stated plainly.** This is a harness-grade
+implementation, not a production one: no authentication, no TLS. It binds
+`127.0.0.1` by default; passing `--listen` with a non-loopback address prints
+a warning at startup instead of silently exposing allow-listed contract
+payloads to anything that can reach it. It is still a strict improvement over
+today's baseline (the CLI holding the fronted participant's admin JWT
+outright), but a production deployment needs, at minimum: mTLS or OAuth
+client-credentials auth, per-consumer (not global) allow-lists, rate
+limiting, and an audit log of `(consumer, template, contract id, offset)`.
+Do not point `--listen` at anything but loopback outside a test/harness
+context.
+
+```sh
+# operator side, holding guardian-governance's own credentials:
+./ntt-playground --profile localnet disclosure serve
+# disclosure serve: fronting participant=guardian-governance templates=11
+# disclosure serve: unauthenticated harness-grade service; keep it loopback-bound unless you know why
+# disclosure serve: listening on http://127.0.0.1:7599
+
+# consumer side, holding only its own participant's credentials:
+./ntt-playground --profile localnet \
+  --disclosure-service-url http://127.0.0.1:7599 \
+  --strict-participant-isolation \
+  transfer --deployment burnmint --user Zoe --chain 2 \
+  --recipient-address 00..ee --amount 500000 --sign
+```
+
 ## Profiles
 
 ### sandbox (default)
@@ -450,7 +551,7 @@ instead; set `LOCALNET_POSTGRES_CONTAINER_NAME` / `LOCALNET_POSTGRES_HOST_PORT`
 to change either. In-network connectivity is unaffected — services resolve the
 database by compose service name. Requires docker compose >= 2.24 (`!override`).
 
-See [Topology](#topology) above for the five-participant layout this profile
+See [Topology](#topology) above for the six-participant layout this profile
 runs. Auth is LocalNet's documented "unsafe" shared-secret HS256 mode (never
 valid against a real participant); the CLI mints tokens for
 `ledger-api-user` automatically, on every participant.
@@ -553,8 +654,12 @@ Documented, not implemented — this CLI is devnet-only throughout.
   Amulet directly (it has no `BurnMintFactory`).
 - **Disclosures.** The `queryDisclosure`/`coveringDisclosure` pattern this CLI
   uses (reading as guardianGovernance or operator, whichever party owns the
-  data) is replaced by an off-ledger disclosure service over an ACS index, as
-  described in the core bridge's README.
+  data) is fronted, in this CLI, by a harness-grade disclosure service
+  (`ntt-playground disclosure serve` — see
+  [Disclosure service](#disclosure-service)). A production deployment needs
+  the hardening that service deliberately skips: mTLS or OAuth
+  client-credentials auth, per-consumer (not global) allow-lists, rate
+  limiting, and an audit log, as described in the core bridge's README.
 
 ## Follow-ups
 
@@ -566,5 +671,3 @@ Out of scope for this CLI, listed here rather than silently dropped:
 - Demoting `gg` by governance VAA (`admin accept-gg-vaa` only covers an
   ordinary admin handing the role TO `gg`; `gg` handing it back still needs
   the direct `TransferAdmin` path — see the core NTT README's follow-ups).
-- A `RemoteSeam` extension for `admin accept-gg-vaa` on the multi-participant
-  `localnet` topology (see [Guardian custody opt-in](#guardian-custody-opt-in)).

--- a/canton/testing/cli/TESTING.md
+++ b/canton/testing/cli/TESTING.md
@@ -11,12 +11,15 @@ Run everything from this directory (`canton/testing/cli`).
 | Tier | Needs |
 |------|-------|
 | unit, daml, e2e-sandbox | `dpm` on `PATH`, Go, `just` |
-| e2e-localnet | the above **plus** Docker Desktop (>= 24 GB RAM) |
+| e2e-localnet | the above **plus** Docker Desktop (>= 28 GB RAM) |
 
 - `dpm` (Daml toolchain) — the recipes add `~/.dpm/bin` to `PATH` for you.
 - `just` — `brew install just`.
-- Docker memory: give Docker **>= 24 GB** (Settings -> Resources -> Memory). Below that,
-  the Splice stack's Postgres boots unhealthy and the run fails at network-up.
+- Docker memory: give Docker **>= 28 GB** (Settings -> Resources -> Memory), up from the
+  previous >= 24 GB floor. A sixth Canton participant (`alice-solo`, fronting the disclosure
+  service's fresh-participant scenario) pushed the shared `canton` container's `mem_limit`
+  from `10g` to `12g` and its `-Xmx` from `7g` to `8g` (`internal/network/localnet_participants_override.yaml`).
+  Below the floor, the Splice stack's Postgres boots unhealthy and the run fails at network-up.
 - An extracted `splice-node/docker-compose/localnet` from a Splice release bundle (e.g.
   `0.6.12_splice-node.tar.gz`). `LOCALNET_DIR` is optional: the CLI auto-discovers the bundle at
   one of these paths, in order, and only needs the env var if none of them apply:
@@ -47,17 +50,29 @@ just e2e-localnet    # full e2e on real LocalNet      (Docker, ~15 min)
 
 `e2e-sandbox` runs the whole suite in-process, against a single in-process
 participant; the LocalNet-only subtests self-skip. `e2e-localnet` runs the
-complete suite against the real 5-participant topology (see the CLI
+complete suite against the real 6-participant topology (see the CLI
 README's [Topology](README.md#topology) section) including the real Canton
 Coin/Amulet custody transfer, the Ledger API v2 stream observer (read from
 the guardian-observer participant), and the cross-participant disclosure
 mechanism (`--topology-config`, exercised via `testdata/topology-*.json`) —
 this is the only tier that actually proves a party allocated on one
 participant is invisible to another absent an explicit disclosure entry.
+The sixth participant, `alice-solo` (`testdata/topology-alice-solo.json`),
+boots and receives the DAR alongside the rest of the topology; the disclosure
+service itself (`ntt-playground disclosure serve` — see the CLI README's
+[Disclosure service](README.md#disclosure-service) section) and the `fund`
+command it depends on are covered in the no-Docker `unit` tier
+(`internal/disclosure`, `cmd/ntt-playground/cmd_wiring_test.go`,
+`internal/network/localnet_test.go`, `internal/profile/profile_test.go`), and
+end to end — a real `disclosure serve` subprocess fronting a fresh
+alice-solo party through a transfer/receive round trip, plus a dedicated
+allow-list-enforcement negative control — by `e2e-localnet`'s own
+"fresh participant transacts via the disclosure service" and "disclosure
+service enforces the allow-list server-side" subtests.
 
 ## Step by step: the LocalNet run
 
-1. Give Docker >= 24 GB and make sure it is running.
+1. Give Docker >= 28 GB and make sure it is running.
 2. Make your extracted bundle discoverable: either extract it to one of the standard paths
    (see Prerequisites above), or point `LOCALNET_DIR` at it explicitly:
    ```sh
@@ -87,7 +102,7 @@ just localnet-down     # tear it down (also cleans up after an interrupted run)
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| `splice-localnet-postgres is unhealthy`, `docker compose up failed` | Docker VM too small / host RAM thrashing | Give Docker >= 24 GB; free host RAM; retry |
+| `splice-localnet-postgres is unhealthy`, `docker compose up failed` | Docker VM too small / host RAM thrashing | Give Docker >= 28 GB; free host RAM; retry |
 | `UNAVAILABLE: Connection reset` / `CoordinatedShutdown` mid-run | ledger dropped under memory pressure | same as above — it is resources, not the tests |
 | sandbox run fails ~3 min in, ports `6864-6869` in use | a stale `ntt-playground` sandbox process from a killed run | `pkill -f ntt-playground`, rerun |
 | `nginx ... host not found in upstream "ans-web-ui-app-user"` at boot | cosmetic — the web-UI proxy; the CLI uses the gRPC ledger directly | ignore; tests are unaffected |

--- a/canton/testing/cli/cmd/ntt-playground/admin.go
+++ b/canton/testing/cli/cmd/ntt-playground/admin.go
@@ -153,6 +153,7 @@ func newAdminAcceptGgVaaCmd(a *app) *cobra.Command {
 			// baseline (runner.go), immediately after it is known and before
 			// prepareRemoteSeam below (which may need to cross a participant boundary).
 			a.isolationBaselineRole = executorRole
+			a.isolationBaselineSet = true
 
 			// The data owner for a Mock-kind prepare fetch is gg's OWN participant, not
 			// operator's -- see remote.go's doc comment and receive.go's identical reasoning.

--- a/canton/testing/cli/cmd/ntt-playground/admin.go
+++ b/canton/testing/cli/cmd/ntt-playground/admin.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -9,9 +10,12 @@ import (
 )
 
 // proposeAdminTransferToGgInput/proposeAdminTransferToGgOutput mirror Playground.Ops.daml's
-// ProposeAdminTransferToGgInput/ProposeAdminTransferToGgOutput.
+// ProposeAdminTransferToGgInput/ProposeAdminTransferToGgOutput. Admin is the deployment's
+// CURRENT admin (Deployment.CurrentAdminOrAdmin()), not operator: the script is single-party --
+// reads and submits as Admin alone -- which is what lets the CLI route the whole call to
+// Admin's own participant (see newAdminProposeGgCmd's doc comment).
 type proposeAdminTransferToGgInput struct {
-	Operator  string `json:"operator"`
+	Admin     string `json:"admin"`
 	ManagerID int    `json:"managerId"`
 }
 
@@ -28,6 +32,9 @@ type acceptAdminTransferByVaaInput struct {
 	Executor  string              `json:"executor"`
 	VaaBytes  string              `json:"vaaBytes"`
 	PubKeys   []ledger.PubKeyHint `json:"pubKeys"`
+	// Remote carries a pre-fetched Playground.Prepare:prepareAcceptAdmin RemoteSeam, as raw
+	// JSON -- see transferOutInput.Remote's doc comment (transfer.go).
+	Remote json.RawMessage `json:"remote"`
 }
 
 type acceptAdminTransferByVaaOutput struct {
@@ -37,14 +44,20 @@ type acceptAdminTransferByVaaOutput struct {
 
 // newAdminCmd builds the `admin` command group: the two halves of the VAA-gated gg custody
 // opt-in (Wormhole.Ntt.Manager's header) -- `propose-gg` (the current admin's standing offer)
-// and `accept-gg-vaa` (permissionlessly relaying the guardians' signed acceptance). Neither
-// subcommand builds a Playground.Disclose.RemoteSeam: both run the sandbox-first `remote =
-// None` path Playground.Ops:acceptAdminTransferByVaa supports today (see that script's doc
-// comment). This works unmodified on the single-participant sandbox profile; on a
-// multi-participant LocalNet topology, `accept-gg-vaa` needs the executing participant to see
-// operator/admin/guardianGovernance's contracts directly, so pass an `--executor` hint that
-// resolves to a party already co-located with them (the default, no `--executor`, stays on the
-// operator's own participant). A RemoteSeam extension mirroring `receive`'s is follow-up work.
+// and `accept-gg-vaa` (permissionlessly relaying the guardians' signed acceptance). `propose-gg`
+// is single-party (Playground.Ops:proposeAdminTransferToGg reads AND submits as the CURRENT
+// admin alone), so it routes the whole script run to THAT party's own participant --
+// participantRoleForParty(s, d.CurrentAdminOrAdmin()) -- rather than the default runner: before
+// any handoff the current admin is the registering admin, co-located with operator under the
+// default topology, so this is byte-identical to before; after a successful `accept-gg-vaa` the
+// current admin is guardianGovernance, hosted on its own participant, and the old
+// always-default-participant routing would fail PERMISSION_DENIED there (the bug a second
+// propose/accept cycle post-handoff exposed). `accept-gg-vaa` gets the standard prepareRemoteSeam
+// treatment mirroring `receive`'s (see remote.go): the actor (the relaying `--executor`, or
+// operator by default) and the data owner (guardianGovernance) are compared, and a RemoteSeam is
+// fetched via Playground.Prepare:prepareAcceptAdmin whenever they differ -- unconditionally the
+// case on a multi-participant LocalNet topology once guardianGovernance became its own
+// participant, where no single participant hosts both operator and gg.
 func newAdminCmd(a *app) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "admin",
@@ -71,19 +84,24 @@ func newAdminProposeGgCmd(a *app) *cobra.Command {
 				return fmt.Errorf("admin propose-gg: unknown deployment %q", deployment)
 			}
 
-			// The proposal is a self-signed create by the CURRENT admin; the deployment's
-			// admin is co-located with operator under the default topology (mirrors
-			// `deploy`'s deployNtt routing), so the default runner suffices.
-			runner, cleanup, err := a.newScriptRunner(ctx)
+			// The proposal is a self-signed create by the CURRENT admin -- route the script
+			// run to THAT party's own participant, not the default one: pre-handoff this is
+			// the registering admin (co-located with operator under the default topology,
+			// participantRoleForParty resolves "" -- unchanged from before this fix); after a
+			// successful `accept-gg-vaa` it is guardianGovernance, hosted elsewhere (see
+			// newAdminCmd's doc comment).
+			adminParty := d.CurrentAdminOrAdmin()
+			role := participantRoleForParty(s, adminParty)
+			runner, cleanup, err := a.newScriptRunnerFor(ctx, role)
 			if err != nil {
 				return err
 			}
 			defer cleanup()
 
-			a.vlogf(cmd, "admin propose-gg: deployment=%s admin=%s -> guardianGovernance=%s", deployment, d.CurrentAdminOrAdmin(), s.GuardianGovernance)
+			a.vlogf(cmd, "admin propose-gg: deployment=%s admin=%s -> guardianGovernance=%s", deployment, adminParty, s.GuardianGovernance)
 			var out proposeAdminTransferToGgOutput
 			if err := runner.Run(ctx, "Playground.Ops:proposeAdminTransferToGg", proposeAdminTransferToGgInput{
-				Operator:  s.Operator,
+				Admin:     adminParty,
 				ManagerID: d.ManagerID,
 			}, &out); err != nil {
 				return err
@@ -119,9 +137,8 @@ func newAdminAcceptGgVaaCmd(a *app) *cobra.Command {
 			}
 
 			// executor defaults to the Operator (stays on the default/app-provider
-			// participant); an explicit --executor routes the submit to THAT hint's own
-			// participant instead -- mirrors `receive`'s executor routing, minus the
-			// RemoteSeam fallback (see newAdminCmd's doc comment).
+			// participant, executorRole=""); an explicit --executor routes the submit to
+			// THAT hint's own participant instead -- mirrors `receive`'s executor routing.
 			executorParty := s.Operator
 			executorRole := ""
 			if executorHint != "" {
@@ -130,6 +147,26 @@ func newAdminAcceptGgVaaCmd(a *app) *cobra.Command {
 					return err
 				}
 				executorRole = s.UserParticipants[executorHint]
+			}
+
+			// Record the actor's participant role as the --strict-participant-isolation
+			// baseline (runner.go), immediately after it is known and before
+			// prepareRemoteSeam below (which may need to cross a participant boundary).
+			a.isolationBaselineRole = executorRole
+
+			// The data owner for a Mock-kind prepare fetch is gg's OWN participant, not
+			// operator's -- see remote.go's doc comment and receive.go's identical reasoning.
+			ownerRole := participantRoleForParty(s, s.GuardianGovernance)
+			remoteSeam, err := prepareRemoteSeam(ctx, cmd, a, s, executorRole, ownerRole, "Playground.Prepare:prepareAcceptAdmin", "acceptAdminTransfer", func(templates []string) any {
+				return prepareAcceptAdminInput{
+					GuardianGovernance: s.GuardianGovernance,
+					ManagerID:          d.ManagerID,
+					VaaBytes:           vaaHex,
+					DiscloseTemplates:  templates,
+				}
+			})
+			if err != nil {
+				return fmt.Errorf("admin accept-gg-vaa: prepare remote disclosure: %w", err)
 			}
 
 			runner, cleanup, err := a.newScriptRunnerFor(ctx, executorRole)
@@ -146,6 +183,7 @@ func newAdminAcceptGgVaaCmd(a *app) *cobra.Command {
 				Executor:  executorParty,
 				VaaBytes:  vaaHex,
 				PubKeys:   []ledger.PubKeyHint{{Index: 0, Key: pubKeyHex}},
+				Remote:    remoteSeam,
 			}, &out); err != nil {
 				return err
 			}

--- a/canton/testing/cli/cmd/ntt-playground/cmd_wiring_test.go
+++ b/canton/testing/cli/cmd/ntt-playground/cmd_wiring_test.go
@@ -1290,9 +1290,12 @@ func TestCmd_AdminAcceptGgVaa_DisclosureServiceURL_UsesAcceptAdminSeam(t *testin
 // TestNewScriptRunnerFor_StrictIsolationGuard is a focused unit test of the guard itself
 // (normalizeRole comparison), bypassing any subcommand: strict isolation with a recorded
 // baseline that differs from the target role must error naming
-// "strict-participant-isolation"; an empty baseline (no actor-routing command in play, e.g.
-// init/deploy/fund/party -- design doc §7 R8) must never trip the guard, even against a
-// participant role that would otherwise differ from the profile's default.
+// "strict-participant-isolation" -- including when the recorded baseline is "" (an actor on
+// the profile's DEFAULT participant, e.g. receive/accept-gg-vaa with no --executor), which
+// normalizeRole resolves to the default participant rather than treating as "guard off". Only
+// an UNSET baseline (no actor-routing command in play, e.g. init/deploy/fund/party -- design
+// doc §7 R8) must never trip the guard, even against a participant role that would otherwise
+// differ from the profile's default.
 func TestNewScriptRunnerFor_StrictIsolationGuard(t *testing.T) {
 	r := newFakeRunner()
 
@@ -1301,19 +1304,33 @@ func TestNewScriptRunnerFor_StrictIsolationGuard(t *testing.T) {
 		profile:                    profile.LocalNet,
 		strictParticipantIsolation: true,
 		isolationBaselineRole:      "app-user",
+		isolationBaselineSet:       true,
 	}
 	if _, _, err := blocked.newScriptRunnerFor(context.Background(), "guardian-governance"); err == nil || !contains(err.Error(), "strict-participant-isolation") {
 		t.Fatalf("expected a strict-participant-isolation error for a cross-participant target, got %v", err)
+	}
+
+	defaultActor := &app{
+		runnerOverride:             r,
+		profile:                    profile.LocalNet,
+		strictParticipantIsolation: true,
+		isolationBaselineRole:      "",
+		isolationBaselineSet:       true,
+	}
+	if _, _, err := defaultActor.newScriptRunnerFor(context.Background(), "guardian-governance"); err == nil || !contains(err.Error(), "strict-participant-isolation") {
+		t.Fatalf("expected a strict-participant-isolation error for a default-participant actor targeting another participant, got %v", err)
+	}
+	if _, _, err := defaultActor.newScriptRunnerFor(context.Background(), ""); err != nil {
+		t.Fatalf("expected no error for a default-participant actor targeting the default participant, got %v", err)
 	}
 
 	noBaseline := &app{
 		runnerOverride:             r,
 		profile:                    profile.LocalNet,
 		strictParticipantIsolation: true,
-		isolationBaselineRole:      "",
 	}
-	if _, _, err := noBaseline.newScriptRunnerFor(context.Background(), ""); err != nil {
-		t.Fatalf("expected no error with an empty isolationBaselineRole (no actor-routing command in play), got %v", err)
+	if _, _, err := noBaseline.newScriptRunnerFor(context.Background(), "guardian-governance"); err != nil {
+		t.Fatalf("expected no error with an unset baseline (no actor-routing command in play), got %v", err)
 	}
 }
 

--- a/canton/testing/cli/cmd/ntt-playground/cmd_wiring_test.go
+++ b/canton/testing/cli/cmd/ntt-playground/cmd_wiring_test.go
@@ -2,12 +2,17 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/wormholelabs-xyz/native-token-transfers/canton/testing/cli/internal/profile"
 	"github.com/wormholelabs-xyz/native-token-transfers/canton/testing/cli/internal/state"
 )
 
@@ -857,7 +862,10 @@ func TestCmd_AdminProposeGg_UnknownDeployment(t *testing.T) {
 }
 
 // TestCmd_AdminProposeGg_CallsProposeAdminTransferToGg pins the script name + routing:
-// Playground.Ops:proposeAdminTransferToGg, called with the deployment's managerId.
+// Playground.Ops:proposeAdminTransferToGg, called with the deployment's managerId and (with
+// CurrentAdmin unset) the REGISTERING admin as the input's Admin field -- the pre-handoff case,
+// which must stay byte-identical to before this fix (default routing, registering admin
+// co-located with operator under the default topology).
 func TestCmd_AdminProposeGg_CallsProposeAdminTransferToGg(t *testing.T) {
 	stateFile := filepath.Join(t.TempDir(), "playground.state.json")
 	s := state.New()
@@ -883,11 +891,53 @@ func TestCmd_AdminProposeGg_CallsProposeAdminTransferToGg(t *testing.T) {
 	if !ok {
 		t.Fatalf("proposeAdminTransferToGg input type mismatch: %T", r.calls[0].Input)
 	}
-	if in.Operator != "operator::abc" || in.ManagerID != 3 {
+	if in.Admin != "ntt1-admin::abc" || in.ManagerID != 3 {
 		t.Fatalf("unexpected proposeAdminTransferToGg input: %+v", in)
 	}
 	if !contains(stdout, "factoryEpoch=0") {
 		t.Fatalf("expected factoryEpoch=0 in output, got %q", stdout)
+	}
+}
+
+// TestCmd_AdminProposeGg_PostHandoff_PassesCurrentAdmin pins the fix for the PERMISSION_DENIED
+// bug the e2e localnet run surfaced (the propose-gg follow-up to the accept-gg-vaa seam
+// fix): once a deployment's CurrentAdmin is guardianGovernance (a prior `accept-gg-vaa`
+// succeeded), a SECOND `admin propose-gg` call must pass THAT party -- not the registering
+// admin -- as proposeAdminTransferToGgInput.Admin, so the CLI routes the script run to gg's own
+// participant (participantRoleForParty) rather than the default one. A fakeRunner can't observe
+// which participant role was requested (newScriptRunnerFor is overridden uniformly in tests --
+// see runPlaygroundWithRunner), so this asserts on the routed value the input actually carries,
+// matching this file's existing conventions for routing tests.
+func TestCmd_AdminProposeGg_PostHandoff_PassesCurrentAdmin(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "playground.state.json")
+	s := state.New()
+	s.Operator = "operator::abc"
+	s.GuardianGovernance = "gg::abc"
+	s.UserParticipants["GuardianGovernance"] = "guardian-governance"
+	s.Deployments["ntt1"] = state.Deployment{
+		Name: "ntt1", ManagerID: 3, Admin: "ntt1-admin::abc", CurrentAdmin: "gg::abc",
+	}
+	seedStateFile(t, stateFile, s)
+
+	r := newFakeRunner()
+	r.outputs["Playground.Ops:proposeAdminTransferToGg"] = map[string]any{
+		"managerAddress": strings.Repeat("00", 31) + "aa", "factoryEpoch": 1,
+	}
+
+	_, _, err := runPlaygroundWithRunner(t, r, append(baseFlags(stateFile),
+		"admin", "propose-gg", "--deployment", "ntt1")...)
+	if err != nil {
+		t.Fatalf("admin propose-gg: %v", err)
+	}
+	if len(r.calls) != 1 || r.calls[0].Script != "Playground.Ops:proposeAdminTransferToGg" {
+		t.Fatalf("expected exactly one Playground.Ops:proposeAdminTransferToGg call, got %v", r.scriptNames())
+	}
+	in, ok := r.calls[0].Input.(proposeAdminTransferToGgInput)
+	if !ok {
+		t.Fatalf("proposeAdminTransferToGg input type mismatch: %T", r.calls[0].Input)
+	}
+	if in.Admin != "gg::abc" {
+		t.Fatalf("expected the CURRENT admin (gg::abc) as Admin, got %+v", in)
 	}
 }
 
@@ -968,5 +1018,479 @@ func TestCmd_AdminAcceptGgVaa_UpdatesDeploymentAdminOnSuccess(t *testing.T) {
 	}
 	if reloaded.Deployments["ntt1"].Admin != "ntt1-admin::abc" {
 		t.Fatalf("expected Deployment.Admin (the registering admin) to stay untouched, got %+v", reloaded.Deployments["ntt1"])
+	}
+}
+
+// ----------------------------------------------------------------------
+// disclosure serve / --disclosure-service-url / --strict-participant-isolation
+//
+// These pin the disclosure-service design's step 3 CLI wiring (the design doc's §5.2/§5.3/§7
+// R8/§8 step 3): a new `disclosure serve` subcommand, a new persistent --disclosure-service-url
+// flag that reroutes prepareRemoteSeam's fetch through internal/disclosure.Client instead of a
+// local `dpm script` run, and a new --strict-participant-isolation flag that makes
+// newScriptRunnerFor refuse to target a participant other than the current invocation's actor.
+// As with the wiring tests above, these assert on the CLI's own plumbing (call sequence,
+// routing, HTTP requests made) with a fakeRunner double / httptest server, never on real Daml
+// behavior.
+// ----------------------------------------------------------------------
+
+// seedCrossParticipantTransferState builds a "localnet"-shaped seed state for a "mock"
+// burnmint deployment whose sender (hint "Alice") is routed to a DIFFERENT participant
+// ("app-user") than guardianGovernance ("guardian-governance") -- the split transfer.go's
+// fund/prepare steps need in order for --strict-participant-isolation /
+// --disclosure-service-url to have anything to bite on (a same-participant sender never
+// crosses a boundary at all, per prepareRemoteSeam's own actorRole==ownerRole fast path).
+func seedCrossParticipantTransferState(t *testing.T, stateFile string) *state.State {
+	t.Helper()
+	s := state.New()
+	s.Operator = "operator::abc"
+	s.GuardianGovernance = "gg::abc"
+	s.UserParticipants["GuardianGovernance"] = "guardian-governance"
+	s.Deployments["ntt1"] = state.Deployment{
+		Name: "ntt1", ManagerID: 0, Admin: "ntt1-admin::abc",
+		Mode: "burn-mint", TokenKind: "mock", TokenDecimals: 8,
+		Peers: map[int]state.Peer{2: {ManagerAddress: strings.Repeat("00", 31) + "bb", TransceiverAddress: strings.Repeat("00", 31) + "cc"}},
+	}
+	s.Users["Alice"] = "alice::abc" // cached, so resolveParty needs no ledger round-trip
+	s.UserParticipants["Alice"] = "app-user"
+	seedStateFile(t, stateFile, s)
+	return s
+}
+
+// canonicalTransferFakeOutputs seeds r with the same canned preapprove/fundUser/transferOut
+// outputs TestCmd_Transfer_MockKindRunsPreapproveFundThenTransferOut uses, so the transfer
+// wiring under test can run its full sequence (or fail partway through, for the isolation
+// negative control) without a live sandbox.
+func canonicalTransferFakeOutputs(r *fakeRunner) {
+	r.outputs["Playground.Ops:preapprove"] = map[string]any{"preapproved": true}
+	r.outputs["Playground.Ops:fundUser"] = map[string]any{"holdingCid": "holding-cid-1"}
+	r.outputs["Playground.Ops:transferOut"] = map[string]any{
+		"outboundSequence": 0, "emitterChain": 72, "emitterAddress": strings.Repeat("00", 31) + "dd",
+		"nonce": 0, "consistencyLevel": 0, "payload": "9945ff10",
+	}
+}
+
+// TestCmd_DisclosureServe_Wiring pins that `disclosure serve` is registered at all and exposes
+// its --listen/--participant flags -- --help never reaches RunE, so this needs no state file,
+// no runner, no listening socket.
+func TestCmd_DisclosureServe_Wiring(t *testing.T) {
+	stdout, _, err := runPlayground(t, "disclosure", "serve", "--help")
+	if err != nil {
+		t.Fatalf("disclosure serve --help: %v", err)
+	}
+	if !contains(stdout, "--listen") {
+		t.Fatalf("expected --listen in help output, got %q", stdout)
+	}
+	if !contains(stdout, "--participant") {
+		t.Fatalf("expected --participant in help output, got %q", stdout)
+	}
+}
+
+// TestCmd_Transfer_StrictIsolation_BlocksCrossParticipant pins the negative control the design
+// doc's §6.3 calls "the single most important new artifact in the test": with
+// --strict-participant-isolation set and no --disclosure-service-url, a transfer whose sender
+// lives on a different participant than guardianGovernance must fail fast, naming
+// "strict-participant-isolation" in the error, and must NEVER reach a gg-side script (neither
+// the faucet's Playground.Ops:fundUser nor the local Playground.Prepare:prepareTransferOut
+// disclosure fetch) -- proving the flow genuinely needs cross-participant data it cannot reach
+// on its own. Deliberately does NOT assert which step trips first (a later plan step moves
+// funding out of transfer entirely).
+func TestCmd_Transfer_StrictIsolation_BlocksCrossParticipant(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "playground.state.json")
+	seedCrossParticipantTransferState(t, stateFile)
+
+	r := newFakeRunner()
+	canonicalTransferFakeOutputs(r)
+
+	_, _, err := runPlaygroundWithRunner(t, r, append(append(baseFlags(stateFile),
+		"--profile", "localnet", "--strict-participant-isolation"),
+		"transfer", "--deployment", "ntt1", "--user", "Alice", "--chain", "2",
+		"--recipient-address", strings.Repeat("00", 31)+"ee", "--amount", "100")...)
+	if err == nil {
+		t.Fatalf("expected --strict-participant-isolation to block the cross-participant step")
+	}
+	if !contains(err.Error(), "strict-participant-isolation") {
+		t.Fatalf("expected the error to mention strict-participant-isolation, got %v", err)
+	}
+	names := r.scriptNames()
+	for _, bad := range []string{"Playground.Ops:fundUser", "Playground.Prepare:prepareTransferOut"} {
+		for _, n := range names {
+			if n == bad {
+				t.Fatalf("expected %q never to run under strict isolation, got call sequence %v", bad, names)
+			}
+		}
+	}
+}
+
+// TestCmd_Transfer_DisclosureServiceURL_FetchesSeamFromService pins that --disclosure-service-url
+// replaces the local Playground.Prepare:prepareTransferOut run with exactly one
+// POST /v1/seam/transferOut against the given service, that the request carries no
+// client-supplied discloseTemplates entries (the server's own allow-list is authoritative --
+// design doc §1.4(3)/§5.3), and that the service's raw response flows verbatim into
+// transferOut's Remote field.
+func TestCmd_Transfer_DisclosureServiceURL_FetchesSeamFromService(t *testing.T) {
+	var hits int
+	var postedBody []byte
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/seam/transferOut", func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read posted seam body: %v", err)
+		}
+		postedBody = body
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"seam":"canned"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	stateFile := filepath.Join(t.TempDir(), "playground.state.json")
+	seedCrossParticipantTransferState(t, stateFile)
+
+	r := newFakeRunner()
+	canonicalTransferFakeOutputs(r)
+
+	_, _, err := runPlaygroundWithRunner(t, r, append(append(baseFlags(stateFile),
+		"--profile", "localnet", "--disclosure-service-url", srv.URL),
+		"transfer", "--deployment", "ntt1", "--user", "Alice", "--chain", "2",
+		"--recipient-address", strings.Repeat("00", 31)+"ee", "--amount", "100")...)
+	if err != nil {
+		t.Fatalf("transfer: %v", err)
+	}
+	if hits != 1 {
+		t.Fatalf("expected exactly one POST /v1/seam/transferOut, got %d", hits)
+	}
+
+	var decoded struct {
+		DiscloseTemplates []string `json:"discloseTemplates"`
+	}
+	if err := json.Unmarshal(postedBody, &decoded); err != nil {
+		t.Fatalf("decode posted seam body: %v (raw: %s)", err, postedBody)
+	}
+	if len(decoded.DiscloseTemplates) != 0 {
+		t.Fatalf("expected no client-supplied discloseTemplates entries, got %v", decoded.DiscloseTemplates)
+	}
+
+	names := r.scriptNames()
+	for _, n := range names {
+		if n == "Playground.Prepare:prepareTransferOut" {
+			t.Fatalf("expected no local prepareTransferOut script when --disclosure-service-url is set, got %v", names)
+		}
+	}
+
+	last := r.calls[len(r.calls)-1]
+	transferInput, ok := last.Input.(transferOutInput)
+	if !ok || last.Script != "Playground.Ops:transferOut" {
+		t.Fatalf("expected the last call to be transferOut, got script=%q input type %T", last.Script, last.Input)
+	}
+	if strings.TrimSpace(string(transferInput.Remote)) != `{"seam":"canned"}` {
+		t.Fatalf("expected transferOut's Remote to equal the disclosure service's raw response, got %s", transferInput.Remote)
+	}
+}
+
+// TestCmd_Receive_DisclosureServiceURL_UsesReceiveSeam mirrors the transfer test above for
+// `receive`: an --executor routed to a different participant than guardianGovernance, combined
+// with --disclosure-service-url, must fetch the RemoteSeam via exactly one
+// POST /v1/seam/receive and never run the local Playground.Prepare:prepareReceive script.
+func TestCmd_Receive_DisclosureServiceURL_UsesReceiveSeam(t *testing.T) {
+	var hits int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/seam/receive", func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"seam":"canned-receive"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	stateFile := filepath.Join(t.TempDir(), "playground.state.json")
+	s := state.New()
+	s.Operator = "operator::abc"
+	s.GuardianGovernance = "gg::abc"
+	s.UserParticipants["GuardianGovernance"] = "guardian-governance"
+	s.Deployments["ntt1"] = state.Deployment{Name: "ntt1", ManagerID: 0, Admin: "ntt1-admin::abc", TokenKind: "mock"}
+	s.Users["Alice"] = "alice::abc"
+	s.Users["Bob"] = "bob::abc"
+	s.UserParticipants["Bob"] = "app-user" // executor routed to a different participant than gg
+	seedStateFile(t, stateFile, s)
+
+	r := newFakeRunner()
+	r.outputs["Playground.Ops:receiveVaa"] = map[string]any{"recipientChain": 2, "amount": 100, "decimals": 8}
+
+	_, _, err := runPlaygroundWithRunner(t, r, append(append(baseFlags(stateFile),
+		"--profile", "localnet", "--disclosure-service-url", srv.URL),
+		"receive", "--deployment", "ntt1", "--vaa", "aa", "--recipient", "Alice", "--executor", "Bob", "--pubkey", "bb")...)
+	if err != nil {
+		t.Fatalf("receive: %v", err)
+	}
+	if hits != 1 {
+		t.Fatalf("expected exactly one POST /v1/seam/receive, got %d", hits)
+	}
+	names := r.scriptNames()
+	for _, n := range names {
+		if n == "Playground.Prepare:prepareReceive" {
+			t.Fatalf("expected no local prepareReceive script when --disclosure-service-url is set, got %v", names)
+		}
+	}
+}
+
+// TestCmd_AdminAcceptGgVaa_DisclosureServiceURL_UsesAcceptAdminSeam mirrors the transfer/receive
+// tests above for `admin accept-gg-vaa`: an --executor routed to a different participant than
+// guardianGovernance, combined with --disclosure-service-url, must fetch the RemoteSeam via
+// exactly one POST /v1/seam/acceptAdminTransfer and never run the local
+// Playground.Prepare:prepareAcceptAdmin script -- pins the fourth seam admin.go's
+// prepareRemoteSeam call wires up (remote.go/service.go).
+func TestCmd_AdminAcceptGgVaa_DisclosureServiceURL_UsesAcceptAdminSeam(t *testing.T) {
+	var hits int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/seam/acceptAdminTransfer", func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"seam":"canned-accept-admin"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	stateFile := filepath.Join(t.TempDir(), "playground.state.json")
+	s := state.New()
+	s.Operator = "operator::abc"
+	s.GuardianGovernance = "gg::abc"
+	s.UserParticipants["GuardianGovernance"] = "guardian-governance"
+	s.Deployments["ntt1"] = state.Deployment{Name: "ntt1", ManagerID: 0, Admin: "ntt1-admin::abc", CurrentAdmin: "ntt1-admin::abc"}
+	s.Users["Bob"] = "bob::abc"
+	s.UserParticipants["Bob"] = "app-user" // executor routed to a different participant than gg
+	seedStateFile(t, stateFile, s)
+
+	r := newFakeRunner()
+	r.outputs["Playground.Ops:acceptAdminTransferByVaa"] = map[string]any{
+		"managerAddress": strings.Repeat("00", 31) + "aa", "admin": "gg::abc",
+	}
+
+	_, _, err := runPlaygroundWithRunner(t, r, append(append(baseFlags(stateFile),
+		"--profile", "localnet", "--disclosure-service-url", srv.URL),
+		"admin", "accept-gg-vaa", "--deployment", "ntt1", "--vaa", "aa", "--pubkey", "bb", "--executor", "Bob")...)
+	if err != nil {
+		t.Fatalf("admin accept-gg-vaa: %v", err)
+	}
+	if hits != 1 {
+		t.Fatalf("expected exactly one POST /v1/seam/acceptAdminTransfer, got %d", hits)
+	}
+	names := r.scriptNames()
+	for _, n := range names {
+		if n == "Playground.Prepare:prepareAcceptAdmin" {
+			t.Fatalf("expected no local prepareAcceptAdmin script when --disclosure-service-url is set, got %v", names)
+		}
+	}
+}
+
+// TestNewScriptRunnerFor_StrictIsolationGuard is a focused unit test of the guard itself
+// (normalizeRole comparison), bypassing any subcommand: strict isolation with a recorded
+// baseline that differs from the target role must error naming
+// "strict-participant-isolation"; an empty baseline (no actor-routing command in play, e.g.
+// init/deploy/fund/party -- design doc §7 R8) must never trip the guard, even against a
+// participant role that would otherwise differ from the profile's default.
+func TestNewScriptRunnerFor_StrictIsolationGuard(t *testing.T) {
+	r := newFakeRunner()
+
+	blocked := &app{
+		runnerOverride:             r,
+		profile:                    profile.LocalNet,
+		strictParticipantIsolation: true,
+		isolationBaselineRole:      "app-user",
+	}
+	if _, _, err := blocked.newScriptRunnerFor(context.Background(), "guardian-governance"); err == nil || !contains(err.Error(), "strict-participant-isolation") {
+		t.Fatalf("expected a strict-participant-isolation error for a cross-participant target, got %v", err)
+	}
+
+	noBaseline := &app{
+		runnerOverride:             r,
+		profile:                    profile.LocalNet,
+		strictParticipantIsolation: true,
+		isolationBaselineRole:      "",
+	}
+	if _, _, err := noBaseline.newScriptRunnerFor(context.Background(), ""); err != nil {
+		t.Fatalf("expected no error with an empty isolationBaselineRole (no actor-routing command in play), got %v", err)
+	}
+}
+
+// ----------------------------------------------------------------------
+// fund (design doc §5.5: funding split out of transfer)
+// ----------------------------------------------------------------------
+
+// TestCmd_Fund_RunsPreapproveThenFundUser pins `fund`'s wiring: exactly
+// Playground.Ops:preapprove then Playground.Ops:fundUser, in that order, with fundUser's
+// Owner set to the resolved user party, and the minted holding cid surfaced on stdout.
+func TestCmd_Fund_RunsPreapproveThenFundUser(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "playground.state.json")
+	s := state.New()
+	s.Operator = "operator::abc"
+	s.GuardianGovernance = "gg::abc"
+	s.Deployments["ntt1"] = state.Deployment{
+		Name: "ntt1", ManagerID: 0, Admin: "ntt1-admin::abc",
+		Mode: "burn-mint", TokenKind: "mock", TokenDecimals: 8,
+	}
+	s.Users["Alice"] = "alice::abc" // cached, so resolveParty needs no ledger round-trip
+	seedStateFile(t, stateFile, s)
+
+	r := newFakeRunner()
+	r.outputs["Playground.Ops:preapprove"] = map[string]any{"preapproved": true}
+	r.outputs["Playground.Ops:fundUser"] = map[string]any{"holdingCid": "holding-cid-1"}
+
+	stdout, _, err := runPlaygroundWithRunner(t, r, append(baseFlags(stateFile),
+		"fund", "--deployment", "ntt1", "--user", "Alice", "--amount", "500000")...)
+	if err != nil {
+		t.Fatalf("fund: %v", err)
+	}
+
+	names := r.scriptNames()
+	want := []string{"Playground.Ops:preapprove", "Playground.Ops:fundUser"}
+	if len(names) != len(want) {
+		t.Fatalf("expected exactly %v, got %v", want, names)
+	}
+	for i, n := range want {
+		if names[i] != n {
+			t.Fatalf("expected call %d to be %q, got %q (full sequence %v)", i, n, names[i], names)
+		}
+	}
+
+	fundInput, ok := r.calls[1].Input.(fundUserInput)
+	if !ok {
+		t.Fatalf("fundUser input type mismatch: %T", r.calls[1].Input)
+	}
+	if fundInput.Owner != "alice::abc" {
+		t.Fatalf("expected fundUser's Owner to be the resolved user party, got %q", fundInput.Owner)
+	}
+	if !contains(stdout, "holdingCid=holding-cid-1") {
+		t.Fatalf("expected stdout to carry the minted holding cid, got %q", stdout)
+	}
+}
+
+// TestCmd_Fund_AmuletDeploymentRejected pins that `fund` rejects an "amulet" deployment
+// client-side, before any script runs at all -- amulet senders tap via `transfer --tap-usd`.
+func TestCmd_Fund_AmuletDeploymentRejected(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "playground.state.json")
+	s := state.New()
+	s.Deployments["ntt1"] = state.Deployment{Name: "ntt1", TokenKind: "amulet"}
+	s.Users["Alice"] = "alice::abc"
+	seedStateFile(t, stateFile, s)
+
+	r := newFakeRunner()
+	_, _, err := runPlaygroundWithRunner(t, r, append(baseFlags(stateFile),
+		"fund", "--deployment", "ntt1", "--user", "Alice", "--amount", "100")...)
+	if err == nil || !contains(err.Error(), "mock deployments only") {
+		t.Fatalf("expected a mock-deployments-only error, got %v", err)
+	}
+	if len(r.calls) != 0 {
+		t.Fatalf("expected no script calls at all for a rejected amulet fund, got %v", r.scriptNames())
+	}
+}
+
+// ----------------------------------------------------------------------
+// transfer --no-fund / --strict-participant-isolation (design doc §5.5)
+// ----------------------------------------------------------------------
+
+// TestCmd_Transfer_NoFund_SkipsFundingAndLeavesHoldingsEmpty pins that `transfer --no-fund`
+// skips the preapprove+fundUser block entirely and leaves transferOut's InputHoldingCids
+// empty (non-nil) -- Playground.Ops:transferOut then enumerates the sender's own holdings
+// in-script (Playground.Ops:mockHoldings).
+func TestCmd_Transfer_NoFund_SkipsFundingAndLeavesHoldingsEmpty(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "playground.state.json")
+	s := state.New()
+	s.Operator = "operator::abc"
+	s.GuardianGovernance = "gg::abc"
+	s.Deployments["ntt1"] = state.Deployment{
+		Name: "ntt1", ManagerID: 0, Admin: "ntt1-admin::abc",
+		Mode: "burn-mint", TokenKind: "mock", TokenDecimals: 8,
+		Peers: map[int]state.Peer{2: {ManagerAddress: strings.Repeat("00", 31) + "bb", TransceiverAddress: strings.Repeat("00", 31) + "cc"}},
+	}
+	s.Users["Alice"] = "alice::abc"
+	seedStateFile(t, stateFile, s)
+
+	r := newFakeRunner()
+	canonicalTransferFakeOutputs(r)
+
+	_, _, err := runPlaygroundWithRunner(t, r, append(baseFlags(stateFile),
+		"transfer", "--deployment", "ntt1", "--user", "Alice", "--chain", "2",
+		"--recipient-address", strings.Repeat("00", 31)+"ee", "--amount", "100", "--no-fund")...)
+	if err != nil {
+		t.Fatalf("transfer --no-fund: %v", err)
+	}
+
+	names := r.scriptNames()
+	for _, bad := range []string{"Playground.Ops:preapprove", "Playground.Ops:fundUser"} {
+		for _, n := range names {
+			if n == bad {
+				t.Fatalf("expected %q never to run under --no-fund, got call sequence %v", bad, names)
+			}
+		}
+	}
+
+	last := r.calls[len(r.calls)-1]
+	transferInput, ok := last.Input.(transferOutInput)
+	if !ok || last.Script != "Playground.Ops:transferOut" {
+		t.Fatalf("expected the last call to be transferOut, got script=%q input type %T", last.Script, last.Input)
+	}
+	if transferInput.InputHoldingCids == nil {
+		t.Fatalf("expected InputHoldingCids to be non-nil (Daml needs [] not null)")
+	}
+	if len(transferInput.InputHoldingCids) != 0 {
+		t.Fatalf("expected InputHoldingCids to be empty under --no-fund, got %+v", transferInput.InputHoldingCids)
+	}
+}
+
+// TestCmd_Transfer_StrictIsolationImpliesNoFund pins that --strict-participant-isolation
+// combined with --disclosure-service-url lets a cross-participant transfer proceed WITHOUT
+// fundUser and WITHOUT tripping the isolation guard: strict isolation implies --no-fund
+// (design doc §5.5), and the disclosure service supplies the RemoteSeam the local
+// prepareTransferOut fetch would otherwise need gg's own credentials for.
+func TestCmd_Transfer_StrictIsolationImpliesNoFund(t *testing.T) {
+	mux := http.NewServeMux()
+	var hits int
+	mux.HandleFunc("/v1/seam/transferOut", func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"seam":"canned"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	stateFile := filepath.Join(t.TempDir(), "playground.state.json")
+	seedCrossParticipantTransferState(t, stateFile)
+
+	r := newFakeRunner()
+	canonicalTransferFakeOutputs(r)
+
+	_, _, err := runPlaygroundWithRunner(t, r, append(append(baseFlags(stateFile),
+		"--profile", "localnet", "--strict-participant-isolation", "--disclosure-service-url", srv.URL),
+		"transfer", "--deployment", "ntt1", "--user", "Alice", "--chain", "2",
+		"--recipient-address", strings.Repeat("00", 31)+"ee", "--amount", "100")...)
+	if err != nil {
+		t.Fatalf("expected the transfer to succeed via the disclosure service, got %v", err)
+	}
+	if hits != 1 {
+		t.Fatalf("expected exactly one POST /v1/seam/transferOut, got %d", hits)
+	}
+
+	names := r.scriptNames()
+	for _, bad := range []string{"Playground.Ops:fundUser", "Playground.Ops:preapprove", "Playground.Prepare:prepareTransferOut"} {
+		for _, n := range names {
+			if n == bad {
+				t.Fatalf("expected %q never to run when strict isolation implies --no-fund, got call sequence %v", bad, names)
+			}
+		}
+	}
+
+	last := r.calls[len(r.calls)-1]
+	transferInput, ok := last.Input.(transferOutInput)
+	if !ok || last.Script != "Playground.Ops:transferOut" {
+		t.Fatalf("expected the last call to be transferOut, got script=%q input type %T", last.Script, last.Input)
+	}
+	if len(transferInput.InputHoldingCids) != 0 {
+		t.Fatalf("expected InputHoldingCids to be empty under strict isolation, got %+v", transferInput.InputHoldingCids)
 	}
 }

--- a/canton/testing/cli/cmd/ntt-playground/deploy.go
+++ b/canton/testing/cli/cmd/ntt-playground/deploy.go
@@ -309,7 +309,7 @@ func newDeployCmd(a *app) *cobra.Command {
 			var deployRemote json.RawMessage
 			if cfg.Mode == "burn-mint" && cfg.TokenKind == "mock" {
 				ownerRole := participantRoleForParty(s, s.GuardianGovernance)
-				deployRemote, err = prepareRemoteSeam(ctx, cmd, a, s, "", ownerRole, "Playground.Prepare:prepareDeployNtt", func(templates []string) any {
+				deployRemote, err = prepareRemoteSeam(ctx, cmd, a, s, "", ownerRole, "Playground.Prepare:prepareDeployNtt", "deployNtt", func(templates []string) any {
 					return prepareDeployNttInput{
 						GuardianGovernance: s.GuardianGovernance,
 						FactoryCid:         *regOut.FactoryCid,

--- a/canton/testing/cli/cmd/ntt-playground/disclosure.go
+++ b/canton/testing/cli/cmd/ntt-playground/disclosure.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/wormholelabs-xyz/native-token-transfers/canton/testing/cli/internal/disclosure"
+	"github.com/wormholelabs-xyz/native-token-transfers/canton/testing/cli/internal/network"
+)
+
+// defaultDisclosureListenAddr is `disclosure serve`'s default bind address. Loopback-only by
+// default is a deliberate posture, not an accident: the service is unauthenticated (design doc
+// §4), so an operator must opt in explicitly (via --listen) to expose it more broadly.
+const defaultDisclosureListenAddr = "127.0.0.1:7599"
+
+// defaultDisclosureParticipant is the participant role `disclosure serve` fronts absent an
+// explicit --participant -- guardianGovernance, since that is the participant every existing
+// prepare* seam (transferOut/receive) needs a cross-participant fetch against (see remote.go).
+const defaultDisclosureParticipant = "guardian-governance"
+
+func newDisclosureCmd(a *app) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "disclosure",
+		Short: "Run the disclosure service that fronts one participant's allow-listed contracts",
+	}
+	cmd.AddCommand(newDisclosureServeCmd(a))
+	return cmd
+}
+
+// newDisclosureServeCmd builds `ntt-playground disclosure serve` -- the design doc's §5.2
+// harness-grade disclosure service: an HTTP sidecar fronting ONE participant (--participant),
+// serving the generic ACS-backed GET /v1/disclosures and the typed POST /v1/seam/* endpoints
+// (see internal/disclosure.Service). This is what lets a consumer obtain a cross-participant
+// RemoteSeam -- or raw disclosed contracts -- WITHOUT holding the fronted participant's own
+// credentials, the property --disclosure-service-url/--strict-participant-isolation exist to
+// make load-bearing (remote.go's prepareRemoteSeam, runner.go's isolation guard).
+func newDisclosureServeCmd(a *app) *cobra.Command {
+	var listen, participant string
+
+	cmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Serve the disclosure service (GET /v1/disclosures, POST /v1/seam/*) fronting one participant",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			s, err := a.loadState()
+			if err != nil {
+				return err
+			}
+			if s.GuardianGovernance == "" {
+				return fmt.Errorf("disclosure serve: no guardianGovernance party in state -- run `init` first")
+			}
+
+			prof, err := a.resolvedProfile()
+			if err != nil {
+				return err
+			}
+			ep, err := prof.Endpoint(participant)
+			if err != nil {
+				return err
+			}
+
+			cfg, err := a.topologyConfig()
+			if err != nil {
+				return err
+			}
+
+			// The generic /v1/disclosures endpoint needs a live ACS reader; the sandbox
+			// profile has no JSON Ledger API at all (Endpoint.JSONAPIBaseURL is empty there),
+			// so ACS stays nil and that endpoint 503s (internal/disclosure/service.go's
+			// handleDisclosures). POST /v1/seam/* -- the only thing the acceptance criterion
+			// needs -- is unaffected: it runs entirely through NewRunner's `dpm script` path
+			// below, never through ACS.
+			var acs *disclosure.ActiveContracts
+			if ep.JSONAPIBaseURL != "" {
+				var token string
+				if prof.RequiresAuth {
+					token, err = network.MintUnsafeToken(ep.UserID, 24*time.Hour)
+					if err != nil {
+						return fmt.Errorf("disclosure serve: mint ACS reader token: %w", err)
+					}
+				}
+				acs = &disclosure.ActiveContracts{
+					BaseURL: ep.JSONAPIBaseURL,
+					Token:   token,
+					Party:   s.GuardianGovernance,
+					Logf:    a.verboseLogf(),
+				}
+			}
+
+			svc := &disclosure.Service{
+				Cfg:         cfg,
+				Participant: participant,
+				ACS:         acs,
+				// a.newScriptRunnerFor returns this package's scriptRunner interface;
+				// disclosure.ScriptRunner has the identical single-method shape
+				// (Run(ctx, scriptName string, input, output any) error), so the interface
+				// value is directly assignable here -- no adapter needed.
+				NewRunner: func(ctx context.Context) (disclosure.ScriptRunner, func(), error) {
+					return a.newScriptRunnerFor(ctx, participant)
+				},
+				Logf: a.verboseLogf(),
+			}
+
+			ln, err := net.Listen("tcp", listen)
+			if err != nil {
+				return fmt.Errorf("disclosure serve: listen on %s: %w", listen, err)
+			}
+
+			// The startup banner and the resolved-address line below are ALWAYS printed (not
+			// gated on --verbose): the security posture is load-bearing information, not
+			// narration, and the address line is what an e2e harness parses to learn an
+			// ephemeral ":0" port after Listen resolves it.
+			stderr := a.stderr
+			if stderr == nil {
+				stderr = cmd.ErrOrStderr()
+			}
+			fmt.Fprintf(stderr, "disclosure serve: fronting participant=%s templates=%d\n", participant, len(cfg.Templates()))
+			fmt.Fprintln(stderr, "disclosure serve: unauthenticated harness-grade service; keep it loopback-bound unless you know why")
+			if !isLoopbackListenAddr(listen) {
+				fmt.Fprintln(stderr, "disclosure serve: WARNING: --listen is not loopback-bound -- this exposes allow-listed contract payloads, unauthenticated, to anything that can reach this address")
+			}
+			fmt.Fprintf(stderr, "disclosure serve: listening on http://%s\n", ln.Addr().String())
+
+			srv := &http.Server{Handler: svc.Handler()}
+			// Shut down gracefully once the command's context is done (e.g. the process
+			// receives SIGINT via cobra's signal handling, or a test cancels the context) --
+			// srv.Serve returns http.ErrServerClosed in that case, which is not itself an
+			// error worth propagating.
+			context.AfterFunc(ctx, func() {
+				shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				_ = srv.Shutdown(shutdownCtx)
+			})
+
+			if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+				return fmt.Errorf("disclosure serve: %w", err)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&listen, "listen", defaultDisclosureListenAddr, "address to listen on (host:port)")
+	cmd.Flags().StringVar(&participant, "participant", defaultDisclosureParticipant, "participant role this service fronts (internal/profile.Profile.Participants key)")
+	return cmd
+}
+
+// isLoopbackListenAddr reports whether addr's host part names a loopback interface --
+// "127.0.0.1", "localhost", or "::1". Any other host (including an empty one, which
+// net.Listen binds to every interface) is treated as non-loopback -- an operator opting into a
+// broader bind should see the warning, not have it silently suppressed by an edge case.
+func isLoopbackListenAddr(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+	}
+	switch host {
+	case "127.0.0.1", "localhost", "::1":
+		return true
+	default:
+		return false
+	}
+}

--- a/canton/testing/cli/cmd/ntt-playground/fund.go
+++ b/canton/testing/cli/cmd/ntt-playground/fund.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/wormholelabs-xyz/native-token-transfers/canton/testing/cli/internal/wire"
+)
+
+// newFundCmd builds `fund` -- an operator/faucet action lifted verbatim out of `transfer`
+// (design doc §5.5): ensure the recipient's standing pre-approval (Playground.Ops:preapprove,
+// on the user's own participant), then mint via the deployment's committed faucet
+// (Playground.Ops:fundUser, on gg's own participant -- gg is the mint's sole signatory).
+//
+// Splitting this out of `transfer` is what makes `--strict-participant-isolation` meaningful
+// for a sender whose participant differs from gg's: fundUser is a gg-side submit that no
+// disclosure service can stand in for (a DisclosedContract grants visibility, never
+// authority -- see internal/disclosure's package doc), so it must run on gg's own
+// participant, by an operator who legitimately holds gg's credentials. `fund` is that
+// operator-side command; `transfer --no-fund` (transfer.go) is what a participant-isolated
+// sender uses instead, leaving `Playground.Ops:transferOut` to enumerate the sender's own
+// holdings in-script (Playground.Ops:mockHoldings).
+//
+// Deliberately does NOT set a.isolationBaselineRole: `fund` legitimately spans the user's and
+// gg's participants by design (like `init`/`deploy`/`party`), so --strict-participant-isolation
+// must never fire for it -- see runner.go's newScriptRunnerFor doc comment.
+func newFundCmd(a *app) *cobra.Command {
+	var deployment, userHint string
+	var amount int64
+
+	cmd := &cobra.Command{
+		Use:   "fund",
+		Short: "Mint mock-kind funds to a user via the deployment's faucet (Playground.Ops:preapprove + fundUser)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			s, err := a.loadState()
+			if err != nil {
+				return err
+			}
+			d, ok := s.Deployment(deployment)
+			if !ok {
+				return fmt.Errorf("fund: unknown deployment %q", deployment)
+			}
+			if d.TokenKind == "amulet" {
+				return fmt.Errorf("fund: mock deployments only; amulet senders tap via transfer --tap-usd")
+			}
+
+			userParty, err := resolveParty(cmd, a, s, userHint)
+			if err != nil {
+				return err
+			}
+			a.vlogf(cmd, "fund: user %q → %s, deployment %q (managerId=%d)", userHint, userParty, deployment, d.ManagerID)
+
+			// preapprove is a self-signed create by the recipient, so it routes to the
+			// recipient's own participant (see Playground.Ops's doc comment on 'preapprove');
+			// idempotent, so calling it here even for an already-preapproved user is a no-op.
+			preRunner, preCleanup, err := a.newScriptRunnerFor(ctx, s.UserParticipants[userHint])
+			if err != nil {
+				return err
+			}
+			a.vlogf(cmd, "fund: ensuring user %q has a standing pre-approval (Playground.Ops:preapprove)", userHint)
+			var preOut preapproveOutput
+			preErr := preRunner.Run(ctx, "Playground.Ops:preapprove", preapproveInput{
+				Admin:              d.Admin,
+				GuardianGovernance: s.GuardianGovernance,
+				TokenKind:          d.TokenKind,
+				Mode:               "burn-mint",
+				User:               userParty,
+			}, &preOut)
+			preCleanup()
+			if preErr != nil {
+				return fmt.Errorf("fund: ensure user pre-approval: %w", preErr)
+			}
+
+			// fundUser submits (and queries the faucet factory/preapproval) as gg alone -- see
+			// Playground.Ops:fundUser -- so it routes to gg's OWN participant, never the
+			// user's or the default one.
+			ggRole := participantRoleForParty(s, s.GuardianGovernance)
+			fundRunner, fundCleanup, err := a.newScriptRunnerFor(ctx, ggRole)
+			if err != nil {
+				return err
+			}
+			defer fundCleanup()
+
+			decimals := wire.TrimDecimals(d.TokenDecimals)
+			formatted := formatDecimal(amount, decimals)
+			a.vlogf(cmd, "fund: minting %s to %q via Playground.Ops:fundUser", formatted, userHint)
+			var fundOut fundUserOutput
+			if err := fundRunner.Run(ctx, "Playground.Ops:fundUser", fundUserInput{
+				GuardianGovernance: s.GuardianGovernance,
+				Admin:              d.Admin,
+				Owner:              userParty,
+				Amount:             decimalLiteral(formatted),
+			}, &fundOut); err != nil {
+				return fmt.Errorf("fund: %w", err)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "fund: holdingCid=%s amount=%s\n", fundOut.HoldingCid, formatted)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&deployment, "deployment", "", "deployment name")
+	cmd.Flags().StringVar(&userHint, "user", "", "party hint for the user to fund")
+	cmd.Flags().Int64Var(&amount, "amount", 0, "raw amount to mint")
+	_ = cmd.MarkFlagRequired("deployment")
+	_ = cmd.MarkFlagRequired("user")
+	_ = cmd.MarkFlagRequired("amount")
+	return cmd
+}

--- a/canton/testing/cli/cmd/ntt-playground/main.go
+++ b/canton/testing/cli/cmd/ntt-playground/main.go
@@ -49,14 +49,19 @@ type app struct {
 
 	// isolationBaselineRole is the current invocation's actor participant role -- the baseline
 	// strictParticipantIsolation compares every newScriptRunnerFor call's target against. This
-	// is NOT a cobra flag: it is set once per invocation by the three actor-routing commands
-	// (transfer.go, receive.go, publish.go), immediately after the actor's own role is resolved
-	// and before any call that might cross a participant boundary. Commands that legitimately
-	// span participants by design -- init, deploy, fund, party -- never set it, so it stays ""
-	// for them, which the guard treats as "no actor-routing command is in play" and therefore
-	// never fires (design doc §7 R8: the guard must not break those commands even when
-	// --strict-participant-isolation is passed globally).
+	// is NOT a cobra flag: it is set once per invocation by the actor-routing commands
+	// (transfer.go, receive.go, publish.go, admin.go's accept-gg-vaa), immediately after the
+	// actor's own role is resolved and before any call that might cross a participant boundary.
+	// "" is a valid baseline meaning the profile's default participant (normalizeRole resolves
+	// it for comparison), so isolationBaselineSet below -- not this value -- records whether a
+	// baseline was taken at all.
 	isolationBaselineRole string
+
+	// isolationBaselineSet records that an actor-routing command took a baseline this
+	// invocation. Commands that legitimately span participants by design -- init, deploy, fund,
+	// party -- never set it, and the guard never fires for them even when
+	// --strict-participant-isolation is passed globally (design doc §7 R8).
+	isolationBaselineSet bool
 
 	// stderr is the invoked command's error stream, captured once in PersistentPreRun so
 	// helpers constructed without a *cobra.Command in scope (the script runner and network

--- a/canton/testing/cli/cmd/ntt-playground/main.go
+++ b/canton/testing/cli/cmd/ntt-playground/main.go
@@ -31,6 +31,33 @@ type app struct {
 	// path next to the state file" (see resolvedTopologyConfigPath).
 	topologyConfigPath string
 
+	// disclosureServiceURL is the --disclosure-service-url flag's value. Empty (the default)
+	// means "unchanged behavior": prepareRemoteSeam (remote.go) runs the local
+	// `Playground.Prepare:prepare*` script directly against the data owner's own participant,
+	// exactly as before this flag existed. When set, prepareRemoteSeam instead issues a
+	// POST /v1/seam/{name} against this base URL (internal/disclosure.Client) -- the property
+	// that lets a consumer fetch a cross-participant RemoteSeam without holding the data
+	// owner's own credentials (design doc §5.3).
+	disclosureServiceURL string
+
+	// strictParticipantIsolation is the --strict-participant-isolation flag's value. When set,
+	// newScriptRunnerFor (runner.go) refuses to build a runner targeting any participant other
+	// than isolationBaselineRole below -- the negative control that proves a flow genuinely
+	// needs --disclosure-service-url rather than silently working because the harness happens
+	// to hold every participant's credentials (design doc §7 R8).
+	strictParticipantIsolation bool
+
+	// isolationBaselineRole is the current invocation's actor participant role -- the baseline
+	// strictParticipantIsolation compares every newScriptRunnerFor call's target against. This
+	// is NOT a cobra flag: it is set once per invocation by the three actor-routing commands
+	// (transfer.go, receive.go, publish.go), immediately after the actor's own role is resolved
+	// and before any call that might cross a participant boundary. Commands that legitimately
+	// span participants by design -- init, deploy, fund, party -- never set it, so it stays ""
+	// for them, which the guard treats as "no actor-routing command is in play" and therefore
+	// never fires (design doc §7 R8: the guard must not break those commands even when
+	// --strict-participant-isolation is passed globally).
+	isolationBaselineRole string
+
 	// stderr is the invoked command's error stream, captured once in PersistentPreRun so
 	// helpers constructed without a *cobra.Command in scope (the script runner and network
 	// managers' Logf closures) narrate to the same stream vlogf writes to.
@@ -68,6 +95,8 @@ func newRootCmdForApp(a *app) *cobra.Command {
 	root.PersistentFlags().StringVar((*string)(&a.profile), "profile", string(profile.Sandbox), "network profile: sandbox|localnet")
 	root.PersistentFlags().BoolVar(&a.verbose, "verbose", false, "narrate every sub-step (network bring-up, party allocation, each dpm script run) on stderr")
 	root.PersistentFlags().StringVar(&a.topologyConfigPath, "topology-config", "", "path to the topology/disclosure config file (default: playground.topology.json next to the state file)")
+	root.PersistentFlags().StringVar(&a.disclosureServiceURL, "disclosure-service-url", "", "base URL of a disclosure service to fetch cross-participant RemoteSeams from (default: run the prepare script directly against the data owner's participant)")
+	root.PersistentFlags().BoolVar(&a.strictParticipantIsolation, "strict-participant-isolation", false, "fail any step that would target a participant other than the actor's own (see --disclosure-service-url)")
 
 	root.AddCommand(
 		newNetworkCmd(a),
@@ -79,6 +108,7 @@ func newRootCmdForApp(a *app) *cobra.Command {
 		newPartyCmd(a),
 		newEmitterCmd(a),
 		newPublishCmd(a),
+		newFundCmd(a),
 		newTransferCmd(a),
 		newReceiveCmd(a),
 		newPreapproveCmd(a),
@@ -88,6 +118,7 @@ func newRootCmdForApp(a *app) *cobra.Command {
 		newContractsCmd(a),
 		newBalanceCmd(a),
 		newObserveCmd(a),
+		newDisclosureCmd(a),
 	)
 	return root
 }

--- a/canton/testing/cli/cmd/ntt-playground/publish.go
+++ b/canton/testing/cli/cmd/ntt-playground/publish.go
@@ -55,8 +55,14 @@ func newPublishCmd(a *app) *cobra.Command {
 			// transferOut/receiveVaa, whose data owner is guardianGovernance -- see
 			// remote.go's doc comment).
 			actorRole := participantRoleForParty(s, em.Owner)
+
+			// Record the actor's participant role as the --strict-participant-isolation
+			// baseline (runner.go), immediately after it is known and before prepareRemoteSeam
+			// below (which may need to cross a participant boundary).
+			a.isolationBaselineRole = actorRole
+
 			dataOwnerRole := participantRoleForParty(s, s.Operator)
-			remoteSeam, err := prepareRemoteSeam(ctx, cmd, a, s, actorRole, dataOwnerRole, "Playground.Prepare:preparePublish", func(templates []string) any {
+			remoteSeam, err := prepareRemoteSeam(ctx, cmd, a, s, actorRole, dataOwnerRole, "Playground.Prepare:preparePublish", "publish", func(templates []string) any {
 				return preparePublishInput{
 					Operator:          s.Operator,
 					EmitterID:         em.EmitterID,

--- a/canton/testing/cli/cmd/ntt-playground/publish.go
+++ b/canton/testing/cli/cmd/ntt-playground/publish.go
@@ -60,6 +60,7 @@ func newPublishCmd(a *app) *cobra.Command {
 			// baseline (runner.go), immediately after it is known and before prepareRemoteSeam
 			// below (which may need to cross a participant boundary).
 			a.isolationBaselineRole = actorRole
+			a.isolationBaselineSet = true
 
 			dataOwnerRole := participantRoleForParty(s, s.Operator)
 			remoteSeam, err := prepareRemoteSeam(ctx, cmd, a, s, actorRole, dataOwnerRole, "Playground.Prepare:preparePublish", "publish", func(templates []string) any {

--- a/canton/testing/cli/cmd/ntt-playground/receive.go
+++ b/canton/testing/cli/cmd/ntt-playground/receive.go
@@ -70,6 +70,7 @@ func newReceiveCmd(a *app) *cobra.Command {
 			// baseline (runner.go), immediately after it is known and before
 			// prepareRemoteSeam below (which may need to cross a participant boundary).
 			a.isolationBaselineRole = executorRole
+			a.isolationBaselineSet = true
 
 			if pubKeyHex == "" {
 				return fmt.Errorf("receive: --pubkey is required (the signing guardian's 65-byte uncompressed pubkey)")

--- a/canton/testing/cli/cmd/ntt-playground/receive.go
+++ b/canton/testing/cli/cmd/ntt-playground/receive.go
@@ -65,6 +65,12 @@ func newReceiveCmd(a *app) *cobra.Command {
 				}
 				executorRole = s.UserParticipants[executorHint]
 			}
+
+			// Record the actor's participant role as the --strict-participant-isolation
+			// baseline (runner.go), immediately after it is known and before
+			// prepareRemoteSeam below (which may need to cross a participant boundary).
+			a.isolationBaselineRole = executorRole
+
 			if pubKeyHex == "" {
 				return fmt.Errorf("receive: --pubkey is required (the signing guardian's 65-byte uncompressed pubkey)")
 			}
@@ -72,7 +78,7 @@ func newReceiveCmd(a *app) *cobra.Command {
 			// The data owner for a Mock-kind prepare fetch is gg's OWN participant, not
 			// operator's -- see remote.go's doc comment and transfer.go's identical reasoning.
 			ownerRole := participantRoleForParty(s, s.GuardianGovernance)
-			remoteSeam, err := prepareRemoteSeam(ctx, cmd, a, s, executorRole, ownerRole, "Playground.Prepare:prepareReceive", func(templates []string) any {
+			remoteSeam, err := prepareRemoteSeam(ctx, cmd, a, s, executorRole, ownerRole, "Playground.Prepare:prepareReceive", "receive", func(templates []string) any {
 				return prepareReceiveInput{
 					GuardianGovernance: s.GuardianGovernance,
 					ManagerID:          d.ManagerID,

--- a/canton/testing/cli/cmd/ntt-playground/remote.go
+++ b/canton/testing/cli/cmd/ntt-playground/remote.go
@@ -28,12 +28,24 @@ func discloseTemplateAllowList(cfg disclosure.Config) []string {
 
 // prepareRemoteSeam decides whether a submit needs a RemoteSeam (the actor's participant
 // differs from ownerRole, the participant the data this op needs actually lives on) and, if so,
-// runs prepareScript against ownerRole's participant to obtain one -- returned as raw JSON,
-// since the CLI never needs to parse or construct a RemoteSeam itself: it flows verbatim from
-// the prepare script's stdout into the submit script's stdin (see
-// Playground.Disclose:RemoteSeam's doc comment). Returns (nil, nil) when actorRole already
-// matches ownerRole -- the existing local fast path, byte-identical to pre-phase-5 behavior (a
-// nil json.RawMessage marshals to JSON `null`, i.e. Daml's `None`).
+// obtains one -- returned as raw JSON, since the CLI never needs to parse or construct a
+// RemoteSeam itself: it flows verbatim from wherever it was fetched into the submit script's
+// stdin (see Playground.Disclose:RemoteSeam's doc comment). Returns (nil, nil) when actorRole
+// already matches ownerRole -- the existing local fast path, byte-identical to pre-phase-5
+// behavior (a nil json.RawMessage marshals to JSON `null`, i.e. Daml's `None`).
+//
+// Two ways to obtain a seam once the fast path above doesn't apply (design doc §5.3):
+//   - a.disclosureServiceURL set: POST /v1/seam/{seamName} against a disclosure service
+//     (internal/disclosure.Client/Service) fronting ownerRole's participant. The service
+//     injects its OWN discloseTemplates allow-list server-side (design doc §1.4(3)), so
+//     buildInput is called with a nil allow-list here -- passing a client-supplied one would be
+//     silently overwritten by the service anyway (internal/disclosure/service.go's handleSeam).
+//     This is the path that lets an actor submit a cross-participant op WITHOUT holding
+//     ownerRole's own credentials, which is what --strict-participant-isolation (runner.go)
+//     exists to prove is otherwise required.
+//   - unset (default, byte-identical to pre-disclosure-service behavior): run prepareScript
+//     directly against ownerRole's participant via a.newScriptRunnerFor(ctx, ownerRole), passing
+//     the LOCAL discloseTemplateAllowList (the existing client-side allow-list, unchanged).
 //
 // ownerRole is caller-supplied rather than derived from a single global helper: which
 // participant actually owns the needed data differs per entrypoint post-rework --
@@ -43,9 +55,15 @@ func discloseTemplateAllowList(cfg disclosure.Config) []string {
 // emitter's owner is not necessarily gg, but operator co-signs every Emitter/CoreState
 // regardless of who registered it) -- see each call site.
 //
-// buildInput receives the config-derived discloseTemplates allow-list and returns the fully
-// populated input value for prepareScript.
-func prepareRemoteSeam(ctx context.Context, cmd *cobra.Command, a *app, s *state.State, actorRole, ownerRole, prepareScript string, buildInput func(discloseTemplates []string) any) (json.RawMessage, error) {
+// seamName is the POST /v1/seam/{name} path segment for this entrypoint ("transferOut",
+// "receive", or "publish" -- see internal/disclosure/service.go's seamScripts map), used only on
+// the disclosure-service path; the local path keeps using prepareScript's Daml script name as
+// before.
+//
+// buildInput receives the config-derived discloseTemplates allow-list (nil on the
+// disclosure-service path) and returns the fully populated input value for prepareScript / the
+// seam POST body.
+func prepareRemoteSeam(ctx context.Context, cmd *cobra.Command, a *app, s *state.State, actorRole, ownerRole, prepareScript, seamName string, buildInput func(discloseTemplates []string) any) (json.RawMessage, error) {
 	prof, err := a.resolvedProfile()
 	if err != nil {
 		return nil, err
@@ -79,6 +97,21 @@ func prepareRemoteSeam(ctx context.Context, cmd *cobra.Command, a *app, s *state
 	}
 	if actorRole == ownerRole {
 		return nil, nil
+	}
+
+	// disclosure-service path (design doc §5.3): fetch the RemoteSeam over HTTP instead of
+	// running prepareScript locally against ownerRole's own participant. buildInput(nil) is
+	// deliberate -- the service is authoritative over which templates get disclosed (its own
+	// Config.Disclose, injected server-side), so there is no client-side allow-list to pass;
+	// see internal/disclosure/service.go's handleSeam, which overwrites discloseTemplates
+	// unconditionally. This is what lets the actor obtain a seam without ever holding
+	// ownerRole's participant's own credentials -- the property
+	// --strict-participant-isolation's guard (runner.go) otherwise requires.
+	if a.disclosureServiceURL != "" {
+		cl := &disclosure.Client{BaseURL: a.disclosureServiceURL, Logf: a.verboseLogf()}
+		a.vlogf(cmd, "disclosure: fetching a RemoteSeam from the disclosure service at %s (seam=%s)",
+			a.disclosureServiceURL, seamName)
+		return cl.Seam(ctx, seamName, buildInput(nil))
 	}
 
 	cfg, err := a.topologyConfig()
@@ -130,5 +163,13 @@ type preparePublishInput struct {
 type prepareDeployNttInput struct {
 	GuardianGovernance string   `json:"guardianGovernance"`
 	FactoryCid         string   `json:"factoryCid"`
+	DiscloseTemplates  []string `json:"discloseTemplates"`
+}
+
+// prepareAcceptAdminInput mirrors Playground.Prepare.daml's PrepareAcceptAdminInput.
+type prepareAcceptAdminInput struct {
+	GuardianGovernance string   `json:"guardianGovernance"`
+	ManagerID          int      `json:"managerId"`
+	VaaBytes           string   `json:"vaaBytes"`
 	DiscloseTemplates  []string `json:"discloseTemplates"`
 }

--- a/canton/testing/cli/cmd/ntt-playground/runner.go
+++ b/canton/testing/cli/cmd/ntt-playground/runner.go
@@ -9,7 +9,25 @@ import (
 
 	"github.com/wormholelabs-xyz/native-token-transfers/canton/testing/cli/internal/ledger"
 	"github.com/wormholelabs-xyz/native-token-transfers/canton/testing/cli/internal/network"
+	"github.com/wormholelabs-xyz/native-token-transfers/canton/testing/cli/internal/profile"
 )
+
+// normalizeRole resolves role to a concrete profile.Profile.Participants key, mirroring
+// profile.Profile.Endpoint's own fallback: "" means "the profile's default participant", and an
+// unrecognized role (not a key in prof.Participants) also falls back to the default rather than
+// being treated as some other, distinct participant. This mirrors remote.go's
+// prepareRemoteSeam, which normalizes actorRole/ownerRole the same way before comparing them --
+// comparing a raw "" against a resolved concrete role would wrongly treat every default-routed
+// actor as cross-participant.
+func normalizeRole(prof profile.Profile, role string) string {
+	if role == "" {
+		return prof.DefaultParticipant
+	}
+	if _, ok := prof.Participants[role]; ok {
+		return role
+	}
+	return prof.DefaultParticipant
+}
 
 // scriptRunner is the subset of *ledger.Runner every RunE/helper in this package actually
 // calls -- narrow on purpose so wiring tests (cmd_wiring_test.go) can substitute a fake that
@@ -36,7 +54,29 @@ func (a *app) newScriptRunner(ctx context.Context) (scriptRunner, func(), error)
 // token file when required. The returned cleanup func removes the per-invocation script I/O
 // directory. If a.runnerOverride is set (tests only), it is used instead of constructing a
 // real runner -- see cmd_wiring_test.go's fakeRunner.
+//
+// The --strict-participant-isolation guard (below) runs BEFORE the a.runnerOverride
+// short-circuit, deliberately: it must fire identically whether the underlying runner is a real
+// ledger.Runner or a wiring test's fakeRunner, so cmd_wiring_test.go can pin the guard's
+// behavior (which participant a call would have targeted) without a live sandbox/LocalNet.
+// Placing it after the short-circuit would make every fakeRunner-based wiring test blind to it.
 func (a *app) newScriptRunnerFor(ctx context.Context, role string) (scriptRunner, func(), error) {
+	// a.isolationBaselineRole is set once per invocation by the three actor-routing commands
+	// (transfer/receive/publish -- see their RunE), immediately after the actor's own role is
+	// known. An empty baseline means no actor-routing command is in play for this invocation
+	// (init, deploy, fund, party, ... -- design doc §7 R8), so the guard can never fire for
+	// them, regardless of --strict-participant-isolation.
+	if a.strictParticipantIsolation && a.isolationBaselineRole != "" {
+		prof, err := a.resolvedProfile()
+		if err != nil {
+			return nil, nil, err
+		}
+		if normalizeRole(prof, role) != normalizeRole(prof, a.isolationBaselineRole) {
+			return nil, nil, fmt.Errorf("--strict-participant-isolation: this step targets participant %q but the actor is on %q -- pass --disclosure-service-url to fetch cross-participant data without holding the data owner's credentials",
+				normalizeRole(prof, role), normalizeRole(prof, a.isolationBaselineRole))
+		}
+	}
+
 	if a.runnerOverride != nil {
 		return a.runnerOverride, func() {}, nil
 	}

--- a/canton/testing/cli/cmd/ntt-playground/runner.go
+++ b/canton/testing/cli/cmd/ntt-playground/runner.go
@@ -61,12 +61,14 @@ func (a *app) newScriptRunner(ctx context.Context) (scriptRunner, func(), error)
 // behavior (which participant a call would have targeted) without a live sandbox/LocalNet.
 // Placing it after the short-circuit would make every fakeRunner-based wiring test blind to it.
 func (a *app) newScriptRunnerFor(ctx context.Context, role string) (scriptRunner, func(), error) {
-	// a.isolationBaselineRole is set once per invocation by the three actor-routing commands
-	// (transfer/receive/publish -- see their RunE), immediately after the actor's own role is
-	// known. An empty baseline means no actor-routing command is in play for this invocation
-	// (init, deploy, fund, party, ... -- design doc §7 R8), so the guard can never fire for
-	// them, regardless of --strict-participant-isolation.
-	if a.strictParticipantIsolation && a.isolationBaselineRole != "" {
+	// a.isolationBaselineSet is set once per invocation by the actor-routing commands
+	// (transfer/receive/publish/admin accept-gg-vaa -- see their RunE), immediately after the
+	// actor's own role is known; the baseline role itself may be "" (the profile's default
+	// participant -- normalizeRole resolves it). An unset baseline means no actor-routing
+	// command is in play for this invocation (init, deploy, fund, party, ... -- design doc
+	// §7 R8), so the guard can never fire for them, regardless of
+	// --strict-participant-isolation.
+	if a.strictParticipantIsolation && a.isolationBaselineSet {
 		prof, err := a.resolvedProfile()
 		if err != nil {
 			return nil, nil, err

--- a/canton/testing/cli/cmd/ntt-playground/transfer.go
+++ b/canton/testing/cli/cmd/ntt-playground/transfer.go
@@ -102,7 +102,7 @@ func newTransferCmd(a *app) *cobra.Command {
 	var chain int
 	var amount int64
 	var nonce, consistencyLevel int
-	var sign bool
+	var sign, noFund bool
 
 	cmd := &cobra.Command{
 		Use:   "transfer",
@@ -168,10 +168,28 @@ func newTransferCmd(a *app) *cobra.Command {
 			}
 			a.vlogf(cmd, "transfer: user %q → %s, deployment %q (managerId=%d)", userHint, userParty, deployment, d.ManagerID)
 
+			// Record the actor's participant role as the --strict-participant-isolation
+			// baseline (runner.go), immediately after it is known and before any call that
+			// might cross a participant boundary (the preapprove/fundUser/prepareRemoteSeam
+			// calls below). s.UserParticipants[userHint] is "" for an "amulet" sender (never
+			// routed through resolveParty), matching how prepareRemoteSeam's own actorRole
+			// normalization treats it -- "" means the profile's default participant, not a
+			// distinct, unrouted one.
+			a.isolationBaselineRole = s.UserParticipants[userHint]
+
 			// Daml's `[ContractId Holding]` needs a JSON array, never `null` -- must start
 			// non-nil (a nil Go slice marshals to `null`).
 			holdingCids := []string{}
-			if d.TokenKind == "mock" {
+			// --strict-participant-isolation implies --no-fund: fundUser is a gg-side submit
+			// (gg is the mint's sole signatory, see Playground.Ops:fundUser) that no disclosure
+			// service can stand in for -- a DisclosedContract grants visibility, never
+			// authority. So a participant-isolated sender skips this block entirely and leaves
+			// holdingCids empty; Playground.Ops:transferOut's Mock branch then enumerates the
+			// sender's own holdings in-script (Playground.Ops:mockHoldings, design doc §5.5),
+			// which needs no cross-participant disclosure at all. Use `fund` (fund.go) first,
+			// on the operator's own CLI, to mint them.
+			skipFund := noFund || a.strictParticipantIsolation
+			if d.TokenKind == "mock" && !skipFund {
 				// fundUser mints via the sender's own standing DepositPreapproval (the
 				// preapproval-based faucet Deposit -- see Playground.Ops:fundUser), so the CLI
 				// ensures it exists first; idempotent if the sender already opted in. This is
@@ -276,7 +294,7 @@ func newTransferCmd(a *app) *cobra.Command {
 			actorRole := s.UserParticipants[userHint]
 			if d.TokenKind != "amulet" {
 				ownerRole := participantRoleForParty(s, s.GuardianGovernance)
-				remoteSeam, err = prepareRemoteSeam(ctx, cmd, a, s, actorRole, ownerRole, "Playground.Prepare:prepareTransferOut", func(templates []string) any {
+				remoteSeam, err = prepareRemoteSeam(ctx, cmd, a, s, actorRole, ownerRole, "Playground.Prepare:prepareTransferOut", "transferOut", func(templates []string) any {
 					return prepareTransferOutInput{
 						GuardianGovernance: s.GuardianGovernance,
 						ManagerID:          d.ManagerID,
@@ -339,6 +357,7 @@ func newTransferCmd(a *app) *cobra.Command {
 	cmd.Flags().IntVar(&nonce, "nonce", 0, "transceiver nonce")
 	cmd.Flags().IntVar(&consistencyLevel, "consistency-level", 0, "transceiver consistency level")
 	cmd.Flags().BoolVar(&sign, "sign", false, "also sign the resulting VAA with the playground's guardian key")
+	cmd.Flags().BoolVar(&noFund, "no-fund", false, "skip the mock-kind ensure-preapproval+fundUser step (implied by --strict-participant-isolation); transferOut enumerates the sender's own holdings in-script instead -- fund the sender separately with `fund`")
 	cmd.Flags().StringVar(&tapUSD, "tap-usd", defaultTapUSD, "amulet only: USD amount to tap for the sender before transferring (\"0\" skips)")
 	_ = cmd.MarkFlagRequired("deployment")
 	_ = cmd.MarkFlagRequired("user")

--- a/canton/testing/cli/cmd/ntt-playground/transfer.go
+++ b/canton/testing/cli/cmd/ntt-playground/transfer.go
@@ -176,6 +176,7 @@ func newTransferCmd(a *app) *cobra.Command {
 			// normalization treats it -- "" means the profile's default participant, not a
 			// distinct, unrouted one.
 			a.isolationBaselineRole = s.UserParticipants[userHint]
+			a.isolationBaselineSet = true
 
 			// Daml's `[ContractId Holding]` needs a JSON array, never `null` -- must start
 			// non-nil (a nil Go slice marshals to `null`).

--- a/canton/testing/cli/e2e/playground_e2e_test.go
+++ b/canton/testing/cli/e2e/playground_e2e_test.go
@@ -549,8 +549,9 @@ func TestPlaygroundE2E(t *testing.T) {
 		require.Contains(t, out, "emitterChain=72")
 		require.Contains(t, out, "guardianSetIndex=0")
 
-		// observe: confirm the manager's own on-ledger outboundSequence advanced (0 -> 1
-		// from the single transfer above) -- the transfer output's sequence is
+		// observe: confirm the manager's own on-ledger outboundSequence advanced to 3
+		// (two bundled broadcasts at deploy time plus the single transfer above) -- the
+		// transfer output's sequence is
 		// recompute-based, so this is the suite's only direct on-ledger check of it. Also
 		// cross-check the reported chain-2 peer against the state file's peer entry (set
 		// from testdata/deploy-burnmint.json at deploy time).
@@ -564,8 +565,8 @@ func TestPlaygroundE2E(t *testing.T) {
 			} `json:"peers"`
 		}
 		require.NoErrorf(t, json.Unmarshal([]byte(stripVerbose(out)), &observed), "observe should print JSON:\n%s", out)
-		require.Equal(t, 1, observed.OutboundSequence,
-			"outboundSequence should have advanced from 0 by the single outbound transfer above")
+		require.Equal(t, 3, observed.OutboundSequence,
+			"outboundSequence: TransceiverInit broadcast at deploy (seq 0) + the pre-set peer's TransceiverRegistration broadcast (seq 1) + the single outbound transfer above (seq 2)")
 		require.Len(t, observed.Peers, 1)
 		require.Equal(t, 2, observed.Peers[0].Chain)
 		require.Equal(t, peer.ManagerAddress, observed.Peers[0].ManagerAddress)

--- a/canton/testing/cli/e2e/playground_e2e_test.go
+++ b/canton/testing/cli/e2e/playground_e2e_test.go
@@ -15,6 +15,7 @@
 package e2e
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -23,7 +24,9 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
@@ -212,6 +215,126 @@ func decimalsEqual(t *testing.T, a, b string) bool {
 	fb, err := strconv.ParseFloat(b, 64)
 	require.NoErrorf(t, err, "parse decimal %q", b)
 	return fa == fb
+}
+
+// safeBuffer is a concurrency-safe io.Writer wrapping bytes.Buffer. os/exec copies a
+// subprocess's stderr into whatever io.Writer Cmd.Stderr names from a background goroutine it
+// starts internally (Cmd.Start), so a test that polls the accumulated output while the process
+// is still running needs a writer safe for concurrent Write/String -- a bare bytes.Buffer is not.
+// Used by startDisclosureServe, below.
+type safeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *safeBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *safeBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// startDisclosureServe launches `ntt-playground disclosure serve` as a REAL subprocess of the
+// built CLI binary -- not an in-process httptest.Server standing in for it. The disclosure-
+// service design's entire point is that a consumer reaches the service over the network without
+// the fronted participant's own credentials, so the e2e proof has to exercise the actual
+// `disclosure serve` command end to end (cmd/ntt-playground/disclosure.go's RunE), including its
+// startup banner and its --topology-config-driven allow-list, not a Go-level stand-in for it.
+//
+// It shares this harness's base flags (--state-file/--canton-dir/--profile/--run-dir) so the
+// service reads the SAME on-ledger world and state file this subtest's earlier steps already
+// built, binds an ephemeral loopback port (--listen 127.0.0.1:0 -- disclosure.go resolves the
+// concrete port only after Listen succeeds, hence the banner-line parse below), and fronts
+// guardian-governance (disclosure.go's default --participant, the data owner every existing
+// prepare* seam needs), loading its allow-list from topologyFile.
+//
+// Blocks until the "disclosure serve: listening on http://" banner line appears on the process's
+// stderr, or a few seconds elapse, whichever comes first, and returns the resolved base URL plus
+// a logs func that snapshots everything the process has written to stderr so far -- used by the
+// acceptance subtest below to confirm the service actually served a seam, not just that the CLI
+// claims to have fetched one. t.Cleanup kills the process; the process also shuts itself down
+// when its own context is cancelled (disclosure.go's context.AfterFunc), so this is
+// belt-and-suspenders, not the only teardown path.
+func startDisclosureServe(t *testing.T, h *harness, topologyFile string) (baseURL string, logs func() string) {
+	t.Helper()
+	args := []string{
+		"--state-file", h.stateFile,
+		"--canton-dir", cantonDir,
+		"--profile", playgroundProfile,
+		"--run-dir", filepath.Join(h.workDir, ".run"),
+		"--topology-config", topologyFile,
+		"--verbose",
+		"disclosure", "serve", "--listen", "127.0.0.1:0",
+	}
+	cmd := exec.CommandContext(t.Context(), cliBinPath, args...)
+	var stderr safeBuffer
+	cmd.Stderr = &stderr
+	require.NoErrorf(t, cmd.Start(), "start `disclosure serve` (topology=%s)", topologyFile)
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+	})
+
+	const marker = "disclosure serve: listening on http://"
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if out := stderr.String(); strings.Contains(out, marker) {
+			rest := out[strings.Index(out, marker)+len(marker):]
+			addr := rest
+			if nl := strings.IndexByte(rest, '\n'); nl >= 0 {
+				addr = rest[:nl]
+			}
+			return "http://" + strings.TrimSpace(addr), stderr.String
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("disclosure serve (topology=%s): did not print its listening address within 10s; stderr so far:\n%s", topologyFile, stderr.String())
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// requireRoutedTo asserts that every "participant=... party=<party> ... isLocal=..." line in
+// `party list`'s (verbose-stripped) output agrees with wantParticipant: isLocal=true on that
+// participant, isLocal=false everywhere else the same party is topology-visible (only its home
+// participant actually hosts it). A package-level twin of the identically-shaped local closure
+// "parties live on separate participants" defines for itself further down -- duplicated rather
+// than hoisted out from under that subtest, which predates this one and documents its own
+// reasoning inline; sharing it here avoids a third copy for the disclosure-service subtests
+// below.
+func requireRoutedTo(t *testing.T, out, party, wantParticipant string) {
+	t.Helper()
+	matched := 0
+	for _, line := range strings.Split(stripVerbose(out), "\n") {
+		fields := strings.Fields(line)
+		var gotParty, gotParticipant, gotIsLocal string
+		for _, f := range fields {
+			switch {
+			case strings.HasPrefix(f, "party="):
+				gotParty = strings.TrimPrefix(f, "party=")
+			case strings.HasPrefix(f, "participant="):
+				gotParticipant = strings.TrimPrefix(f, "participant=")
+			case strings.HasPrefix(f, "isLocal="):
+				gotIsLocal = strings.TrimPrefix(f, "isLocal=")
+			}
+		}
+		if gotParty != party {
+			continue
+		}
+		matched++
+		if gotParticipant == wantParticipant {
+			require.Equal(t, "true", gotIsLocal, "party %s on its home participant=%s should be local: %q", party, wantParticipant, line)
+		} else {
+			require.Equal(t, "false", gotIsLocal, "party %s under a foreign participant=%s should not be local: %q", party, gotParticipant, line)
+		}
+	}
+	require.Positivef(t, matched, "expected party %s to appear in `party list` output at all:\n%s", party, out)
 }
 
 func TestPlaygroundE2E(t *testing.T) {
@@ -1417,6 +1540,164 @@ func TestPlaygroundE2E(t *testing.T) {
 		// co-signed submit.
 		require.Contains(t, initOut, "[v] script Playground.Init:proposeGenesis")
 		require.Contains(t, initOut, "[v] script Playground.Init:acceptGenesis")
+	})
+
+	// ----------------------------------------------------------------------
+	// The disclosure-service design's own acceptance criterion (its §0/§6): "an e2e test
+	// showing that a fresh participant, hosting nothing but the alice party, with only the DARs
+	// uploaded, can transact." alice-solo is that fresh participant: it hosts no playground
+	// party but the one this subtest allocates, and no playground contract exists there until it
+	// transacts (it does host its own Splice validator operator party, unavoidably -- the
+	// design's §7 R1 -- which is honest to note, not a violation of the criterion's intent).
+	//
+	// The hint allocated below is "Zoe", a fresh one, not "Alice": Alice is already routed to
+	// app-user by roughly fifteen earlier subtests in this file, and resolveParty pins a hint's
+	// participant on first allocation, so re-routing "Alice" here would force all of them
+	// cross-participant. The design doc's own §6.1 records that "alice" in the acceptance
+	// criterion denotes a plain end-user party with no privileges -- the hint's name is
+	// incidental, not load-bearing.
+	// ----------------------------------------------------------------------
+
+	t.Run("fresh participant transacts via the disclosure service", func(t *testing.T) {
+		if playgroundProfile != "localnet" {
+			t.Skip("alice-solo and the disclosure service are localnet-only concepts (sandbox has a single participant)")
+		}
+
+		// Two disclosure services, both fronting guardian-governance: one with the full
+		// disclosure allow-list (testdata/topology-alice-solo.json, widened to the same 11
+		// templates internal/disclosure.DefaultDisclose ships), one with an empty list
+		// (testdata/topology-empty.json -- the suite's existing "disclose nothing" negative
+		// control; see "cross-participant transfer fails without disclosure config" above).
+		fullURL, fullLogs := startDisclosureServe(t, h, testdataPath("topology-alice-solo.json"))
+		emptyURL, _ := startDisclosureServe(t, h, testdataPath("topology-empty.json"))
+
+		// 1. Allocate Zoe, routed to alice-solo by topology-alice-solo.json's partyHosting
+		// entry. This is the design doc's §7 R3 first-failure point: the very first ledger
+		// submit alice-solo's participant ever processes (allocatePlaygroundParty) -- a
+		// participant that, until this line runs, has never hosted a playground party at all.
+		// If this step fails, the failure is the participant-onboarding/DAR gap the design
+		// doc's §7 R1-R3 describe, not a disclosure-service problem, and is worth reporting
+		// verbatim rather than working around.
+		out := h.mustRun(t, "party", "allocate", "--hint", "Zoe", "--topology-config", testdataPath("topology-alice-solo.json"))
+		zoe := extractField(t, out, "party")
+		require.NotEmpty(t, zoe)
+
+		out = h.mustRun(t, "party", "list")
+		requireRoutedTo(t, out, zoe, "alice-solo")
+
+		// 2. Fund Zoe via the operator's own CLI (design doc §5.5): `fund` ensures Zoe's
+		// standing DepositPreapproval (routed to alice-solo, Zoe's own participant) and mints
+		// via gg's fundUser faucet (routed to gg's own participant) -- both legitimately
+		// cross-participant, operator-side actions, so `fund` never sets
+		// a.isolationBaselineRole and stays unaffected by --strict-participant-isolation below
+		// (runner.go's doc comment).
+		h.mustRun(t, "fund", "--deployment", "burnmint", "--user", "Zoe", "--amount", "500000")
+
+		// 3. Negative control A: --strict-participant-isolation with NO disclosure-service URL.
+		// Zoe's own participant cannot resolve gg-owned data (NttManager/CoreState/Emitter/the
+		// committed factory) by itself, so the isolation guard (runner.go's newScriptRunnerFor)
+		// must refuse the cross-participant prepare fetch client-side, before any script runs at
+		// all -- proving the flow genuinely needs cross-participant data it cannot reach on its
+		// own, not merely that today's harness happens to make it work.
+		out, err := h.run(t, "--topology-config", testdataPath("topology-alice-solo.json"),
+			"--strict-participant-isolation",
+			"transfer", "--deployment", "burnmint", "--user", "Zoe", "--chain", "2",
+			"--recipient-address", addr32("77"), "--amount", "500000")
+		require.Error(t, err, "a strict-isolation transfer with no disclosure-service URL must fail before reaching the ledger")
+		require.Contains(t, out, "strict-participant-isolation")
+
+		// 4. Negative control B: a disclosure service IS configured, but its own allow-list is
+		// empty. The prepare seam still runs (it is gg's own script, on gg's own participant),
+		// but discloses nothing at all, so Zoe's own submit-side Playground.Ops:transferOut
+		// (running on alice-solo) still cannot see -- let alone exercise -- the gg-owned
+		// NttManager the transfer needs. Fails ON-LEDGER, not client-side, proving the
+		// service's allow-list is genuinely load-bearing and not merely a URL-presence check.
+		// Neither this control nor the one above moves any of Zoe's just-funded 500000: a Daml
+		// transaction is atomic, so a client-side abort (A) or an on-ledger CONTRACT_NOT_FOUND
+		// (B, here) leaves no partial effect -- the same literal amount is reused unspent by
+		// the successful transfer in step 5.
+		out, err = h.run(t, "--topology-config", testdataPath("topology-alice-solo.json"),
+			"--strict-participant-isolation", "--disclosure-service-url", emptyURL,
+			"transfer", "--deployment", "burnmint", "--user", "Zoe", "--chain", "2",
+			"--recipient-address", addr32("77"), "--amount", "500000")
+		require.Error(t, err, "a disclosure service with an empty allow-list must not let the transfer through")
+		require.Contains(t, out, "CONTRACT_NOT_FOUND")
+
+		// 5. The acceptance criterion itself: the SAME command, against the full-allow-list
+		// service, with --sign -- succeeds WITHOUT Zoe's CLI ever holding gg's participant's
+		// credentials (--strict-participant-isolation is still on). The narration must show the
+		// RemoteSeam came from the disclosure service, and must NOT show a local
+		// "script Playground.Prepare:prepareTransferOut" run -- that would mean this
+		// invocation fell back to the pre-disclosure-service local path, which defeats the
+		// point entirely (see remote.go's prepareRemoteSeam doc comment). The service's own
+		// captured stderr independently confirms it actually served the transferOut seam.
+		out = h.mustRun(t, "--topology-config", testdataPath("topology-alice-solo.json"),
+			"--strict-participant-isolation", "--disclosure-service-url", fullURL,
+			"transfer", "--deployment", "burnmint", "--user", "Zoe", "--chain", "2",
+			"--recipient-address", addr32("77"), "--amount", "500000", "--sign")
+		require.Contains(t, out, "emitterChain=72")
+		require.Contains(t, out, "disclosure: fetching a RemoteSeam from the disclosure service")
+		require.NotContains(t, out, "script Playground.Prepare:prepareTransferOut",
+			"the prepare/disclose script must run inside the disclosure-service process, not this CLI invocation")
+		require.Contains(t, fullLogs(), "disclosure: seam transferOut ok",
+			"the service's own logs should confirm it served the transferOut seam")
+
+		// 6. Round trip: Zoe also RECEIVES, as her own executor, through the same service --
+		// exercising the "receive" seam (prepareReceive) rather than "transferOut", still under
+		// --strict-participant-isolation. Her standing DepositPreapproval (created by `fund`'s
+		// own preapprove step above) already satisfies receive's prior-opt-in gate, so no
+		// separate preapprove call is needed here.
+		out = h.mustRun(t, "guardian", "sign-transfer",
+			"--deployment", "burnmint", "--to-recipient", "Zoe", "--amount", "250000", "--source-chain", "2")
+		vaaHex := extractField(t, out, "vaa")
+		pubKeyHex := extractField(t, out, "pubkey")
+		require.NotEmpty(t, vaaHex)
+
+		out = h.mustRun(t, "--topology-config", testdataPath("topology-alice-solo.json"),
+			"--strict-participant-isolation", "--disclosure-service-url", fullURL,
+			"receive", "--deployment", "burnmint",
+			"--vaa", vaaHex, "--recipient", "Zoe", "--executor", "Zoe", "--pubkey", pubKeyHex)
+		require.Contains(t, out, "recipientChain=72")
+		require.Contains(t, out, "amount=250000")
+
+		out = h.mustRun(t, "balance", "--party", "Zoe", "--deployment", "burnmint")
+		require.Contains(t, out, "cip56HoldingTotal=")
+	})
+
+	t.Run("disclosure service enforces the allow-list server-side", func(t *testing.T) {
+		if playgroundProfile != "localnet" {
+			t.Skip("alice-solo and the disclosure service are localnet-only concepts (sandbox has a single participant)")
+		}
+
+		// A service whose allow-list is missing exactly one entry (CoreState) -- the same
+		// negative control as "disclosure config recovers the transfer" above
+		// (testdata/topology-missing-corestate.json), now enforced SERVER-side instead of
+		// client-side: the client sends no discloseTemplates of its own at all on the
+		// disclosure-service path (remote.go's prepareRemoteSeam calls buildInput(nil) there),
+		// so a failure here proves the SERVICE's own Config.Disclose -- not anything the client
+		// asked for -- is authoritative, and that the granularity survives the move to a
+		// service: it is still per-template, not an all-or-nothing switch (the e2e:1394-style
+		// assertion, now moved server-side).
+		missingURL, _ := startDisclosureServe(t, h, testdataPath("topology-missing-corestate.json"))
+
+		// Re-fund Zoe before reusing the acceptance subtest's own transfer command verbatim:
+		// that subtest's step 5 already spent her funded 500000 (BurnMint burns exactly the
+		// requested amount and returns any surplus as change, Wormhole.Ntt.Manager.daml's
+		// Transfer choice), and her subsequent receive only replaced part of it. Without this,
+		// Playground.Ops:transferOut's insufficient-holdings assertion ("ntt: input holdings do
+		// not cover the burn amount") could fire before the transaction ever reaches the
+		// CoreState visibility check this subtest exists to pin, which would make the test pass
+		// for the wrong reason (or fail with a confusing, unrelated message).
+		h.mustRun(t, "fund", "--deployment", "burnmint", "--user", "Zoe", "--amount", "500000")
+
+		// The SAME command as the acceptance subtest's step 5 (same deployment/user/chain/
+		// amount/recipient-address/--sign), pointed at the CoreState-missing service instead.
+		out, err := h.run(t, "--topology-config", testdataPath("topology-alice-solo.json"),
+			"--strict-participant-isolation", "--disclosure-service-url", missingURL,
+			"transfer", "--deployment", "burnmint", "--user", "Zoe", "--chain", "2",
+			"--recipient-address", addr32("77"), "--amount", "500000", "--sign")
+		require.Error(t, err, "a disclosure service missing one required template from its allow-list must still fail the transfer")
+		require.Contains(t, out, "CONTRACT_NOT_FOUND")
 	})
 
 	t.Run("network down", func(t *testing.T) {

--- a/canton/testing/cli/internal/disclosure/acs.go
+++ b/canton/testing/cli/internal/disclosure/acs.go
@@ -1,0 +1,227 @@
+package disclosure
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Contract is one disclosed contract served by the disclosure service: the fields a Daml
+// Script needs to reconstitute a Disclosure (see Playground/Disclose.daml's
+// DisclosedContractIn, mkSeedDisclosure/toDisclosureByName), plus the decoded create argument
+// for a generic HTTP consumer that has no Daml Script of its own to run.
+type Contract struct {
+	TemplateID string          `json:"templateId"`
+	ContractID string          `json:"contractId"`
+	Blob       string          `json:"blob"`    // hex, converted from the JSON API's base64 (see toHexBlob)
+	Payload    json.RawMessage `json:"payload"` // Daml-JSON createArgument
+}
+
+// activeContractsRequest mirrors the /v2/state/active-contracts request body confirmed live
+// against Splice LocalNet 0.6.12 (the plan's §2.3): filtersByParty keyed on the reading party,
+// one TemplateFilter per requested template with includeCreatedEventBlob:true. Reuses the exact
+// nested-struct idiom internal/observer/observer.go uses for GetUpdatesRequest -- copied rather
+// than imported so this package has no internal/observer dependency (the plan's §3: observer is
+// a shape reference, not a shared implementation).
+type activeContractsRequest struct {
+	ActiveAtOffset int64 `json:"activeAtOffset"`
+	EventFormat    struct {
+		FiltersByParty map[string]acsPartyFilter `json:"filtersByParty"`
+		Verbose        bool                      `json:"verbose"`
+	} `json:"eventFormat"`
+}
+
+type acsPartyFilter struct {
+	Cumulative []acsCumulativeFilter `json:"cumulative"`
+}
+
+type acsCumulativeFilter struct {
+	IdentifierFilter struct {
+		TemplateFilter struct {
+			Value struct {
+				TemplateID              string `json:"templateId"`
+				IncludeCreatedEventBlob bool   `json:"includeCreatedEventBlob"`
+			} `json:"value"`
+		} `json:"TemplateFilter"`
+	} `json:"identifierFilter"`
+}
+
+// acsCreatedEvent is the subset of CreatedEvent fields this package needs off a JsActiveContract.
+type acsCreatedEvent struct {
+	ContractID       string          `json:"contractId"`
+	TemplateID       string          `json:"templateId"`
+	CreateArgument   json.RawMessage `json:"createArgument"`
+	CreatedEventBlob string          `json:"createdEventBlob"` // base64, per the JSON API
+}
+
+// acsContractEntry is one active-contracts response element's "contractEntry" -- a Daml-JSON
+// sum type. Only the JsActiveContract variant carries a createdEvent; other variants (e.g. an
+// incomplete-reassignment marker) decode with JsActiveContract left nil and are skipped by
+// Query, not treated as an error.
+type acsContractEntry struct {
+	JsActiveContract *struct {
+		CreatedEvent *acsCreatedEvent `json:"createdEvent"`
+	} `json:"JsActiveContract"`
+}
+
+type acsResponseEntry struct {
+	ContractEntry acsContractEntry `json:"contractEntry"`
+}
+
+// ActiveContracts queries one participant's ACS over the JSON Ledger API v2, with
+// includeCreatedEventBlob:true so the response carries everything a Daml Script's
+// mkSeedDisclosure/toDisclosureByName needs to reconstitute a Disclosure (the plan's §2.3).
+type ActiveContracts struct {
+	BaseURL    string               // e.g. http://localhost:6975
+	Token      string               // bearer token; empty sends no Authorization header
+	Party      string               // the reader party -- the filtersByParty key
+	HTTPClient *http.Client         // nil → http.DefaultClient
+	Logf       func(string, ...any) // nil-safe
+}
+
+func (a *ActiveContracts) httpClient() *http.Client {
+	if a.HTTPClient != nil {
+		return a.HTTPClient
+	}
+	return http.DefaultClient
+}
+
+func (a *ActiveContracts) logf(format string, args ...any) {
+	if a.Logf != nil {
+		a.Logf(format, args...)
+	}
+}
+
+func (a *ActiveContracts) authHeader(req *http.Request) {
+	if a.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+a.Token)
+	}
+}
+
+// LedgerEnd fetches GET /v2/state/ledger-end -- the offset Query pins its activeAtOffset to.
+// Mirrors internal/observer.LedgerEnd exactly (same endpoint, same response shape), copied
+// rather than imported for the same reason as activeContractsRequest above.
+func (a *ActiveContracts) LedgerEnd(ctx context.Context) (int64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, a.BaseURL+"/v2/state/ledger-end", nil)
+	if err != nil {
+		return 0, fmt.Errorf("disclosure: build ledger-end request: %w", err)
+	}
+	a.authHeader(req)
+
+	resp, err := a.httpClient().Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("disclosure: ledger-end request: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, fmt.Errorf("disclosure: read ledger-end response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("disclosure: ledger-end: HTTP %d: %s", resp.StatusCode, body)
+	}
+	var out struct {
+		Offset int64 `json:"offset"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return 0, fmt.Errorf("disclosure: parse ledger-end response: %w\nraw: %s", err, body)
+	}
+	return out.Offset, nil
+}
+
+// toHexBlob re-encodes a JSON API createdEventBlob from base64 (the API's wire format) to hex
+// (what Daml Script's Disclosure.blob requires). Same reasoning as
+// cmd/ntt-playground/transfer.go's toAmuletSeamJSON: passing the API's base64 straight through
+// to a `dpm script` input fails with "cannot parse HexString". Both encodings carry the same
+// bytes.
+func toHexBlob(base64Blob string) (string, error) {
+	raw, err := base64.StdEncoding.DecodeString(base64Blob)
+	if err != nil {
+		return "", fmt.Errorf("disclosure: decode createdEventBlob (base64): %w", err)
+	}
+	return hex.EncodeToString(raw), nil
+}
+
+// Query fetches the current ACS for templates (each a "Module:Entity" or
+// "#<package-name>:Module:Entity" name, per observer.go's package-name convention) as a.Party,
+// with includeCreatedEventBlob:true, and returns the decoded contracts plus the activeAtOffset
+// the read was pinned to. Stateless and query-on-demand by design (the plan's §3): no cid is
+// ever cached across calls.
+func (a *ActiveContracts) Query(ctx context.Context, templates []string) ([]Contract, int64, error) {
+	offset, err := a.LedgerEnd(ctx)
+	if err != nil {
+		return nil, 0, fmt.Errorf("disclosure: query: %w", err)
+	}
+
+	cumulative := make([]acsCumulativeFilter, len(templates))
+	for i, t := range templates {
+		var cf acsCumulativeFilter
+		cf.IdentifierFilter.TemplateFilter.Value.TemplateID = t
+		cf.IdentifierFilter.TemplateFilter.Value.IncludeCreatedEventBlob = true
+		cumulative[i] = cf
+	}
+	var reqBody activeContractsRequest
+	reqBody.ActiveAtOffset = offset
+	reqBody.EventFormat.FiltersByParty = map[string]acsPartyFilter{
+		a.Party: {Cumulative: cumulative},
+	}
+	reqBody.EventFormat.Verbose = false
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, 0, fmt.Errorf("disclosure: marshal active-contracts request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.BaseURL+"/v2/state/active-contracts", bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, 0, fmt.Errorf("disclosure: build active-contracts request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	a.authHeader(req)
+
+	resp, err := a.httpClient().Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("disclosure: active-contracts request: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, 0, fmt.Errorf("disclosure: read active-contracts response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, 0, fmt.Errorf("disclosure: active-contracts: HTTP %d: %s", resp.StatusCode, respBody)
+	}
+
+	var entries []acsResponseEntry
+	if err := json.Unmarshal(respBody, &entries); err != nil {
+		return nil, 0, fmt.Errorf("disclosure: parse active-contracts response: %w\nraw: %s", err, respBody)
+	}
+
+	contracts := make([]Contract, 0, len(entries))
+	for _, e := range entries {
+		ac := e.ContractEntry.JsActiveContract
+		if ac == nil || ac.CreatedEvent == nil {
+			// A non-JsActiveContract oneOf variant (e.g. an incomplete-reassignment
+			// marker) -- not an active contract, not an error.
+			continue
+		}
+		hexBlob, err := toHexBlob(ac.CreatedEvent.CreatedEventBlob)
+		if err != nil {
+			return nil, 0, fmt.Errorf("disclosure: contract %s: %w", ac.CreatedEvent.ContractID, err)
+		}
+		contracts = append(contracts, Contract{
+			TemplateID: ac.CreatedEvent.TemplateID,
+			ContractID: ac.CreatedEvent.ContractID,
+			Blob:       hexBlob,
+			Payload:    ac.CreatedEvent.CreateArgument,
+		})
+	}
+
+	a.logf("disclosure: acs query as %s: %d template(s), %d contract(s) at offset %d", a.Party, len(templates), len(contracts), offset)
+	return contracts, offset, nil
+}

--- a/canton/testing/cli/internal/disclosure/acs_test.go
+++ b/canton/testing/cli/internal/disclosure/acs_test.go
@@ -1,0 +1,154 @@
+package disclosure
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// knownBlobBase64/knownBlobHex are the same bytes ("hello world") in the JSON API's base64
+// wire format and the hex format Daml Script's Disclosure.blob requires -- the
+// cmd/ntt-playground/transfer.go:68-84 gotcha this package must also handle.
+const (
+	knownBlobBase64 = "aGVsbG8gd29ybGQ="
+	knownBlobHex    = "68656c6c6f20776f726c64"
+)
+
+// acsTestServer records the last /v2/state/active-contracts request body and serves canned
+// ledger-end/active-contracts responses, plus asserting on the Authorization header.
+type acsTestServer struct {
+	*httptest.Server
+	ledgerEnd      int64
+	lastAuth       string
+	lastReqBody    activeContractsRequest
+	acsResponseRaw string
+}
+
+func newACSTestServer(t *testing.T, ledgerEnd int64, acsResponseRaw string) *acsTestServer {
+	t.Helper()
+	s := &acsTestServer{ledgerEnd: ledgerEnd, acsResponseRaw: acsResponseRaw}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/state/ledger-end", func(w http.ResponseWriter, r *http.Request) {
+		s.lastAuth = r.Header.Get("Authorization")
+		_ = json.NewEncoder(w).Encode(struct {
+			Offset int64 `json:"offset"`
+		}{Offset: s.ledgerEnd})
+	})
+	mux.HandleFunc("/v2/state/active-contracts", func(w http.ResponseWriter, r *http.Request) {
+		s.lastAuth = r.Header.Get("Authorization")
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &s.lastReqBody))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(s.acsResponseRaw))
+	})
+	s.Server = httptest.NewServer(mux)
+	t.Cleanup(s.Close)
+	return s
+}
+
+// canned response: one genuine JsActiveContract, plus one other oneOf variant that Query must
+// tolerate and skip (the plan's §5.2: "other oneOf variants exist").
+const acsCannedResponse = `[
+  {"contractEntry": {"JsActiveContract": {"createdEvent": {
+      "contractId": "cid-1",
+      "templateId": "#wormhole-core:Wormhole.Core.State:CoreState",
+      "createArgument": {"owner": "Alice", "amount": "10.0"},
+      "createdEventBlob": "` + knownBlobBase64 + `"
+  }}}},
+  {"contractEntry": {"JsEmpty": {}}}
+]`
+
+func TestActiveContracts_LedgerEnd(t *testing.T) {
+	srv := newACSTestServer(t, 42, "[]")
+	a := &ActiveContracts{BaseURL: srv.URL, Token: "tok-123", Party: "alice::party"}
+
+	offset, err := a.LedgerEnd(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(42), offset)
+	require.Equal(t, "Bearer tok-123", srv.lastAuth)
+}
+
+func TestActiveContracts_LedgerEnd_NonOKStatus(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/state/ledger-end", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	a := &ActiveContracts{BaseURL: srv.URL, Party: "alice::party"}
+	_, err := a.LedgerEnd(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "500")
+	require.Contains(t, err.Error(), "boom")
+}
+
+func TestActiveContracts_Query_RequestShape(t *testing.T) {
+	srv := newACSTestServer(t, 99, acsCannedResponse)
+	a := &ActiveContracts{BaseURL: srv.URL, Token: "tok-456", Party: "alice::party"}
+
+	_, offset, err := a.Query(context.Background(), []string{
+		"Wormhole.Core.State:CoreState",
+		"Wormhole.Ntt.Manager:NttManager",
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(99), offset)
+
+	req := srv.lastReqBody
+	require.Equal(t, int64(99), req.ActiveAtOffset)
+	require.False(t, req.EventFormat.Verbose)
+
+	pf, ok := req.EventFormat.FiltersByParty["alice::party"]
+	require.True(t, ok, "filtersByParty must be keyed on ActiveContracts.Party")
+	require.Len(t, pf.Cumulative, 2)
+	for _, cf := range pf.Cumulative {
+		require.True(t, cf.IdentifierFilter.TemplateFilter.Value.IncludeCreatedEventBlob,
+			"includeCreatedEventBlob must be true -- this is the whole blob-export mechanism (plan §2.3)")
+	}
+	require.Equal(t, "Wormhole.Core.State:CoreState", pf.Cumulative[0].IdentifierFilter.TemplateFilter.Value.TemplateID)
+	require.Equal(t, "Wormhole.Ntt.Manager:NttManager", pf.Cumulative[1].IdentifierFilter.TemplateFilter.Value.TemplateID)
+
+	require.Equal(t, "Bearer tok-456", srv.lastAuth)
+}
+
+func TestActiveContracts_Query_DecodesAndConvertsBlob(t *testing.T) {
+	srv := newACSTestServer(t, 7, acsCannedResponse)
+	a := &ActiveContracts{BaseURL: srv.URL, Party: "alice::party"}
+
+	contracts, _, err := a.Query(context.Background(), []string{"Wormhole.Core.State:CoreState"})
+	require.NoError(t, err)
+
+	// The JsEmpty entry must be skipped, leaving exactly the one genuine contract.
+	require.Len(t, contracts, 1)
+	c := contracts[0]
+	require.Equal(t, "cid-1", c.ContractID)
+	require.Equal(t, "#wormhole-core:Wormhole.Core.State:CoreState", c.TemplateID)
+	require.Equal(t, knownBlobHex, c.Blob, "createdEventBlob must be re-encoded base64 -> hex")
+	require.JSONEq(t, `{"owner": "Alice", "amount": "10.0"}`, string(c.Payload))
+}
+
+func TestActiveContracts_Query_NonOKStatus(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/state/ledger-end", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(struct {
+			Offset int64 `json:"offset"`
+		}{Offset: 1})
+	})
+	mux.HandleFunc("/v2/state/active-contracts", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusForbidden)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	a := &ActiveContracts{BaseURL: srv.URL, Party: "alice::party"}
+	_, _, err := a.Query(context.Background(), []string{"A:B"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "403")
+	require.Contains(t, err.Error(), "nope")
+}

--- a/canton/testing/cli/internal/disclosure/client.go
+++ b/canton/testing/cli/internal/disclosure/client.go
@@ -1,0 +1,106 @@
+package disclosure
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// Client is the CLI-side client for a disclosure service (Service, above). Used by
+// cmd/ntt-playground/remote.go's prepareRemoteSeam when --disclosure-service-url is set (the
+// plan's §5.3), and directly by anything that only needs the generic /v1/disclosures layer.
+type Client struct {
+	BaseURL    string
+	HTTPClient *http.Client // nil → http.DefaultClient
+	Logf       func(string, ...any)
+}
+
+func (c *Client) httpClient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return http.DefaultClient
+}
+
+func (c *Client) logf(format string, args ...any) {
+	if c.Logf != nil {
+		c.Logf(format, args...)
+	}
+}
+
+// Disclosures calls GET /v1/disclosures?template=... once per template, returning the served
+// contracts and the offset they were valid at. A non-2xx response (notably 403, when a
+// requested template is not in the service's allow-list) is returned as an error carrying the
+// status and body verbatim, so a caller can surface the offending template name.
+func (c *Client) Disclosures(ctx context.Context, templates []string) ([]Contract, int64, error) {
+	u, err := url.Parse(c.BaseURL + "/v1/disclosures")
+	if err != nil {
+		return nil, 0, fmt.Errorf("disclosure: client: parse base URL: %w", err)
+	}
+	q := u.Query()
+	for _, t := range templates {
+		q.Add("template", t)
+	}
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("disclosure: client: build disclosures request: %w", err)
+	}
+	c.logf("disclosure: client: GET %s", u.String())
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("disclosure: client: disclosures request: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, 0, fmt.Errorf("disclosure: client: read disclosures response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, 0, fmt.Errorf("disclosure: client: disclosures: HTTP %d: %s", resp.StatusCode, body)
+	}
+
+	var out disclosuresResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, 0, fmt.Errorf("disclosure: client: parse disclosures response: %w\nraw: %s", err, body)
+	}
+	return out.Contracts, out.ActiveAtOffset, nil
+}
+
+// Seam calls POST /v1/seam/{name}, marshaling input as the request body, and returns the
+// script's RemoteSeam output verbatim as raw JSON -- the CLI never parses it, only relays it
+// into the next `dpm script` call's input (matching how transferOutInput.Remote is already
+// handled today). A non-2xx response is returned as an error carrying the status and body.
+func (c *Client) Seam(ctx context.Context, name string, input any) (json.RawMessage, error) {
+	body, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("disclosure: client: marshal seam %s input: %w", name, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/v1/seam/"+name, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("disclosure: client: build seam %s request: %w", name, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	c.logf("disclosure: client: POST /v1/seam/%s", name)
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("disclosure: client: seam %s request: %w", name, err)
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("disclosure: client: read seam %s response: %w", name, err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("disclosure: client: seam %s: HTTP %d: %s", name, resp.StatusCode, respBody)
+	}
+	return json.RawMessage(respBody), nil
+}

--- a/canton/testing/cli/internal/disclosure/client_test.go
+++ b/canton/testing/cli/internal/disclosure/client_test.go
@@ -1,0 +1,86 @@
+package disclosure
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestClient_Disclosures_RoundTrip runs Client against a real Service.Handler backed by a
+// canned ACS server -- proves the two independently-tested halves (Client's HTTP encoding,
+// Service's HTTP decoding) agree on the wire.
+func TestClient_Disclosures_RoundTrip(t *testing.T) {
+	acsSrv := newACSTestServer(t, 12, acsCannedResponse)
+	svc := &Service{
+		Cfg: testConfig(),
+		ACS: &ActiveContracts{BaseURL: acsSrv.URL, Party: "gg::party"},
+	}
+	svcSrv := httptest.NewServer(svc.Handler())
+	t.Cleanup(svcSrv.Close)
+
+	cl := &Client{BaseURL: svcSrv.URL}
+	contracts, offset, err := cl.Disclosures(context.Background(), []string{"Wormhole.Core.State:CoreState"})
+	require.NoError(t, err)
+	require.Equal(t, int64(12), offset)
+	require.Len(t, contracts, 1)
+	require.Equal(t, "cid-1", contracts[0].ContractID)
+	require.Equal(t, knownBlobHex, contracts[0].Blob)
+}
+
+// TestClient_Disclosures_SurfacesForbiddenOffender proves the 403 offender text (the plan's
+// §5.2) survives the client round-trip, not just the raw HTTP handler test.
+func TestClient_Disclosures_SurfacesForbiddenOffender(t *testing.T) {
+	svc := &Service{Cfg: testConfig()}
+	svcSrv := httptest.NewServer(svc.Handler())
+	t.Cleanup(svcSrv.Close)
+
+	cl := &Client{BaseURL: svcSrv.URL}
+	_, _, err := cl.Disclosures(context.Background(), []string{"Evil:Template"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Evil:Template")
+	require.Contains(t, err.Error(), "403")
+}
+
+// TestClient_Seam_RoundTrip proves a client-supplied discloseTemplates is overridden
+// server-side and the fake runner's RemoteSeam output comes back verbatim.
+func TestClient_Seam_RoundTrip(t *testing.T) {
+	runner := &fakeScriptRunner{output: json.RawMessage(`{"mgr": {"managerId": 3}}`)}
+	svc := &Service{
+		Cfg: testConfig(),
+		NewRunner: func(ctx context.Context) (ScriptRunner, func(), error) {
+			return runner, func() {}, nil
+		},
+	}
+	svcSrv := httptest.NewServer(svc.Handler())
+	t.Cleanup(svcSrv.Close)
+
+	cl := &Client{BaseURL: svcSrv.URL}
+	input := map[string]any{
+		"operator":          "Operator",
+		"discloseTemplates": []string{"Evil:Template"},
+	}
+	out, err := cl.Seam(context.Background(), "transferOut", input)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"mgr": {"managerId": 3}}`, string(out))
+
+	require.Equal(t, "Playground.Prepare:prepareTransferOut", runner.scriptName)
+	gotInput, ok := runner.input.(map[string]any)
+	require.True(t, ok)
+	gotTemplates, ok := gotInput["discloseTemplates"].([]string)
+	require.True(t, ok)
+	require.Equal(t, testConfig().Templates(), gotTemplates)
+}
+
+func TestClient_Seam_UnknownName_SurfacesNotFound(t *testing.T) {
+	svc := &Service{Cfg: testConfig()}
+	svcSrv := httptest.NewServer(svc.Handler())
+	t.Cleanup(svcSrv.Close)
+
+	cl := &Client{BaseURL: svcSrv.URL}
+	_, err := cl.Seam(context.Background(), "bogus", map[string]any{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "404")
+}

--- a/canton/testing/cli/internal/disclosure/config.go
+++ b/canton/testing/cli/internal/disclosure/config.go
@@ -79,6 +79,7 @@ func DefaultDisclose() []Entry {
 		{Template: "Playground.MockRegistry:MockPreapprovedTransferFactory", FetchAs: "GuardianGovernance"},
 		{Template: "Token.CIP0056.CoinFactory:CoinFactory", FetchAs: "GuardianGovernance"},
 		{Template: "Test.TestNtt:Cip56MockHolding", FetchAs: "GuardianGovernance"},
+		{Template: "Wormhole.Ntt.Manager:AdminTransferProposal", FetchAs: "GuardianGovernance"},
 	}
 }
 
@@ -125,4 +126,15 @@ func (c Config) Entry(template string) (Entry, bool) {
 		}
 	}
 	return Entry{}, false
+}
+
+// Templates returns Disclose's template names -- the server-side allow-list a disclosure
+// Service enforces (the plan's §5.4) and injects into a POST /v1/seam/* request's
+// discloseTemplates, overriding anything the client sent.
+func (c Config) Templates() []string {
+	out := make([]string, len(c.Disclose))
+	for i, e := range c.Disclose {
+		out[i] = e.Template
+	}
+	return out
 }

--- a/canton/testing/cli/internal/disclosure/config_test.go
+++ b/canton/testing/cli/internal/disclosure/config_test.go
@@ -127,3 +127,33 @@ func TestEntry_MissOnEmptyConfig(t *testing.T) {
 	_, ok := c.Entry("anything:AtAll")
 	require.False(t, ok)
 }
+
+// ----------------------------------------------------------------------
+// Templates: the server-side allow-list a disclosure Service enforces (the plan's §5.4)
+// ----------------------------------------------------------------------
+
+func TestTemplates_ListsAllDiscloseEntriesInOrder(t *testing.T) {
+	c, err := Load(writeConfig(t, exampleConfigJSON))
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"Wormhole.Ntt.Manager:NttManager",
+		"Wormhole.Core.State:CoreState",
+		"Wormhole.Core.State:Emitter",
+		"Playground.MockToken:MockToken",
+		"Wormhole.Ntt.TokenCip56:Cip56BurnMintToken",
+		"Test.TestNtt:MockBurnMintFactory",
+	}, c.Templates())
+}
+
+func TestTemplates_EmptyOnEmptyConfig(t *testing.T) {
+	c, err := Load(writeConfig(t, `{"disclose": []}`))
+	require.NoError(t, err)
+	require.Empty(t, c.Templates())
+}
+
+func TestTemplates_DefaultsWhenFileMissing(t *testing.T) {
+	c, err := Load(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	require.NoError(t, err)
+	require.Len(t, c.Templates(), len(DefaultDisclose()))
+	require.Equal(t, "Wormhole.Ntt.Manager:NttManager", c.Templates()[0])
+}

--- a/canton/testing/cli/internal/disclosure/service.go
+++ b/canton/testing/cli/internal/disclosure/service.go
@@ -1,0 +1,194 @@
+package disclosure
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// ScriptRunner is the subset of internal/ledger.Runner the service needs to run the
+// Playground.Prepare seam scripts -- lifted here so Service is unit-testable with a fake and
+// carries no `dpm` dependency in tests. Mirrors cmd/ntt-playground/runner.go's scriptRunner
+// interface shape exactly; *ledger.Runner satisfies both structurally.
+type ScriptRunner interface {
+	Run(ctx context.Context, scriptName string, input, output any) error
+}
+
+// seamScripts maps the POST /v1/seam/{name} path segment to the Playground.Prepare script it
+// runs. Only these four exist today (the plan's §5.6: no new Daml resolution logic beyond
+// prepareAcceptAdmin, itself mechanical);
+// any other name 404s.
+var seamScripts = map[string]string{
+	"transferOut":         "Playground.Prepare:prepareTransferOut",
+	"receive":             "Playground.Prepare:prepareReceive",
+	"publish":             "Playground.Prepare:preparePublish",
+	"acceptAdminTransfer": "Playground.Prepare:prepareAcceptAdmin",
+}
+
+// Service is the allow-list-gated, stateless disclosure server fronting one participant (the
+// plan's §5.2/§5.3).
+//
+// Security posture (the plan's §4) -- this is a harness-grade implementation, not a production
+// one:
+//   - No authentication, no TLS. It is still a strict privilege reduction versus today's CLI,
+//     which holds the fronted participant's admin JWT and can read its entire ACS and submit as
+//     it; this service can only read allow-listed templates and can never submit.
+//   - The caller (cmd/ntt-playground) is responsible for binding to 127.0.0.1 by default and
+//     requiring an explicit opt-in to listen more broadly.
+//   - A production deployment needs, at minimum: mTLS or OAuth client-credentials auth,
+//     per-consumer (not global) allow-lists, rate limiting, and an audit log of
+//     (consumer, template, contract id, offset). Whether to echo the create argument payload at
+//     all (as /v1/disclosures does) is a separate decision a production deployment must make
+//     explicitly -- it is no more information than the blob, but it is far more casually
+//     consumed.
+type Service struct {
+	Cfg         Config
+	Participant string           // role name served, for /v1/healthz (e.g. "guardian-governance")
+	ACS         *ActiveContracts // generic /v1/disclosures backend; may be nil (endpoint then 503s)
+
+	// NewRunner builds the ScriptRunner used by POST /v1/seam/*, run against the participant
+	// this service fronts. The returned cleanup func is always called once the script
+	// completes (or fails). May be left nil in a service that only ever serves /v1/disclosures.
+	NewRunner func(ctx context.Context) (ScriptRunner, func(), error)
+
+	Logf func(string, ...any) // nil-safe
+}
+
+func (s *Service) logf(format string, args ...any) {
+	if s.Logf != nil {
+		s.Logf(format, args...)
+	}
+}
+
+// Handler builds the service's http.Handler. Uses net/http's ServeMux only -- no router
+// dependency, matching the plan's "no new dependency" mandate.
+func (s *Service) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/healthz", s.handleHealthz)
+	mux.HandleFunc("/v1/disclosures", s.handleDisclosures)
+	mux.HandleFunc("/v1/seam/", s.handleSeam)
+	return mux
+}
+
+type healthzResponse struct {
+	Participant string   `json:"participant"`
+	Templates   []string `json:"templates"`
+	LedgerEnd   int64    `json:"ledgerEnd,omitempty"`
+}
+
+func (s *Service) handleHealthz(w http.ResponseWriter, r *http.Request) {
+	resp := healthzResponse{
+		Participant: s.Participant,
+		Templates:   s.Cfg.Templates(),
+	}
+	if s.ACS != nil {
+		offset, err := s.ACS.LedgerEnd(r.Context())
+		if err != nil {
+			s.logf("disclosure: healthz: ledger-end: %v", err)
+		} else {
+			resp.LedgerEnd = offset
+		}
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+type disclosuresResponse struct {
+	ActiveAtOffset int64      `json:"activeAtOffset"`
+	Contracts      []Contract `json:"contracts"`
+}
+
+func (s *Service) handleDisclosures(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "disclosure: method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	templates := r.URL.Query()["template"]
+	if len(templates) == 0 {
+		http.Error(w, `disclosure: missing required "template" query parameter`, http.StatusBadRequest)
+		return
+	}
+	// Server-side allow-list enforcement (fixes the plan's §1.4(3)): a template the client
+	// asks for but that is not in this service's own Config.Disclose is refused outright,
+	// naming the offender, rather than silently fetched and handed over.
+	for _, t := range templates {
+		if _, ok := s.Cfg.Entry(t); !ok {
+			http.Error(w, fmt.Sprintf("disclosure: template %q is not in the allow-list", t), http.StatusForbidden)
+			return
+		}
+	}
+	if s.ACS == nil {
+		http.Error(w, "disclosure: no ACS backend configured for this service", http.StatusServiceUnavailable)
+		return
+	}
+	contracts, offset, err := s.ACS.Query(r.Context(), templates)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("disclosure: query active contracts: %v", err), http.StatusInternalServerError)
+		return
+	}
+	for _, t := range templates {
+		s.logf("disclosure: served template %s", t)
+	}
+	writeJSON(w, http.StatusOK, disclosuresResponse{ActiveAtOffset: offset, Contracts: contracts})
+}
+
+func (s *Service) handleSeam(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "disclosure: method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	name := strings.TrimPrefix(r.URL.Path, "/v1/seam/")
+	scriptName, ok := seamScripts[name]
+	if !ok {
+		http.Error(w, fmt.Sprintf("disclosure: unknown seam %q", name), http.StatusNotFound)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("disclosure: read request body: %v", err), http.StatusBadRequest)
+		return
+	}
+	var input map[string]any
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, &input); err != nil {
+			http.Error(w, fmt.Sprintf("disclosure: decode request body: %v", err), http.StatusBadRequest)
+			return
+		}
+	}
+	if input == nil {
+		input = map[string]any{}
+	}
+	// The server's own allow-list is authoritative (the plan's §1.4(3)): overwrite whatever
+	// the client sent for discloseTemplates, if anything, rather than trusting it.
+	input["discloseTemplates"] = s.Cfg.Templates()
+
+	if s.NewRunner == nil {
+		http.Error(w, "disclosure: seam execution not configured for this service", http.StatusInternalServerError)
+		return
+	}
+	runner, cleanup, err := s.NewRunner(r.Context())
+	if err != nil {
+		http.Error(w, fmt.Sprintf("disclosure: create script runner: %v", err), http.StatusBadGateway)
+		return
+	}
+	defer cleanup()
+
+	var output json.RawMessage
+	if err := runner.Run(r.Context(), scriptName, input, &output); err != nil {
+		http.Error(w, fmt.Sprintf("disclosure: run %s: %v", scriptName, err), http.StatusBadGateway)
+		return
+	}
+	s.logf("disclosure: seam %s ok (script=%s, templates=%d)", name, scriptName, len(s.Cfg.Templates()))
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(output)
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/canton/testing/cli/internal/disclosure/service.go
+++ b/canton/testing/cli/internal/disclosure/service.go
@@ -18,7 +18,7 @@ type ScriptRunner interface {
 }
 
 // seamScripts maps the POST /v1/seam/{name} path segment to the Playground.Prepare script it
-// runs. Only these four exist today (the plan's §5.6: no new Daml resolution logic beyond
+// runs. Only these five exist today (the plan's §5.6: no new Daml resolution logic beyond
 // prepareAcceptAdmin, itself mechanical);
 // any other name 404s.
 var seamScripts = map[string]string{
@@ -26,6 +26,7 @@ var seamScripts = map[string]string{
 	"receive":             "Playground.Prepare:prepareReceive",
 	"publish":             "Playground.Prepare:preparePublish",
 	"acceptAdminTransfer": "Playground.Prepare:prepareAcceptAdmin",
+	"deployNtt":           "Playground.Prepare:prepareDeployNtt",
 }
 
 // Service is the allow-list-gated, stateless disclosure server fronting one participant (the

--- a/canton/testing/cli/internal/disclosure/service_test.go
+++ b/canton/testing/cli/internal/disclosure/service_test.go
@@ -1,0 +1,223 @@
+package disclosure
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeScriptRunner records the last Run call so tests can assert what a Service actually asked
+// for, without touching `dpm`.
+type fakeScriptRunner struct {
+	scriptName string
+	input      any
+	output     json.RawMessage
+	err        error
+}
+
+func (f *fakeScriptRunner) Run(ctx context.Context, scriptName string, input, output any) error {
+	f.scriptName = scriptName
+	f.input = input
+	if f.err != nil {
+		return f.err
+	}
+	if out, ok := output.(*json.RawMessage); ok {
+		*out = f.output
+	}
+	return nil
+}
+
+func testConfig() Config {
+	return Config{
+		Disclose: []Entry{
+			{Template: "Wormhole.Core.State:CoreState", FetchAs: "GuardianGovernance"},
+			{Template: "Wormhole.Ntt.Manager:NttManager", FetchAs: "GuardianGovernance"},
+		},
+	}
+}
+
+// ----------------------------------------------------------------------
+// GET /v1/disclosures -- allow-list enforcement
+// ----------------------------------------------------------------------
+
+func TestHandleDisclosures_UnlistedTemplate_Forbidden(t *testing.T) {
+	acsSrv := newACSTestServer(t, 1, acsCannedResponse)
+	svc := &Service{
+		Cfg: testConfig(),
+		ACS: &ActiveContracts{BaseURL: acsSrv.URL, Party: "gg::party"},
+	}
+	srv := httptest.NewServer(svc.Handler())
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/v1/disclosures?template=Evil:Template")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+	var body bytes.Buffer
+	_, _ = body.ReadFrom(resp.Body)
+	require.Contains(t, body.String(), "Evil:Template")
+}
+
+func TestHandleDisclosures_ListedTemplate_OK(t *testing.T) {
+	acsSrv := newACSTestServer(t, 1, acsCannedResponse)
+	svc := &Service{
+		Cfg: testConfig(),
+		ACS: &ActiveContracts{BaseURL: acsSrv.URL, Party: "gg::party"},
+	}
+	srv := httptest.NewServer(svc.Handler())
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/v1/disclosures?template=Wormhole.Core.State:CoreState")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var out disclosuresResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	require.Len(t, out.Contracts, 1)
+	require.Equal(t, "cid-1", out.Contracts[0].ContractID)
+}
+
+func TestHandleDisclosures_MissingTemplateParam_BadRequest(t *testing.T) {
+	svc := &Service{Cfg: testConfig()}
+	srv := httptest.NewServer(svc.Handler())
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/v1/disclosures")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestHandleDisclosures_NilACS_ServiceUnavailable(t *testing.T) {
+	svc := &Service{Cfg: testConfig()} // ACS deliberately nil
+	srv := httptest.NewServer(svc.Handler())
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/v1/disclosures?template=Wormhole.Core.State:CoreState")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+}
+
+// ----------------------------------------------------------------------
+// POST /v1/seam/{name} -- server-side discloseTemplates injection
+// ----------------------------------------------------------------------
+
+func TestHandleSeam_InjectsServerTemplates_IgnoresClientSupplied(t *testing.T) {
+	runner := &fakeScriptRunner{output: json.RawMessage(`{"mgr":null}`)}
+	svc := &Service{
+		Cfg: testConfig(),
+		NewRunner: func(ctx context.Context) (ScriptRunner, func(), error) {
+			return runner, func() {}, nil
+		},
+	}
+	srv := httptest.NewServer(svc.Handler())
+	t.Cleanup(srv.Close)
+
+	clientBody := `{"operator": "Operator", "discloseTemplates": ["Evil:Template"]}`
+	resp, err := http.Post(srv.URL+"/v1/seam/transferOut", "application/json", bytes.NewBufferString(clientBody))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var respBody bytes.Buffer
+	_, _ = respBody.ReadFrom(resp.Body)
+	require.JSONEq(t, `{"mgr":null}`, respBody.String())
+
+	require.Equal(t, "Playground.Prepare:prepareTransferOut", runner.scriptName)
+	input, ok := runner.input.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "Operator", input["operator"])
+
+	gotTemplates, ok := input["discloseTemplates"].([]string)
+	require.True(t, ok)
+	require.Equal(t, testConfig().Templates(), gotTemplates,
+		"the server's own allow-list must win over whatever the client sent")
+}
+
+func TestHandleSeam_ReceiveAndPublish_MapToCorrectScripts(t *testing.T) {
+	cases := map[string]string{
+		"receive":             "Playground.Prepare:prepareReceive",
+		"publish":             "Playground.Prepare:preparePublish",
+		"acceptAdminTransfer": "Playground.Prepare:prepareAcceptAdmin",
+	}
+	for name, wantScript := range cases {
+		runner := &fakeScriptRunner{output: json.RawMessage(`{}`)}
+		svc := &Service{
+			Cfg: testConfig(),
+			NewRunner: func(ctx context.Context) (ScriptRunner, func(), error) {
+				return runner, func() {}, nil
+			},
+		}
+		srv := httptest.NewServer(svc.Handler())
+
+		resp, err := http.Post(srv.URL+"/v1/seam/"+name, "application/json", bytes.NewBufferString(`{}`))
+		require.NoError(t, err)
+		resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, wantScript, runner.scriptName)
+		srv.Close()
+	}
+}
+
+func TestHandleSeam_UnknownName_NotFound(t *testing.T) {
+	svc := &Service{Cfg: testConfig()}
+	srv := httptest.NewServer(svc.Handler())
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Post(srv.URL+"/v1/seam/bogus", "application/json", bytes.NewBufferString(`{}`))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestHandleSeam_RunnerError_BadGateway(t *testing.T) {
+	runner := &fakeScriptRunner{err: errors.New("dpm script failed")}
+	svc := &Service{
+		Cfg: testConfig(),
+		NewRunner: func(ctx context.Context) (ScriptRunner, func(), error) {
+			return runner, func() {}, nil
+		},
+	}
+	srv := httptest.NewServer(svc.Handler())
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Post(srv.URL+"/v1/seam/transferOut", "application/json", bytes.NewBufferString(`{}`))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusBadGateway, resp.StatusCode)
+}
+
+// ----------------------------------------------------------------------
+// GET /v1/healthz
+// ----------------------------------------------------------------------
+
+func TestHandleHealthz(t *testing.T) {
+	acsSrv := newACSTestServer(t, 55, "[]")
+	svc := &Service{
+		Cfg:         testConfig(),
+		Participant: "guardian-governance",
+		ACS:         &ActiveContracts{BaseURL: acsSrv.URL, Party: "gg::party"},
+	}
+	srv := httptest.NewServer(svc.Handler())
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/v1/healthz")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var out healthzResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	require.Equal(t, "guardian-governance", out.Participant)
+	require.Equal(t, testConfig().Templates(), out.Templates)
+	require.Equal(t, int64(55), out.LedgerEnd)
+}

--- a/canton/testing/cli/internal/network/localnet.go
+++ b/canton/testing/cli/internal/network/localnet.go
@@ -44,11 +44,11 @@ var postgresOverride []byte
 // postgresOverrideFile is the override's filename inside ComposeDir.
 const postgresOverrideFile = "wormhole-postgres-override.yaml"
 
-// participantsOverride adds three new Canton participants -- bob, guardian-governance,
-// guardian-observer -- hosted inside the bundle's existing `canton`/`splice` containers (see
-// the plan's §2 port table, .claude/tasks/e2e-separate-participants.md). A fourth candidate,
-// app-user (Alice), needs no override: verified live that it already runs today under the
-// bundle's own default (see the Up doc comment below).
+// participantsOverride adds four new Canton participants -- bob, guardian-governance,
+// guardian-observer, alice-solo -- hosted inside the bundle's existing `canton`/`splice`
+// containers (see the participant/port table in the CLI README's Topology section). A
+// fifth candidate, app-user (Alice), needs no override: verified live that it already runs
+// today under the bundle's own default (see the Up doc comment below).
 //
 //go:embed localnet_participants_override.yaml
 var participantsOverride []byte
@@ -249,20 +249,21 @@ func (m *LocalNetManager) env() []string {
 // check. First boot bootstraps the DSO (the network's Decentralized Synchronizer Operator
 // party) and is documented at 2-6 minutes, so the timeout should be generous.
 //
-// Despite only "sv" and "app-provider" being passed as --profile flags, FIVE participants
+// Despite only "sv" and "app-provider" being passed as --profile flags, SIX participants
 // come up: app-provider and sv (named by the passed profiles), app-user (verified live --
 // compose.env defaults APP_USER_PROFILE=on, and conf/canton/app.conf's
 // `include file("/app/app-user/on/app.conf")` is unconditional once the canton container
 // starts under any profile, since Compose's --profile flag only gates which SERVICES start,
 // not which conf/env-file paths a running service's own volume mounts resolve to -- so
 // app-user's participant and validator run today with no override needed), plus this
-// package's own bob/guardian-governance/guardian-observer additions (participantsOverride).
+// package's own bob/guardian-governance/guardian-observer/alice-solo additions
+// (participantsOverride).
 func (m *LocalNetManager) Up(ctx context.Context, timeout time.Duration) error {
 	tag := m.ImageTag
 	if tag == "" {
 		tag = "default"
 	}
-	m.logf("localnet: compose dir=%s image-tag=%s profiles=[sv app-provider] (app-user, bob, guardian-governance, guardian-observer also come up -- see Up's doc comment)", m.ComposeDir, tag)
+	m.logf("localnet: compose dir=%s image-tag=%s profiles=[sv app-provider] (app-user, bob, guardian-governance, guardian-observer, alice-solo also come up -- see Up's doc comment)", m.ComposeDir, tag)
 	if err := m.ensureOverrides(); err != nil {
 		return err
 	}
@@ -397,7 +398,7 @@ type participantProbe struct {
 // allParticipantProbes lists every participant waitReady must see stably ready before a
 // LocalNet `network up` returns: the two named by --profile (app-provider via the manager's
 // own configurable ledgerAddr/validatorBaseURL, sv has no user-facing participant of its
-// own), app-user (already running today -- see Up's doc comment), and this package's three
+// own), app-user (already running today -- see Up's doc comment), and this package's four
 // additions. Ports are the plan's §2 table; localnet-only fixed ports, no env override (only
 // app-provider's has one, matching profile.Profile's existing LOCALNET_* env vars).
 func (m *LocalNetManager) allParticipantProbes() []participantProbe {
@@ -407,6 +408,7 @@ func (m *LocalNetManager) allParticipantProbes() []participantProbe {
 		{role: "bob", ledgerAddr: "localhost:5901", validatorURL: "http://localhost:5903"},
 		{role: "guardian-governance", ledgerAddr: "localhost:6901", validatorURL: "http://localhost:6903"},
 		{role: "guardian-observer", ledgerAddr: "localhost:7901", validatorURL: "http://localhost:7903"},
+		{role: "alice-solo", ledgerAddr: "localhost:8901", validatorURL: "http://localhost:8903"},
 	}
 }
 
@@ -581,7 +583,7 @@ func (m *LocalNetManager) UploadDAR(ctx context.Context, jsonLedgerAPIBaseURL, d
 
 // allParticipantJSONAPIBaseURLs lists every participant's JSON Ledger API v2 base URL --
 // app-provider (via the manager's own configurable ValidatorBaseURL-adjacent JSON API,
-// mirrored from the port table) plus the four others, all fixed localnet ports (plan §2).
+// mirrored from the port table) plus the five others, all fixed localnet ports (plan §2).
 func (m *LocalNetManager) allParticipantJSONAPIBaseURLs() map[string]string {
 	return map[string]string{
 		"app-provider":        m.jsonAPIBaseURL(),
@@ -589,6 +591,7 @@ func (m *LocalNetManager) allParticipantJSONAPIBaseURLs() map[string]string {
 		"bob":                 "http://localhost:5975",
 		"guardian-governance": "http://localhost:6975",
 		"guardian-observer":   "http://localhost:7975",
+		"alice-solo":          "http://localhost:8975",
 	}
 }
 

--- a/canton/testing/cli/internal/network/localnet_conf/canton-app.conf
+++ b/canton/testing/cli/internal/network/localnet_conf/canton-app.conf
@@ -1,6 +1,6 @@
 # Wormhole wrapper for the `canton` container's /app/app.conf. Chains the bundle's own
 # app.conf (remounted at /app/app-orig.conf by the participants override, never edited in
-# place) with the three new per-participant conf pairs, so the vendored bundle stays
+# place) with the four new per-participant conf pairs, so the vendored bundle stays
 # untouched and upgrade-safe. See localnet.go's ensureParticipantConfs.
 include file("/app/app-orig.conf")
 
@@ -12,3 +12,6 @@ include file("/app/wormhole/guardian-governance/app-auth.conf")
 
 include file("/app/wormhole/guardian-observer/app.conf")
 include file("/app/wormhole/guardian-observer/app-auth.conf")
+
+include file("/app/wormhole/alice-solo/app.conf")
+include file("/app/wormhole/alice-solo/app-auth.conf")

--- a/canton/testing/cli/internal/network/localnet_conf/canton/alice-solo/app-auth.conf
+++ b/canton/testing/cli/internal/network/localnet_conf/canton/alice-solo/app-auth.conf
@@ -1,0 +1,12 @@
+# Wormhole addition: mirrors canton/guardian-governance/app-auth.conf.
+canton.participants.alice-solo {
+  ledger-api {
+    auth-services = [{
+      type = unsafe-jwt-hmac-256
+      target-audience = "https://canton.network.global"
+      secret = "unsafe"
+    }]
+
+    user-management-service.additional-admin-user-id = ledger-api-user
+  }
+}

--- a/canton/testing/cli/internal/network/localnet_conf/canton/alice-solo/app.conf
+++ b/canton/testing/cli/internal/network/localnet_conf/canton/alice-solo/app.conf
@@ -1,0 +1,13 @@
+# Wormhole addition: the "alice-solo" Canton participant -- see canton/bob/app.conf for the
+# pattern this mirrors. Hosts no playground party other than the one the disclosure-service
+# e2e test allocates (see the plan's §6.1, §7 R1).
+canton.participants.alice-solo = ${_participant} {
+  storage.config.properties.databaseName = participant-alice-solo
+  monitoring {
+    http-health-server.port = 8900
+    grpc-health-server.port = 8961
+  }
+  http-ledger-api.port = 8975
+  admin-api.port = 8902
+  ledger-api.port = 8901
+}

--- a/canton/testing/cli/internal/network/localnet_conf/health-check-canton.sh
+++ b/canton/testing/cli/internal/network/localnet_conf/health-check-canton.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Wormhole replacement for docker/canton/health-check.sh: the original three profile-gated
-# probes, plus unconditional probes of the three new participants' gRPC health ports (they
+# probes, plus unconditional probes of the four new participants' gRPC health ports (they
 # are not profile-gated -- see localnet.go's comment on APP_USER_PROFILE, they are always
 # mounted/included once the canton container starts under any profile).
 set -eou pipefail
@@ -24,3 +24,5 @@ echo "Checking 6961 (guardian-governance)"
 grpc-health-probe -addr="localhost:6961"
 echo "Checking 7961 (guardian-observer)"
 grpc-health-probe -addr="localhost:7961"
+echo "Checking 8961 (alice-solo)"
+grpc-health-probe -addr="localhost:8961"

--- a/canton/testing/cli/internal/network/localnet_conf/health-check-splice.sh
+++ b/canton/testing/cli/internal/network/localnet_conf/health-check-splice.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Wormhole replacement for docker/splice/health-check.sh: the original three profile-gated
-# probes, plus unconditional probes of the three new validator apps' readyz endpoints.
+# probes, plus unconditional probes of the four new validator apps' readyz endpoints.
 set -eou pipefail
 
 if [ "$APP_USER_PROFILE" = "on" ]; then
@@ -18,3 +18,4 @@ fi
 wget --no-verbose --tries=1 --spider http://localhost:5903/api/validator/readyz
 wget --no-verbose --tries=1 --spider http://localhost:6903/api/validator/readyz
 wget --no-verbose --tries=1 --spider http://localhost:7903/api/validator/readyz
+wget --no-verbose --tries=1 --spider http://localhost:8903/api/validator/readyz

--- a/canton/testing/cli/internal/network/localnet_conf/splice-app.conf
+++ b/canton/testing/cli/internal/network/localnet_conf/splice-app.conf
@@ -1,6 +1,6 @@
 # Wormhole wrapper for the `splice` container's /app/app.conf. Chains the bundle's own
 # app.conf (remounted at /app/app-orig.conf by the participants override, never edited in
-# place) with the three new per-participant validator-app conf pairs and the SV
+# place) with the four new per-participant validator-app conf pairs and the SV
 # onboarding-secret overlay (included last, so its `+=` sees the SV app config the earlier
 # include already established). See localnet.go's ensureParticipantConfs.
 include file("/app/app-orig.conf")
@@ -13,5 +13,8 @@ include file("/app/wormhole/guardian-governance/app-auth.conf")
 
 include file("/app/wormhole/guardian-observer/app.conf")
 include file("/app/wormhole/guardian-observer/app-auth.conf")
+
+include file("/app/wormhole/alice-solo/app.conf")
+include file("/app/wormhole/alice-solo/app-auth.conf")
 
 include file("/app/wormhole/sv-onboarding-overlay.conf")

--- a/canton/testing/cli/internal/network/localnet_conf/splice/alice-solo/app-auth.conf
+++ b/canton/testing/cli/internal/network/localnet_conf/splice/alice-solo/app-auth.conf
@@ -1,0 +1,19 @@
+# Wormhole addition: mirrors splice/guardian-governance/app-auth.conf. Uses the abbreviated
+# "alice" validator-apps map key -- see app.conf's comment.
+canton.validator-apps.alice-validator_backend {
+  participant-client.ledger-api.auth-config = {
+    type = "self-signed"
+    user = ledger-api-user
+    audience = "https://canton.network.global"
+    secret = "unsafe"
+  }
+
+  auth = {
+    algorithm = "hs-256-unsafe"
+    audience = "https://canton.network.global"
+    secret = "unsafe"
+  }
+
+  ledger-api-user = ledger-api-user
+  validator-wallet-users.0 = ledger-api-user
+}

--- a/canton/testing/cli/internal/network/localnet_conf/splice/alice-solo/app.conf
+++ b/canton/testing/cli/internal/network/localnet_conf/splice/alice-solo/app.conf
@@ -1,0 +1,25 @@
+# Wormhole addition: the validator app fronting the "alice-solo" participant -- see
+# splice/bob/app.conf for the pattern this mirrors. Unlike guardian-governance/
+# guardian-observer, "alice-solo-validator_backend" (28 chars) would already fit under
+# Canton's 30-character node-name limit, but the map key is still abbreviated to
+# "alice-validator_backend" (23 chars) for headroom and to match the gg/gobs convention. The
+# participant itself keeps the full "alice-solo" name.
+canton.validator-apps.alice-validator_backend = ${_validator_backend} {
+  onboarding.secret = "alice-solo-validator-onboarding-secret"
+  storage.config.properties.databaseName = validator-alice-solo
+  admin-api.port = 8903
+  participant-client {
+    admin-api.port = 8902
+    ledger-api.client-config.port = 8901
+  }
+  # Must match <organization>-<function>-<enumerator> -- see
+  # splice/guardian-governance/app.conf's comment (INVALID_ARGUMENT on internal hyphens,
+  # verified live). "alicesolo" is the function segment with the hyphen removed --
+  # "wormhole-alice-solo-1" would split into four segments and fail.
+  validator-party-hint = "wormhole-alicesolo-1"
+
+  domains.global.buy-extra-traffic {
+    min-topup-interval = ${MIN_TRAFFIC_TOPUP_INTERVAL}
+    target-throughput = ${TARGET_TRAFFIC_THROUGHPUT}
+  }
+}

--- a/canton/testing/cli/internal/network/localnet_conf/splice/sv-onboarding-overlay.conf
+++ b/canton/testing/cli/internal/network/localnet_conf/splice/sv-onboarding-overlay.conf
@@ -1,9 +1,10 @@
 # Wormhole addition: extends the SV app's `expected-validator-onboardings` (originally set
 # in conf/splice/sv/app.conf, included further up the wrapper chain in splice-app.conf) to
-# also accept the three new validator apps' onboarding secrets. HOCON's self-referential `+=`
+# also accept the four new validator apps' onboarding secrets. HOCON's self-referential `+=`
 # (`path += value` desugars to `path = ${?path} [value]`) appends onto the array already
 # assigned by the earlier include, so the original two entries (app-provider, app-user) are
 # preserved -- no need to duplicate or copy conf/splice/sv/app.conf.
 canton.sv-apps.sv.expected-validator-onboardings += { secret = "bob-validator-onboarding-secret" }
 canton.sv-apps.sv.expected-validator-onboardings += { secret = "guardian-governance-validator-onboarding-secret" }
 canton.sv-apps.sv.expected-validator-onboardings += { secret = "guardian-observer-validator-onboarding-secret" }
+canton.sv-apps.sv.expected-validator-onboardings += { secret = "alice-solo-validator-onboarding-secret" }

--- a/canton/testing/cli/internal/network/localnet_participants_override.yaml
+++ b/canton/testing/cli/internal/network/localnet_participants_override.yaml
@@ -1,8 +1,8 @@
 # Compose override applied on top of the Splice LocalNet bundle (see localnet.go), additive
-# to wormhole-postgres-override.yaml. Adds three new Canton participants -- bob,
-# guardian-governance, guardian-observer -- hosted inside the bundle's existing `canton`/
-# `splice` containers (a fourth participant, app-user/Alice, is already running today under
-# the bundle's own default -- see the plan's §8.2 finding, recorded in localnet.go).
+# to wormhole-postgres-override.yaml. Adds four new Canton participants -- bob,
+# guardian-governance, guardian-observer, alice-solo -- hosted inside the bundle's existing
+# `canton`/`splice` containers (a fifth participant, app-user/Alice, is already running today
+# under the bundle's own default -- see the plan's §8.2 finding, recorded in localnet.go).
 #
 # Never edits the vendored bundle: this file, plus the per-participant conf files/health-check
 # scripts it references under wormhole-conf/, are all generated into ComposeDir (the resolved
@@ -27,6 +27,8 @@ services:
       CREATE_DATABASE_23: validator-guardian-governance
       CREATE_DATABASE_24: participant-guardian-observer
       CREATE_DATABASE_25: validator-guardian-observer
+      CREATE_DATABASE_26: participant-alice-solo
+      CREATE_DATABASE_27: validator-alice-solo
 
   canton:
     ports:
@@ -39,6 +41,9 @@ services:
       - "7901:7901"
       - "7902:7902"
       - "7975:7975"
+      - "8901:8901"
+      - "8902:8902"
+      - "8975:8975"
     volumes:
       # Remount the bundle's own app.conf under a new path so our wrapper (below) can
       # `include` it verbatim, instead of copying its 127 lines.
@@ -46,21 +51,23 @@ services:
       # Replace /app/app.conf with our wrapper (same target as the bundle's own mount --
       # last -f file wins for a given volume target).
       - ${LOCALNET_DIR}/wormhole-conf/canton-app.conf:/app/app.conf
-      # The three new participants' conf pairs, one subdirectory each.
+      # The four new participants' conf pairs, one subdirectory each.
       - ${LOCALNET_DIR}/wormhole-conf/canton:/app/wormhole
-      # Replace the health-check with one that also probes the three new gRPC health ports.
+      # Replace the health-check with one that also probes the four new gRPC health ports.
       - ${LOCALNET_DIR}/wormhole-conf/health-check-canton.sh:/app/health-check.sh
-    # Three more participants sharing one JVM heap needs more room than the bundle's default
-    # (4g container / 2560m heap, sized for three participants) -- see the plan's §8 risk 7.
-    mem_limit: 10g
+    # Six participants sharing one JVM heap needs more room than the bundle's default (4g
+    # container / 2560m heap, sized for three participants) -- see the plan's §8 risk 7 /
+    # §7 R2 (alice-solo is the sixth, bumping 10g/7g to 12g/8g).
+    mem_limit: 12g
     environment:
-      _JAVA_OPTIONS: "-XX:-UseCompressedOops -Xms1g -Xmx7g"
+      _JAVA_OPTIONS: "-XX:-UseCompressedOops -Xms1g -Xmx8g"
 
   splice:
     ports:
       - "5903:5903"
       - "6903:6903"
       - "7903:7903"
+      - "8903:8903"
     volumes:
       - ${LOCALNET_DIR}/conf/splice/app.conf:/app/app-orig.conf
       - ${LOCALNET_DIR}/wormhole-conf/splice-app.conf:/app/app.conf

--- a/canton/testing/cli/internal/network/localnet_test.go
+++ b/canton/testing/cli/internal/network/localnet_test.go
@@ -238,18 +238,21 @@ func TestEnsureParticipantsOverride_StaleContentIsRewritten(t *testing.T) {
 func TestParticipantsOverride_Content(t *testing.T) {
 	content := string(participantsOverride)
 	for _, want := range []string{
-		// bob / guardian-governance / guardian-observer ledger, admin, JSON-API ports.
+		// bob / guardian-governance / guardian-observer / alice-solo ledger, admin, JSON-API
+		// ports.
 		"5901:5901", "5902:5902", "5975:5975",
 		"6901:6901", "6902:6902", "6975:6975",
 		"7901:7901", "7902:7902", "7975:7975",
+		"8901:8901", "8902:8902", "8975:8975",
 		// validator API ports.
-		"5903:5903", "6903:6903", "7903:7903",
+		"5903:5903", "6903:6903", "7903:7903", "8903:8903",
 		// the wrapper-include mechanism: original conf remounted, wrapper replaces app.conf.
 		"/app/app-orig.conf", "/app/app.conf", "/app/wormhole", "/app/health-check.sh",
 		// new postgres databases.
 		"participant-bob", "validator-bob",
 		"participant-guardian-governance", "validator-guardian-governance",
 		"participant-guardian-observer", "validator-guardian-observer",
+		"participant-alice-solo", "validator-alice-solo",
 	} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("participantsOverride missing %q", want)
@@ -280,6 +283,10 @@ func TestEnsureParticipantConfs_WritesAll(t *testing.T) {
 		filepath.Join("splice", "guardian-governance", "app-auth.conf"),
 		filepath.Join("splice", "guardian-observer", "app.conf"),
 		filepath.Join("splice", "guardian-observer", "app-auth.conf"),
+		filepath.Join("canton", "alice-solo", "app.conf"),
+		filepath.Join("canton", "alice-solo", "app-auth.conf"),
+		filepath.Join("splice", "alice-solo", "app.conf"),
+		filepath.Join("splice", "alice-solo", "app-auth.conf"),
 		filepath.Join("splice", "sv-onboarding-overlay.conf"),
 	} {
 		path := filepath.Join(dir, "wormhole-conf", rel)
@@ -312,6 +319,7 @@ func TestEnsureParticipantConfs_WritesAll(t *testing.T) {
 		"bob-validator-onboarding-secret",
 		"guardian-governance-validator-onboarding-secret",
 		"guardian-observer-validator-onboarding-secret",
+		"alice-solo-validator-onboarding-secret",
 	} {
 		if !strings.Contains(string(overlay), secret) {
 			t.Fatalf("sv onboarding overlay missing %q: %s", secret, overlay)
@@ -367,13 +375,13 @@ func TestEnsureParticipantConfs_StaleRewritten(t *testing.T) {
 	}
 }
 
-func TestAllParticipantProbes_FiveParticipants(t *testing.T) {
+func TestAllParticipantProbes_SixParticipants(t *testing.T) {
 	m := LocalNetManager{}
 	probes := m.allParticipantProbes()
-	if len(probes) != 5 {
-		t.Fatalf("expected 5 participant probes, got %d: %+v", len(probes), probes)
+	if len(probes) != 6 {
+		t.Fatalf("expected 6 participant probes, got %d: %+v", len(probes), probes)
 	}
-	wantRoles := map[string]bool{"app-provider": true, "app-user": true, "bob": true, "guardian-governance": true, "guardian-observer": true}
+	wantRoles := map[string]bool{"app-provider": true, "app-user": true, "bob": true, "guardian-governance": true, "guardian-observer": true, "alice-solo": true}
 	for _, p := range probes {
 		if !wantRoles[p.role] {
 			t.Fatalf("unexpected participant role %q", p.role)
@@ -385,7 +393,26 @@ func TestAllParticipantProbes_FiveParticipants(t *testing.T) {
 	}
 }
 
-func TestAllParticipantJSONAPIBaseURLs_FiveParticipants(t *testing.T) {
+// TestAllParticipantProbes_AliceSolo pins alice-solo's own probe targets (the disclosure
+// service e2e's dedicated participant, added in §6.1): ledger port 8901, validator API 8903.
+func TestAllParticipantProbes_AliceSolo(t *testing.T) {
+	m := LocalNetManager{}
+	probes := m.allParticipantProbes()
+	for _, p := range probes {
+		if p.role == "alice-solo" {
+			if p.ledgerAddr != "localhost:8901" {
+				t.Fatalf("alice-solo ledgerAddr: got %q, want localhost:8901", p.ledgerAddr)
+			}
+			if p.validatorURL != "http://localhost:8903" {
+				t.Fatalf("alice-solo validatorURL: got %q, want http://localhost:8903", p.validatorURL)
+			}
+			return
+		}
+	}
+	t.Fatalf("alice-solo probe not found: %+v", probes)
+}
+
+func TestAllParticipantJSONAPIBaseURLs_SixParticipants(t *testing.T) {
 	m := LocalNetManager{}
 	urls := m.allParticipantJSONAPIBaseURLs()
 	want := map[string]string{
@@ -394,6 +421,7 @@ func TestAllParticipantJSONAPIBaseURLs_FiveParticipants(t *testing.T) {
 		"bob":                 "http://localhost:5975",
 		"guardian-governance": "http://localhost:6975",
 		"guardian-observer":   "http://localhost:7975",
+		"alice-solo":          "http://localhost:8975",
 	}
 	for role, url := range want {
 		if urls[role] != url {

--- a/canton/testing/cli/internal/profile/profile.go
+++ b/canton/testing/cli/internal/profile/profile.go
@@ -55,10 +55,10 @@ type Profile struct {
 	ValidatorBaseURL string
 
 	// Participants maps a participant role (e.g. "app-provider", "app-user", "bob",
-	// "guardian-governance", "guardian-observer") to that participant's connection details.
-	// LocalNet has all five (see the plan's §2 port table); the sandbox -- a single
-	// in-process participant, per internal/network/sandbox.go -- has exactly one, keyed
-	// "default".
+	// "guardian-governance", "guardian-observer", "alice-solo") to that participant's
+	// connection details. LocalNet has all six (see the plan's §2 port table); the sandbox --
+	// a single in-process participant, per internal/network/sandbox.go -- has exactly one,
+	// keyed "default".
 	//
 	// TODO(phase 3): nothing routes through this map yet. The existing top-level
 	// LedgerHost/LedgerPort/JSONAPIBaseURL/ValidatorBaseURL/UserID fields above remain the
@@ -155,7 +155,7 @@ func Get(name Name) (Profile, error) {
 
 		// app-provider is the only endpoint the LOCALNET_* env overrides ever touch (see
 		// TestGet_LocalNet_EnvOverrides_HitDefaultOnly) -- it is both the top-level
-		// LedgerHost/... fields above AND Participants["app-provider"]. The other four
+		// LedgerHost/... fields above AND Participants["app-provider"]. The other five
 		// participants (see the plan's §2 port table) are localnet-only, bundle-fixed
 		// ports with no env override of their own yet.
 		appProvider := Endpoint{
@@ -191,6 +191,7 @@ func Get(name Name) (Profile, error) {
 				"bob":                 localEndpoint(5901, 5975, 5903),
 				"guardian-governance": localEndpoint(6901, 6975, 6903),
 				"guardian-observer":   localEndpoint(7901, 7975, 7903),
+				"alice-solo":          localEndpoint(8901, 8975, 8903),
 			},
 			DefaultParticipant: "app-provider",
 		}, nil

--- a/canton/testing/cli/internal/profile/profile_test.go
+++ b/canton/testing/cli/internal/profile/profile_test.go
@@ -105,16 +105,17 @@ func TestGet_UnknownProfile(t *testing.T) {
 // Multi-participant topology (.claude/tasks/e2e-separate-participants.md §2/§3)
 // ----------------------------------------------------------------------
 
-// TestGet_LocalNet_Participants pins the exact five-participant port table from the plan's
-// §2: app-provider is unchanged (3901/3975/3903); app-user/bob/guardian-governance/
-// guardian-observer are the new participants at 2*/5*/6*/7* respectively.
+// TestGet_LocalNet_Participants pins the exact six-participant port table from the plan's §2
+// (extended in §6.1 with alice-solo): app-provider is unchanged (3901/3975/3903); app-user/
+// bob/guardian-governance/guardian-observer/alice-solo are the new participants at
+// 2*/5*/6*/7*/8* respectively.
 func TestGet_LocalNet_Participants(t *testing.T) {
 	for _, k := range []string{"LOCALNET_LEDGER_HOST", "LOCALNET_LEDGER_PORT", "LOCALNET_JSON_API_URL", "LOCALNET_VALIDATOR_URL"} {
 		t.Setenv(k, "")
 	}
 	p, err := Get(LocalNet)
 	require.NoError(t, err)
-	require.Len(t, p.Participants, 5)
+	require.Len(t, p.Participants, 6)
 	require.Equal(t, "app-provider", p.DefaultParticipant)
 
 	cases := []struct {
@@ -126,6 +127,7 @@ func TestGet_LocalNet_Participants(t *testing.T) {
 		{"bob", 5901, 5975, 5903},
 		{"guardian-governance", 6901, 6975, 6903},
 		{"guardian-observer", 7901, 7975, 7903},
+		{"alice-solo", 8901, 8975, 8903},
 	}
 	for _, c := range cases {
 		ep, ok := p.Participants[c.role]
@@ -185,8 +187,8 @@ func TestGet_Sandbox_SingleEndpoint(t *testing.T) {
 
 // TestGet_LocalNet_EnvOverrides_HitDefaultOnly proves the existing LOCALNET_LEDGER_HOST/PORT/
 // JSON_API_URL/VALIDATOR_URL overrides only affect the default (app-provider) endpoint, never
-// the other four participants -- those are still bundle-fixed ports (phase 2's job to make
-// configurable, if ever needed).
+// the other five participants (including alice-solo, added in §6.1) -- those are still
+// bundle-fixed ports (phase 2's job to make configurable, if ever needed).
 func TestGet_LocalNet_EnvOverrides_HitDefaultOnly(t *testing.T) {
 	t.Setenv("LOCALNET_LEDGER_HOST", "canton.example")
 	t.Setenv("LOCALNET_LEDGER_PORT", "4001")
@@ -202,7 +204,7 @@ func TestGet_LocalNet_EnvOverrides_HitDefaultOnly(t *testing.T) {
 	require.Equal(t, "http://json.example", appProvider.JSONAPIBaseURL)
 	require.Equal(t, "http://validator.example", appProvider.ValidatorBaseURL)
 
-	for _, role := range []string{"app-user", "bob", "guardian-governance", "guardian-observer"} {
+	for _, role := range []string{"app-user", "bob", "guardian-governance", "guardian-observer", "alice-solo"} {
 		ep := p.Participants[role]
 		require.Equal(t, "localhost", ep.LedgerHost, "role %q must not pick up LOCALNET_LEDGER_HOST", role)
 		require.NotEqual(t, "http://json.example", ep.JSONAPIBaseURL, "role %q must not pick up LOCALNET_JSON_API_URL", role)

--- a/canton/testing/cli/testdata/topology-alice-solo.json
+++ b/canton/testing/cli/testdata/topology-alice-solo.json
@@ -1,0 +1,24 @@
+{
+  "partyHosting": {
+    "Alice": "app-user",
+    "Bob": "bob",
+    "GuardianGovernance": "guardian-governance",
+    "GuardianObserver": "guardian-observer",
+    "Zoe": "alice-solo",
+    "*": "app-provider"
+  },
+  "disclose": [
+    { "template": "Wormhole.Ntt.Manager:NttManager", "fetchAs": "GuardianGovernance" },
+    { "template": "Wormhole.Ntt.Governance:NttGovernance", "fetchAs": "Operator" },
+    { "template": "Wormhole.Ntt.Ledger:LockedLedger", "fetchAs": "GuardianGovernance" },
+    { "template": "Wormhole.Core.State:CoreState", "fetchAs": "GuardianGovernance" },
+    { "template": "Wormhole.Core.State:Emitter", "fetchAs": "GuardianGovernance" },
+    { "template": "Wormhole.Core.Replay:ReplayNode", "fetchAs": "GuardianGovernance" },
+    { "template": "Wormhole.Ntt.Deposit:DepositPreapproval", "fetchAs": "GuardianGovernance" },
+    { "template": "Playground.MockRegistry:MockTransferPreapproval", "fetchAs": "GuardianGovernance" },
+    { "template": "Playground.MockRegistry:MockPreapprovedTransferFactory", "fetchAs": "GuardianGovernance" },
+    { "template": "Token.CIP0056.CoinFactory:CoinFactory", "fetchAs": "GuardianGovernance" },
+    { "template": "Test.TestNtt:Cip56MockHolding", "fetchAs": "GuardianGovernance" },
+    { "template": "Wormhole.Ntt.Manager:AdminTransferProposal", "fetchAs": "GuardianGovernance" }
+  ]
+}


### PR DESCRIPTION
## What

A read-only **disclosure service** (`ntt-playground disclosure serve`) that fronts the data-owner participant (guardian-governance) and serves explicit-disclosure material to consumers on other participants, so a transfer submitter no longer needs the data owner's admin JWT:

- `GET /v1/disclosures?template=…` — generic ACS export over JSON Ledger API v2 with `includeCreatedEventBlob: true` (base64→hex normalised), 403 on non-allow-listed templates.
- `POST /v1/seam/{transferOut|receive|publish|acceptAdminTransfer|deployNtt}` — runs the existing `Playground.Prepare:prepare*` resolver and returns the `RemoteSeam` verbatim; the server, not the caller, decides what gets disclosed.
- `--disclosure-service-url` on the CLI routes `prepareRemoteSeam` through the service; `--strict-participant-isolation` makes any cross-participant credential reach fail fast (the negative control that makes the acceptance test falsifiable).
- `fund` split out of `transfer` (a gg-side submit no disclosure can substitute for); `transfer --no-fund` enumerates the sender's own holdings in-script (`mockHoldings`).
- A sixth LocalNet participant, `alice-solo`, and an e2e proving the acceptance criterion: a fresh participant hosting nothing privileged, with only the DARs uploaded and no other participant's credentials, transacts end to end through the service — plus server-side allow-list enforcement.
- Closes the documented `admin accept-gg-vaa` RemoteSeam gap (fourth seam) and fixes the `admin propose-gg` routing bug it masked.

## Base fixes included (latent breakage the dpm-only CI cannot see)

- `deployNtt` seamless path: the gg-committed canonical `CoinFactory` must be disclosed on **every** profile — visibility is party-scoped, not participant-scoped; pristine base fails `just e2e-sandbox` at `deploy burn-mint` without this.
- Playground port to the bundled-broadcast ntt layer: `RegisterManager`/`RegisterManagerByVaa`/`SetPeer` call sites updated for the mandatory `coreStateCid`, `consistencyLevel`, `feeAllocation` and 5-tuple returns; `deployNtt` re-resolves the transceiver by id because the bundled consuming `TransceiverInit` publish archives the emitter cid the choice returns; e2e sequence expectations account for the two deploy-time broadcasts.
- `mockHoldings` enumerates CIP-0056 `Coin` holdings (what the reworked `fundUser` mints) alongside `Cip56MockHolding`.

## Verification

`go vet` + unit tests, `dpm build --all`, `dpm test --all`, `just e2e-sandbox` (27 PASS), and `just e2e-localnet` (34 PASS / 1 expected SKIP / 0 FAIL) — all green at the branch tip.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wormholelabs-xyz/codesmith/native-token-transfers/pr/61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788456087&installation_model_id=15502&pr_number=61&repository=wormholelabs-xyz%2Fnative-token-transfers&return_to=https%3A%2F%2Fgithub.com%2Fwormholelabs-xyz%2Fnative-token-transfers%2Fpull%2F61&signature=f968bd3539baf34a292e794581c5397b7f0036d569a0603ad780ad44c1993145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->