### PR TITLE
canton: pin custody holdings to the instrument admin's signature (hardening)

### DIFF
--- a/canton/ntt/daml/Wormhole/Ntt/Manager.daml
+++ b/canton/ntt/daml/Wormhole/Ntt/Manager.daml
@@ -390,22 +390,30 @@ resolveLedger mgr ledgerCid = do
   assertMsg "ntt: ledger admin observer out of sync" (ledger.admin == mgr.admin)
   pure ledger
 
--- | Validate custody holdings (owned by the deployment's current @admin@ —
--- the custodian — this deployment's instrument, unlocked) and return their
--- total. Run over every custody holding the manager spends: the choice bodies
--- carry all four signatures, so without this check a caller could steer a
--- choice into spending another signatory's holdings on ambient authority
--- alone.
+-- | Validate one custody holding — owned by the deployment's current @admin@
+-- (the custodian), this deployment's instrument, unlocked, and signed by the
+-- instrument admin, which a template-computed view cannot forge — and return
+-- its amount. Run over every custody holding the manager spends or points at:
+-- the choice bodies carry all four signatures, so without this a caller could
+-- steer a choice into spending another signatory's holdings on ambient
+-- authority alone.
+validateCustodyHolding : NttManager -> Holding -> Either Text Decimal
+validateCustodyHolding mgr holding = do
+  let hv = view holding
+  assertMsg "ntt: custody holding is not owned by the custodian"
+    (hv.owner == mgr.admin)
+  assertMsg "ntt: custody holding instrument mismatch"
+    (hv.instrumentId == mgr.instrumentId)
+  assertMsg "ntt: custody holding is locked" (hv.lock == None)
+  assertMsg "ntt: custody holding not signed by the instrument admin"
+    (mgr.instrumentId.admin `elem` signatory holding)
+  pure hv.amount
+
 sumCustodyHoldings : NttManager -> [ContractId Holding] -> Update Decimal
 sumCustodyHoldings mgr cids = do
   amounts <- forA cids \cid -> do
-    hv <- view <$> fetch cid
-    assertMsg "ntt: custody holding is not owned by the custodian"
-      (hv.owner == mgr.admin)
-    assertMsg "ntt: custody holding instrument mismatch"
-      (hv.instrumentId == mgr.instrumentId)
-    assertMsg "ntt: custody holding is locked" (hv.lock == None)
-    pure hv.amount
+    holding <- fetch cid
+    either assertFail pure (validateCustodyHolding mgr holding)
   pure (sum amounts)
 
 -- | The hint stored back on the ledger after an operation: the single

--- a/canton/test/daml/Test/TestNtt.daml
+++ b/canton/test/daml/Test/TestNtt.daml
@@ -95,6 +95,26 @@ template Cip56MockHolding
         lock = None
         meta = emptyMetadata
 
+-- | A holding signed by its owner alone -- the forgery class 'Test.TestFactoryAuthority.FakeHolding'
+-- also models (not imported from there directly: that module imports this one
+-- for its own test helpers, and Daml modules cannot import each other
+-- cyclically). Its interface view can claim anything, including this
+-- deployment's own instrument, but the instrument admin never signs it.
+template ForgedHolding
+  with
+    owner      : Party
+    instrument : InstrumentId
+    amount     : Decimal
+  where
+    signatory owner
+    interface instance Holding for ForgedHolding where
+      view = HoldingView with
+        owner
+        instrumentId = instrument
+        amount
+        lock = None
+        meta = emptyMetadata
+
 -- | A local 'BurnMintFactory': archives the burned inputs and creates one
 -- 'Cip56MockHolding' per output.
 template MockBurnMintFactory
@@ -1382,6 +1402,91 @@ testConsolidateCustody = do
       custodyHoldingCids = [ggHolding]
       extraArgs = emptyExtraArgs
   expectAbort "not owned by the custodian" res
+
+-- | 'ForgedHolding' is signed by its owner alone; its interface view lies
+-- freely, but never carries the instrument admin's (gg's) signature.
+-- 'ConsolidateCustody's single-holding branch reads the view for the
+-- owner/instrument/lock checks, then must pin the fetched contract's actual
+-- signatories -- rejecting the forgery instead of repointing the ledger's
+-- custody hint to it.
+testConsolidateCustodyRejectsForgedHolding : Script ()
+testConsolidateCustodyRejectsForgedHolding = do
+  (operator, gg, csId) <- nttSetup
+  alice <- allocateParty "ForgeAlice"
+  (d, discs) <- sendScaffold operator gg alice LockUnlock csId
+  fakeCid <- toInterfaceContractId @Holding <$> submit alice do
+    createCmd ForgedHolding with owner = alice, instrument = d.instrumentId, amount = 1.0
+  res <- trySubmitWithDiscs alice discs do
+    exerciseCmd d.mgrCid ConsolidateCustody with
+      caller = alice
+      ledgerCid = fromSome d.ledgerCid
+      custodyHoldingCids = [fakeCid]
+      extraArgs = emptyExtraArgs
+  expectAbort "ntt: custody holding not signed by the instrument admin" res
+
+-- | The positive companion, guarding against over-pinning: a genuine holding
+-- -- signed by both the owner and the instrument admin, like a real CIP-56
+-- holding -- still clears 'ConsolidateCustody's single-holding branch.
+testConsolidateCustodyAcceptsGenuineHolding : Script ()
+testConsolidateCustodyAcceptsGenuineHolding = do
+  (operator, gg, csId) <- nttSetup
+  alice <- allocateParty "GenuineAlice"
+  (d, discs) <- sendScaffold operator gg alice LockUnlock csId
+  holdingCid <- mkHolding gg alice d.instrumentId 1.0
+  holdingDisc <- fromSome <$> queryDisclosure gg (fromInterfaceContractId @Cip56MockHolding holdingCid)
+  _ <- submitWithDiscs alice (holdingDisc :: discs) do
+    exerciseCmd d.mgrCid ConsolidateCustody with
+      caller = alice
+      ledgerCid = fromSome d.ledgerCid
+      custodyHoldingCids = [holdingCid]
+      extraArgs = emptyExtraArgs
+  [(_, ledger)] <- query @LockedLedger operator
+  ledger.custodyHoldingCid === Some holdingCid
+
+-- | The same forged-holding griefing, reached through 'Transfer's lock path
+-- instead of 'ConsolidateCustody': a poisoned custody hint (planted here via
+-- 'SetCustodyHint', standing in for a pre-fix 'ConsolidateCustody' or a
+-- registry-side reorganization) is merged with a fresh deposit into
+-- 'sumCustodyHoldings' the moment a second holding needs consolidating. Note
+-- this is the multi-holding merge branch, distinct from the single-holding
+-- branch the two tests above cover -- a real 'Release' cannot be driven this
+-- far in a script test (no static VAA can match a freshly allocated Party's
+-- recipient hash; see the live two-step harness below), so this exercises
+-- the same pin at NTT's other value-moving custody-merge call site.
+testTransferLockRejectsForgedCustodyPot : Script ()
+testTransferLockRejectsForgedCustodyPot = do
+  (operator, gg, csId) <- nttSetup
+  alice <- allocateParty "TransferForgeAlice"
+  (d, _) <- sendScaffold operator gg alice LockUnlock csId
+  fakePotCid <- toInterfaceContractId @Holding <$> submit alice do
+    createCmd ForgedHolding with owner = alice, instrument = d.instrumentId, amount = 1.0
+  -- 'SetCustodyHint' archives and recreates the ledger, so every disclosure
+  -- must be re-queried fresh afterward -- reusing 'sendScaffold's original
+  -- 'discs' here would disclose an already-archived ledger cid and fail the
+  -- submission before the choice body even runs.
+  poisonedLedgerCid <- submit (actAs operator <> actAs gg) do
+    exerciseCmd (fromSome d.ledgerCid) SetCustodyHint with newCustodyHint = Some fakePotCid
+  csDisc <- fromSome <$> queryDisclosure operator csId
+  emitterDisc <- fromSome <$> queryDisclosure operator d.emitterCid
+  ledgerDisc <- fromSome <$> queryDisclosure operator poisonedLedgerCid
+  factoryDisc <- discloseTransferFactory gg
+  depositCid <- mkHolding gg alice d.instrumentId 0.01
+  res <- trySubmitWithDiscs alice [csDisc, emitterDisc, ledgerDisc, factoryDisc] do
+    exerciseCmd d.mgrCid Transfer with
+      user = alice
+      transceiverEmitterCid = d.emitterCid
+      coreStateCid = csId
+      ledgerCid = Some poisonedLedgerCid
+      recipientChain = 2
+      recipientAddress = b32 "ee"
+      sourceToken = b32 "dd"
+      rawAmount = 1000000
+      nonce = 0
+      consistencyLevel = 0
+      inputHoldingCids = [depositCid]
+      feeAllocation = None
+      extraArgs = emptyExtraArgs
+  expectAbort "ntt: custody holding not signed by the instrument admin" res
 
 -- | A lock against a registry that answers Pending moves nothing, so the
 -- manager's synchronous-settlement check aborts the send. Admin repoints the


