### PR TITLE
canton: pin the burn path's holding-ownership check with a wrong-owner test

### DIFF
--- a/canton/test/daml/Test/TestNtt.daml
+++ b/canton/test/daml/Test/TestNtt.daml
@@ -2096,6 +2096,20 @@ testBurnExactCoverNoChange = do
   remaining <- cip56HoldingsOwnedBy gg alice
   remaining === []
 
+-- | A burn input owned by someone other than the sender is rejected, even
+-- once the holding is disclosed to the sender.
+testBurnWrongOwnerRejected : Script ()
+testBurnWrongOwnerRejected = do
+  (operator, gg, csId) <- nttSetup
+  alice <- allocateParty "BurnWrongOwnerAlice"
+  bob <- allocateParty "BurnWrongOwnerBob"
+  (d, discs) <- sendScaffold operator gg alice BurnMint csId
+  holdingCid <- mkHolding gg bob d.instrumentId 0.01
+  holdingDisc <- fromSome <$> queryDisclosure gg (fromInterfaceContractId @Cip56MockHolding holdingCid)
+
+  res <- trySubmitWithDiscs alice (holdingDisc :: discs) do sendTransfer alice d csId [holdingCid]
+  expectAbort "not owned by sender" res
+
 ----------------------------------------------------------------------
 -- Deposit pre-approval + mint (inbound burn/mint)
 ----------------------------------------------------------------------


### PR DESCRIPTION
Test-only. The burn/mint outbound path asserts `hv.owner == user` on every supplied input holding — the check that stops a sender from steering a burn into someone else's holdings while all of the manager's signatures are in scope — and nothing exercised it. The three existing burn tests all pass a holding the sender already owns, so they cover the cover-check and change arithmetic but never the ownership gate.

`testBurnWrongOwnerRejected` sends as alice while supplying a holding owned by bob, and expects the abort.

The subtlety worth reviewing: an undisclosed foreign holding fails on visibility, not on the assertion, which would make the test pass for the wrong reason. `Cip56MockHolding` is `signatory admin, owner`, so gg can produce a disclosure for a holding it does not own — the same mechanism `discloseBurnMintFactory`/`discloseTransferFactory` already use — and passing that disclosure into the submission lets execution reach the ownership check. This was verified with a temporary probe: without the disclosure the failure is `NotVisible`/"Could not find contract", which never contains "not owned by sender"; with it, the expected assertion fires. The probe was removed. The input amount also exactly covers the wire amount, so the later cover check cannot be the thing aborting.

Gates: `dpm build --all` clean; `dpm test` 151 scripts ok (150 before this test), 0 failed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wormholelabs-xyz/codesmith/native-token-transfers/pr/66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788542889&installation_model_id=15502&pr_number=66&repository=wormholelabs-xyz%2Fnative-token-transfers&return_to=https%3A%2F%2Fgithub.com%2Fwormholelabs-xyz%2Fnative-token-transfers%2Fpull%2F66&signature=e9ad2d183e34202dae6fcfb85f8c03ec46eb505bede064ba6d71fa627e9b75c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->