### PR DESCRIPTION
Hardening, not a security fix — worth stating the exposure precisely.

`sumCustodyHoldings` validated each fetched `Holding` from its interface view alone (owner, instrument, lock). Views are template-computed and therefore forgeable; the repo already models the class with `TestFactoryAuthority.FakeHolding`. But every path that reaches this helper then spends those holdings through the canonical CIP-56 transfer factory, which cannot spend a foreign template, so the transaction aborts and rolls back:

- `Release` discards the sum and bounds the payout by `ledger.balance`, so a forged holding cannot inflate a release.
- `Transfer`/lock dies in the pot merge.
- `TransferAdmin`'s `total >= ledger.balance` coverage assertion *would* be satisfied by a forged pot claiming a large amount, but the immediately following move of that pot to the incoming admin fails, so the check cannot be bypassed to completion.

The one reachable effect is `ConsolidateCustody`'s single-holding branch, the only path that accepts a holding without spending it: it validates, discards the sum, and repoints the ledger's `custodyHoldingCid` hint at the caller-supplied contract id. Any party could therefore point a lock/unlock deployment's hint at a contract that is not real backing, after which outbound locks (which always prepend the hint to the pot) fail until it is repointed; an inbound `Release` can sidestep it by supplying explicit `inputHoldingCids`. Since `ConsolidateCustody` is itself permissionless, repair is open to anyone as well — a poison/repair race, with no value at risk. This matches the internal audit's F12 classification (bounded, permissionlessly repairable).

What the change buys: the race disappears, the failure moves from deep inside the token registry to a clear error at the NTT boundary, and the codebase becomes consistent about forgeable views — the pin mirrors the core bridge's existing idiom in `Wormhole.Core.Fees` (`instrument.admin `elem` signatory alloc`). It is deliberately template-agnostic (no `fetchFromInterface`) because lock/unlock deployments custody arbitrary CIP-56 instruments.

The helper is also split along the two jobs it was doing. `validateCustodyHolding` is a pure function over an already-fetched `Holding` returning `Either Text Decimal`; `sumCustodyHoldings` is now just the fetch-and-total wrapper that runs it. Three of the four call sites only ever wanted the validation (two discard the sum outright), while `Transfer`/lock and `TransferAdmin` need the total because CIP-56 transfers are amount-denominated.

Real-Amulet custody stays valid: Splice's `template Amulet` is `signatory dso, owner` and its Holding view sets `instrumentId = amuletInstrumentId dso` (`admin = dso`), and the playground's Amulet path passes that same admin as the DSO, so the instrument admin always signs a genuine Amulet holding.

Tests: forged-holding rejection through `ConsolidateCustody`'s single-holding branch, a genuine-holding positive companion guarding against over-pinning, and forged-holding rejection through `Transfer`'s multi-holding merge branch. Both negative cases were confirmed to submit successfully before the change. `Release` is covered transitively by the shared helper rather than directly: its `verifyInboundTransfer` recipient check runs first and cannot be satisfied from a static VAA fixture against a freshly-allocated party, which is why that path lives in the Go live-sandbox suite.

Gates: `dpm build --all` clean; `dpm test` 153 scripts ok, 0 failed.