### PR TITLE
canton: parse the NTT wire formats with a Get monad that rejects trailing bytes

### DIFF
--- a/canton/ntt/daml/Wormhole/Ntt/Get.daml
+++ b/canton/ntt/daml/Wormhole/Ntt/Get.daml
@@ -1,0 +1,124 @@
+-- | A minimal parser-combinator monad for the wire codecs in
+-- "Wormhole.Ntt.Payload". A 'Get' walks a hex 'Bytes' buffer by byte offset
+-- (not by hand-computed absolute positions), so a decoder built from it reads
+-- as a sequence of fields in wire order.
+module Wormhole.Ntt.Get
+  ( Get
+  , runGet
+  , getBytes
+  , getBytes32
+  , getUint8
+  , getUint16
+  , getUint64
+  , getLengthPrefixed
+  , remainingBytes
+  , assertPrefix
+  ) where
+
+import Wormhole.Core.Bytes
+
+-- | A parser over a hex 'Bytes' buffer: given the buffer and the current byte
+-- offset, either fails with a message or returns a value together with the
+-- offset just past what it consumed. The buffer itself is threaded unchanged
+-- through every step; only the offset advances, so every primitive can report
+-- a failure position without re-slicing.
+newtype Get a = Get (Bytes -> Int -> Either Text (a, Int))
+
+instance Functor Get where
+  fmap f (Get g) = Get $ \b o -> case g b o of
+    Left e -> Left e
+    Right (a, o') -> Right (f a, o')
+
+instance Applicative Get where
+  pure a = Get $ \_ o -> Right (a, o)
+  Get gf <*> Get ga = Get $ \b o -> case gf b o of
+    Left e -> Left e
+    Right (f, o') -> case ga b o' of
+      Left e -> Left e
+      Right (a, o'') -> Right (f a, o'')
+
+instance Action Get where
+  Get g >>= f = Get $ \b o -> case g b o of
+    Left e -> Left e
+    Right (a, o') -> case f a of
+      Get g' -> g' b o'
+
+-- | Run a parser from offset 0 and require it to consume the buffer exactly:
+-- this is the single trailing-bytes check every decoder in
+-- "Wormhole.Ntt.Payload" relies on instead of a hand-written length
+-- assertion of its own.
+runGet : Get a -> Bytes -> Either Text a
+runGet (Get g) b = case g b 0 of
+  Left e -> Left e
+  Right (a, o) ->
+    let total = byteLength b
+    in if o == total
+         then Right a
+         else Left ("length: consumed " <> show o <> " of " <> show total
+           <> " bytes, " <> show (total - o) <> " left over")
+
+-- | Failure is a 'Left', so a parser aborts with 'abort' and the rest of the
+-- 'do' block is skipped. Mirrors how the standard library treats
+-- @Either Text@, the type this parser threads: 'ActionFail' carries the
+-- mechanism (and desugars failing pattern matches in 'do' notation), while
+-- 'CanAbort' is the surface callers use.
+instance ActionFail Get where
+  fail msg = Get $ \_ _ -> Left msg
+
+instance CanAbort Get where
+  abort = fail
+
+-- | Bytes remaining in the buffer from the current offset, without consuming
+-- any of them. Lets a parser branch on how much input is left, e.g. to tell
+-- an omitted trailing field from a present one.
+remainingBytes : Get Int
+remainingBytes = Get $ \b o -> Right (byteLength b - o, o)
+
+-- | Consume exactly @n@ bytes, normalized to lowercase hex. The one bounds
+-- check every other primitive here goes through.
+getBytes : Int -> Get Bytes
+getBytes n = Get $ \b o ->
+  let total = byteLength b
+  in if o + n > total
+       then Left ("getBytes: need " <> show n <> " bytes at offset " <> show o
+         <> ", only " <> show (total - o) <> " left")
+       else Right (normalizeHex (sliceBytes o n b), o + n)
+
+-- | A 32-byte field: addresses, ids and hashes, the width every fixed-size
+-- field in these schemas that is not an integer uses.
+getBytes32 : Get Bytes32
+getBytes32 = getBytes 32
+
+-- | The wire integer widths, named after the schema types they read rather
+-- than a byte count, so a decoder cannot ask for a width the protocol has no
+-- field of. All are big-endian and unsigned on the wire; Daml's 'Int' is a
+-- signed 64-bit, so a uint64 at or above 2^63 does not round-trip (see
+-- 'Test.TestNttVectors.testAmountUint64Bound').
+getUint8 : Get Int
+getUint8 = getUint 1
+
+getUint16 : Get Int
+getUint16 = getUint 2
+
+getUint64 : Get Int
+getUint64 = getUint 8
+
+getUint : Int -> Get Int
+getUint n = bytesToInt <$> getBytes n
+
+-- | A length-prefixed field: a uint16 byte length, then that many bytes.
+-- Mirrors 'Wormhole.Ntt.Payload.encodeLengthPrefixed'.
+getLengthPrefixed : Get Bytes
+getLengthPrefixed = do
+  len <- getUint16
+  getBytes len
+
+-- | Consume a fixed leading tag and require it to match. Sized from @expected@
+-- itself, so a schema's prefix width is stated once, where the prefix is
+-- defined.
+assertPrefix : Bytes -> Get ()
+assertPrefix expected = do
+  actual <- getBytes (byteLength expected)
+  if actual == normalizeHex expected
+    then pure ()
+    else abort ("prefix: " <> actual)

--- a/canton/ntt/daml/Wormhole/Ntt/Payload.daml
+++ b/canton/ntt/daml/Wormhole/Ntt/Payload.daml
@@ -26,7 +26,8 @@
 -- >   module‖action‖chain‖managerAddress‖factoryEpoch layout: the epoch is
 -- >   part of the common identity/freshness prefix, not the peer-specific tail.
 --
--- Decoders 'error' on malformed input (bad prefix / short buffer).
+-- Decoders 'error' on malformed input (bad prefix, short buffer, or trailing
+-- bytes past the decoded message).
 module Wormhole.Ntt.Payload where
 
 import DA.Crypto.Text (keccak256, toHex)
@@ -34,6 +35,7 @@ import DA.Crypto.Text (keccak256, toHex)
 import Splice.Api.Token.HoldingV1 (InstrumentId (..))
 
 import Wormhole.Core.Bytes
+import Wormhole.Ntt.Get
 
 ----------------------------------------------------------------------
 -- Big-endian encoding helpers. 'intToBytesN' / 'leftPadTo' live in
@@ -79,23 +81,27 @@ encodeNativeTokenTransfer n =
     <> intToBytesN n.recipientChain 2
     <> (if n.additionalPayload == "" then "" else encodeLengthPrefixed n.additionalPayload)
 
+-- | The 'Get' counterpart of 'decodeNativeTokenTransfer', for callers that
+-- want an 'Either' instead of an aborting 'error'.
+getNativeTokenTransfer : Get NativeTokenTransfer
+getNativeTokenTransfer = do
+  assertPrefix nativeTokenTransferPrefix
+  decimals <- getUint8
+  amount <- getUint64
+  sourceToken <- getBytes32
+  recipientAddress <- getBytes32
+  recipientChain <- getUint16
+  -- Two valid wire forms of an absent additionalPayload: omitted
+  -- entirely, or an explicit zero-length field (non-canonical, but
+  -- accepted for cross-runtime compatibility).
+  left <- remainingBytes
+  additionalPayload <- if left == 0 then pure "" else getLengthPrefixed
+  pure NativeTokenTransfer with ..
+
 decodeNativeTokenTransfer : Bytes -> NativeTokenTransfer
-decodeNativeTokenTransfer b =
-  let prefix = normalizeHex (sliceBytes 0 4 b)
-      decimals = bytesToInt (sliceBytes 4 1 b)
-      amount = bytesToInt (sliceBytes 5 8 b)
-      sourceToken = normalizeHex (sliceBytes 13 32 b)
-      recipientAddress = normalizeHex (sliceBytes 45 32 b)
-      recipientChain = bytesToInt (sliceBytes 77 2 b)
-      additionalPayload =
-        if byteLength b <= 79
-          then ""
-          else let rest = sliceFrom 79 b
-                   alen = bytesToInt (sliceBytes 0 2 rest)
-               in sliceBytes 2 alen rest
-  in if prefix /= nativeTokenTransferPrefix
-       then error ("ntt: bad NativeTokenTransfer prefix: " <> prefix)
-       else NativeTokenTransfer with ..
+decodeNativeTokenTransfer b = case runGet getNativeTokenTransfer b of
+  Right a -> a
+  Left e -> error ("ntt: bad NativeTokenTransfer " <> e)
 
 ----------------------------------------------------------------------
 -- NttManagerMessage
@@ -111,13 +117,18 @@ encodeNttManagerMessage : NttManagerMessage -> Bytes
 encodeNttManagerMessage m =
   leftPadTo 32 m.id <> leftPadTo 32 m.sender <> encodeLengthPrefixed m.payload
 
+-- | The 'Get' counterpart of 'decodeNttManagerMessage'.
+getNttManagerMessage : Get NttManagerMessage
+getNttManagerMessage = do
+  id <- getBytes32
+  sender <- getBytes32
+  payload <- getLengthPrefixed
+  pure NttManagerMessage with ..
+
 decodeNttManagerMessage : Bytes -> NttManagerMessage
-decodeNttManagerMessage b =
-  let id = normalizeHex (sliceBytes 0 32 b)
-      sender = normalizeHex (sliceBytes 32 32 b)
-      plen = bytesToInt (sliceBytes 64 2 b)
-      payload = sliceBytes 66 plen b
-  in NttManagerMessage with ..
+decodeNttManagerMessage b = case runGet getNttManagerMessage b of
+  Right a -> a
+  Left e -> error ("ntt: bad NttManagerMessage " <> e)
 
 ----------------------------------------------------------------------
 -- WormholeTransceiverMessage (the Wormhole VAA payload)
@@ -138,19 +149,20 @@ encodeWormholeTransceiverMessage w =
     <> encodeLengthPrefixed w.managerPayload
     <> encodeLengthPrefixed w.transceiverPayload
 
+-- | The 'Get' counterpart of 'decodeWormholeTransceiverMessage'.
+getWormholeTransceiverMessage : Get WormholeTransceiverMessage
+getWormholeTransceiverMessage = do
+  assertPrefix wormholeTransceiverPrefix
+  sourceManager <- getBytes32
+  recipientManager <- getBytes32
+  managerPayload <- getLengthPrefixed
+  transceiverPayload <- getLengthPrefixed
+  pure WormholeTransceiverMessage with ..
+
 decodeWormholeTransceiverMessage : Bytes -> WormholeTransceiverMessage
-decodeWormholeTransceiverMessage b =
-  let prefix = normalizeHex (sliceBytes 0 4 b)
-      sourceManager = normalizeHex (sliceBytes 4 32 b)
-      recipientManager = normalizeHex (sliceBytes 36 32 b)
-      mlen = bytesToInt (sliceBytes 68 2 b)
-      managerPayload = sliceBytes 70 mlen b
-      tOffset = 70 + mlen
-      tlen = bytesToInt (sliceBytes tOffset 2 b)
-      transceiverPayload = sliceBytes (tOffset + 2) tlen b
-  in if prefix /= wormholeTransceiverPrefix
-       then error ("ntt: bad WormholeTransceiver prefix: " <> prefix)
-       else WormholeTransceiverMessage with ..
+decodeWormholeTransceiverMessage b = case runGet getWormholeTransceiverMessage b of
+  Right a -> a
+  Left e -> error ("ntt: bad WormholeTransceiver " <> e)
 
 ----------------------------------------------------------------------
 -- NTT governance packets
@@ -257,43 +269,51 @@ encodeNttGovernance = \case
       <> leftPadTo 32 peerTransceiverAddress
       <> intToHexByte peerDecimals
 
+-- | The 'Get' counterpart of 'parseNttGovernance'. Each action reads its own
+-- fields and nothing more; a packet longer than the action's layout is caught
+-- by 'runGet''s end-of-input check.
+getNttGovernance : Get NttGovernanceAction
+getNttGovernance = do
+  moduleId <- getBytes32
+  if moduleId /= nttGovernanceModule
+    then abort "not the Ntt module"
+    else do
+      action <- getUint8
+      chain <- getUint16
+      case action of
+        1 -> do
+          managerAddress <- getBytes32
+          factoryEpoch <- getUint64
+          pure AcceptAdminToGovernance with chain, managerAddress, factoryEpoch
+        2 -> do
+          registrationBinding <- getBytes32
+          tokenDecimals <- getUint8
+          pure RegisterBurnMintManager with chain, registrationBinding, tokenDecimals
+        3 -> do
+          managerAddress <- getBytes32
+          factoryEpoch <- getUint64
+          pure RotateToCanonicalFactory with chain, managerAddress, factoryEpoch
+        4 -> do
+          managerAddress <- getBytes32
+          peerEpoch <- getUint64
+          peerChain <- getUint16
+          peerManagerAddress <- getBytes32
+          peerTransceiverAddress <- getBytes32
+          peerDecimals <- getUint8
+          pure SetPeerByGovernance with
+            chain, managerAddress, peerEpoch, peerChain
+            peerManagerAddress, peerTransceiverAddress, peerDecimals
+        _ -> abort ("unsupported action " <> show action)
+
 -- | Parse an NTT governance packet: verify module = "Ntt", dispatch on action
 -- id, abort (via 'error') on wrong module/unknown action/malformed input.
 -- Callers only reach this after VAA signature verification, so a parse
 -- failure here means a genuinely guardian-signed VAA for the wrong purpose,
 -- not a forgery.
 parseNttGovernance : Bytes -> NttGovernanceAction
-parseNttGovernance payload =
-  let
-    moduleId = normalizeHex (sliceBytes 0 32 payload)
-    action = bytesToInt (sliceBytes 32 1 payload)
-    chain = bytesToInt (sliceBytes 33 2 payload)
-    managerAddress = normalizeHex (sliceBytes 35 32 payload)
-  in
-    if moduleId /= nttGovernanceModule
-      then error "ntt governance: not the Ntt module"
-      else case action of
-        1 -> AcceptAdminToGovernance
-               chain
-               managerAddress
-               (bytesToInt (sliceBytes 67 8 payload))
-        2 -> RegisterBurnMintManager
-               chain
-               managerAddress
-               (bytesToInt (sliceBytes 67 1 payload))
-        3 -> RotateToCanonicalFactory
-               chain
-               managerAddress
-               (bytesToInt (sliceBytes 67 8 payload))
-        4 -> SetPeerByGovernance
-               chain
-               managerAddress
-               (bytesToInt (sliceBytes 67 8 payload))
-               (bytesToInt (sliceBytes 75 2 payload))
-               (normalizeHex (sliceBytes 77 32 payload))
-               (normalizeHex (sliceBytes 109 32 payload))
-               (bytesToInt (sliceBytes 141 1 payload))
-        _ -> error ("ntt governance: unsupported action " <> show action)
+parseNttGovernance payload = case runGet getNttGovernance payload of
+  Right a -> a
+  Left e -> error ("ntt governance: " <> e)
 
 ----------------------------------------------------------------------
 -- TransceiverRegistration / TransceiverInit
@@ -319,14 +339,20 @@ encodeTransceiverRegistration r =
     <> intToBytesN r.peerChain 2
     <> leftPadTo 32 r.peerAddress
 
+-- | The 'Get' counterpart of 'decodeTransceiverRegistration'. Its 38-byte
+-- fixed size follows from consuming exactly these fields plus 'runGet''s end
+-- check; no separate length assertion is needed.
+getTransceiverRegistration : Get TransceiverRegistration
+getTransceiverRegistration = do
+  assertPrefix wormholePeerRegistrationPrefix
+  peerChain <- getUint16
+  peerAddress <- getBytes32
+  pure TransceiverRegistration with ..
+
 decodeTransceiverRegistration : Bytes -> TransceiverRegistration
-decodeTransceiverRegistration b =
-  let prefix = normalizeHex (sliceBytes 0 4 b)
-      peerChain = bytesToInt (sliceBytes 4 2 b)
-      peerAddress = normalizeHex (sliceBytes 6 32 b)
-  in if prefix /= wormholePeerRegistrationPrefix
-       then error ("ntt: bad TransceiverRegistration prefix: " <> prefix)
-       else TransceiverRegistration with ..
+decodeTransceiverRegistration b = case runGet getTransceiverRegistration b of
+  Right a -> a
+  Left e -> error ("ntt: bad TransceiverRegistration " <> e)
 
 -- | The accountant's record of a deployment's manager/token behind a
 -- transceiver. 70 bytes. @nttManagerMode@: 0 = LockUnlock, 1 = BurnMint.
@@ -345,16 +371,22 @@ encodeTransceiverInit i =
     <> leftPadTo 32 i.tokenAddress
     <> intToHexByte i.tokenDecimals
 
+-- | The 'Get' counterpart of 'decodeTransceiverInit'. Its 70-byte fixed size
+-- follows from consuming exactly these fields plus 'runGet''s end check; no
+-- separate length assertion is needed.
+getTransceiverInit : Get TransceiverInit
+getTransceiverInit = do
+  assertPrefix wormholeTransceiverInitPrefix
+  nttManagerAddress <- getBytes32
+  nttManagerMode <- getUint8
+  tokenAddress <- getBytes32
+  tokenDecimals <- getUint8
+  pure TransceiverInit with ..
+
 decodeTransceiverInit : Bytes -> TransceiverInit
-decodeTransceiverInit b =
-  let prefix = normalizeHex (sliceBytes 0 4 b)
-      nttManagerAddress = normalizeHex (sliceBytes 4 32 b)
-      nttManagerMode = bytesToInt (sliceBytes 36 1 b)
-      tokenAddress = normalizeHex (sliceBytes 37 32 b)
-      tokenDecimals = bytesToInt (sliceBytes 69 1 b)
-  in if prefix /= wormholeTransceiverInitPrefix
-       then error ("ntt: bad TransceiverInit prefix: " <> prefix)
-       else TransceiverInit with ..
+decodeTransceiverInit b = case runGet getTransceiverInit b of
+  Right a -> a
+  Left e -> error ("ntt: bad TransceiverInit " <> e)
 
 -- | Domain-separation tag for the token-address binding.
 nttTokenAddressTag : Text

--- a/canton/test/daml/Test/TestGet.daml
+++ b/canton/test/daml/Test/TestGet.daml
@@ -1,0 +1,39 @@
+-- | Unit tests for the 'Wormhole.Ntt.Get' parser primitives, independent of
+-- any concrete NTT wire structure.
+module Test.TestGet where
+
+import Daml.Script
+import DA.Assert ((===))
+import DA.Text (isInfixOf)
+
+import Wormhole.Ntt.Get
+import Wormhole.Ntt.Payload (encodeLengthPrefixed)
+
+-- | 'getBytes' fails, rather than slicing past the end, when fewer bytes
+-- remain than requested.
+testGetBytesPastEnd : Script ()
+testGetBytesPastEnd =
+  case runGet (getBytes 5) "aabb" of
+    Right _ -> abort "expected a bounds failure past the end of input"
+    Left e -> assertMsg ("expected a bounds message, got: " <> e) ("need 5 bytes" `isInfixOf` e)
+
+-- | 'runGet' rejects a parser that leaves bytes unconsumed, even when every
+-- individual field it read was in bounds.
+testRunGetRejectsLeftoverBytes : Script ()
+testRunGetRejectsLeftoverBytes =
+  case runGet (getBytes 2) "aabbcc" of
+    Right _ -> abort "expected runGet to reject the trailing byte"
+    Left e -> assertMsg ("expected a trailing-bytes message, got: " <> e) ("left over" `isInfixOf` e)
+
+-- | 'getLengthPrefixed' recovers exactly what 'encodeLengthPrefixed' wrote.
+testLengthPrefixedRoundTrip : Script ()
+testLengthPrefixedRoundTrip = do
+  let payload = "deadbeef00112233"
+  runGet getLengthPrefixed (encodeLengthPrefixed payload) === Right payload
+
+-- | A failing parser short-circuits: nothing sequenced after it runs, so its
+-- error is the only one that can surface, no matter what would happen next.
+testShortCircuitsOnFirstFailure : Script ()
+testShortCircuitsOnFirstFailure =
+  runGet (abort "first failure" >>= \_ -> pure "shouldNeverAppear") "aabb"
+    === Left "first failure"

--- a/canton/test/daml/Test/TestNttVectors.daml
+++ b/canton/test/daml/Test/TestNttVectors.daml
@@ -12,12 +12,33 @@ module Test.TestNttVectors where
 
 import Daml.Script
 import DA.Assert ((===))
+import DA.Exception (GeneralError (..))
+import DA.Text (isInfixOf)
 
 import Splice.Api.Token.HoldingV1 (InstrumentId (..))
 
 import Wormhole.Core.Bytes
 import Wormhole.Ntt.Amount
 import Wormhole.Ntt.Payload
+
+-- | Run a decode call, catching a decoder's 'error'. The decoders are pure
+-- and signal malformed input via 'error', so this plays the role
+-- 'expectAbort' (in "Test.TestNtt") plays for ledger-level failures. Takes
+-- the decode call suspended behind @()@ so it is only forced inside 'try'.
+expectDecodeError : (Show a, Eq a) => Text -> (() -> a) -> Script ()
+expectDecodeError needle decode = do
+  outcome <- try
+      do
+        let decoded = decode ()
+        decoded === decoded
+        pure None
+    catch
+      GeneralError msg -> pure (Some msg)
+  case outcome of
+    Some msg ->
+      assertMsg ("expected failure containing '" <> needle <> "', got: " <> msg)
+        (needle `isInfixOf` msg)
+    None -> abort ("decoding succeeded; expected failure containing '" <> needle <> "'")
 
 ----------------------------------------------------------------------
 -- The canonical shared TransceiverMessage vector
@@ -95,6 +116,17 @@ testVectorTransceiverMessage1 = do
   mm.sender === vecSender
   decodeNativeTokenTransfer mm.payload === vecNtt
 
+-- | The buffer must end exactly where the message ends: one byte appended to
+-- the reference vector is rejected at both the outer 'WormholeTransceiverMessage'
+-- layer and the nested 'NttManagerMessage' layer.
+testVectorExactLengthTransceiverAndManager : Script ()
+testVectorExactLengthTransceiverAndManager = do
+  expectDecodeError "bad WormholeTransceiver length"
+    (\() -> decodeWormholeTransceiverMessage (transceiverMessage1 <> "ff"))
+  let wm = decodeWormholeTransceiverMessage transceiverMessage1
+  expectDecodeError "bad NttManagerMessage length"
+    (\() -> decodeNttManagerMessage (wm.managerPayload <> "ff"))
+
 ----------------------------------------------------------------------
 -- The 32-byte-additionalPayload vector
 -- (transceiver_message_with_32byte_payload.txt, 251 bytes).
@@ -121,6 +153,12 @@ testVectorAdditionalPayload = do
       ntt = decodeNativeTokenTransfer mm.payload
   ntt === vecNtt32
   ntt.additionalPayload === "deadbeef000000000000000000000000000000000000000000000000deadbeef"
+
+-- | One byte appended to the 32-byte-payload encoding is rejected.
+testVectorExactLengthNativeTokenTransferWithPayload : Script ()
+testVectorExactLengthNativeTokenTransferWithPayload =
+  expectDecodeError "bad NativeTokenTransfer length"
+    (\() -> decodeNativeTokenTransfer (encodeNativeTokenTransfer vecNtt32 <> "ff"))
 
 ----------------------------------------------------------------------
 -- The non-canonical empty-payload vector
@@ -150,6 +188,14 @@ testVectorNonCanonicalEmptyPayload = do
   assert (encodeNativeTokenTransfer decoded /= emptyPayloadInnerNtt)
   byteLength emptyPayloadInnerNtt === 81
   byteLength (encodeNativeTokenTransfer decoded) === 79
+
+-- | One byte appended to the non-canonical (explicit-zero-length) form above
+-- is rejected: the buffer must end exactly where the message ends even when
+-- the empty 'additionalPayload' is spelled out rather than omitted.
+testVectorExactLengthNativeTokenTransferNoPayload : Script ()
+testVectorExactLengthNativeTokenTransferNoPayload =
+  expectDecodeError "bad NativeTokenTransfer length"
+    (\() -> decodeNativeTokenTransfer (emptyPayloadInnerNtt <> "ff"))
 
 ----------------------------------------------------------------------
 -- TrimmedAmount numeric vectors, ported from
@@ -263,6 +309,12 @@ testVectorTransceiverRegistration = do
   byteLength transceiverRegistration1 === 38
   decodeTransceiverRegistration transceiverRegistration1 === vecTransceiverRegistration
 
+-- | One byte appended to the fixture is rejected.
+testVectorTransceiverRegistrationExactLength : Script ()
+testVectorTransceiverRegistrationExactLength =
+  expectDecodeError "bad TransceiverRegistration length"
+    (\() -> decodeTransceiverRegistration (transceiverRegistration1 <> "ff"))
+
 ----------------------------------------------------------------------
 -- TransceiverInit vector (evm/test/payloads/transceiver_info_1.txt, 70 bytes:
 -- prefix ‖ manager hex"BABABABABABA" ‖ mode=LOCKING(0) ‖ token
@@ -292,6 +344,12 @@ testVectorTransceiverInit = do
   byteLength transceiverInit1 === 70
   decodeTransceiverInit transceiverInit1 === vecTransceiverInit
 
+-- | One byte appended to the fixture is rejected.
+testVectorTransceiverInitExactLength : Script ()
+testVectorTransceiverInitExactLength =
+  expectDecodeError "bad TransceiverInit length"
+    (\() -> decodeTransceiverInit (transceiverInit1 <> "ff"))
+
 ----------------------------------------------------------------------
 -- NTT governance action 4 (SetPeerByGovernance) vector: module(32) ‖
 -- action(1)=04 ‖ chain(2) ‖ managerAddress(32) ‖ peerEpoch(8) ‖ peerChain(2) ‖
@@ -319,6 +377,12 @@ testVectorNttGovernanceSetPeer = do
   encodeNttGovernance vecSetPeerAction === nttGovernanceSetPeer1
   byteLength nttGovernanceSetPeer1 === 142
   parseNttGovernance nttGovernanceSetPeer1 === vecSetPeerAction
+
+-- | One byte appended to the fixture is rejected.
+testVectorNttGovernanceSetPeerExactLength : Script ()
+testVectorNttGovernanceSetPeerExactLength =
+  expectDecodeError "ntt governance: length"
+    (\() -> parseNttGovernance (nttGovernanceSetPeer1 <> "ff"))
 
 ----------------------------------------------------------------------
 -- Token-address vector: Canton's InstrumentId -> Bytes32 stand-in for


### PR DESCRIPTION
Replaces the manual offset arithmetic in the NTT wire decoders with a small `Get` parser monad, and closes audit finding F7 (trailing bytes past a decoded message were silently ignored where the EVM reference enforces exact length) as a property of the runner rather than six hand-written assertions.

Not exploitable today — the VAA is guardian-signed, replay keys on the VAA hash, and no digest is re-derived from decoded content — so this is parity and readability, not a fix.

**`Wormhole.Ntt.Get`** (new): `newtype Get a = Get (Bytes -> Int -> Either Text (a, Int))` with `Functor`/`Applicative`/`Action` instances, following `DA.Action.State` as the in-stdlib precedent for a user-space monad. Failure is a `Left`: `ActionFail` carries the mechanism (and desugars failing pattern matches in `do` notation) while `CanAbort` is the surface parsers call, mirroring how the standard library treats `Either Text` (`instance CanAbort (Either Text) where abort = fail`).

Primitives are named after the schema types rather than byte counts — `getUint8`/`getUint16`/`getUint64`/`getBytes32`, plus `getBytes n` where the width genuinely varies and `getLengthPrefixed` mirroring `encodeLengthPrefixed` — so a decoder cannot ask for a width the protocol has no field of. `uint` rather than `int` matches the field comments already in the file; the primitives document that Daml's signed `Int` means a uint64 at or above 2^63 does not round-trip, which `testAmountUint64Bound` already pins.

**`runGet`** runs from offset 0 and requires the parser to consume the buffer exactly. That single check replaces every per-decoder length assertion, including the per-action ones in `parseNttGovernance`, which also removes the hardcoded 75/68/75/142 byte counts. This matters beyond tidiness: a parser that asserts "nothing remains in the whole buffer" is making a claim about the buffer rather than about its own fields, so it cannot be sequenced or nested — `getNttGovernance` is now a composable `Get` like any other.

Each schema's leading tag is consumed by `assertPrefix`, which sizes itself from the expected value, so every parser is a flat sequence of fields with no guard nesting.

Decoders keep their existing signatures and failure behaviour (`decodeX : Bytes -> X`, aborting via `error`), so **no call site changes anywhere**. Each one calls `runGet` directly and names its own type in the message, since `runGet` is generic — that is what keeps the existing message-substring assertions passing. The `Get`-returning parsers are exported alongside for callers that would rather have `Either`.

Governance actions are constructed with named fields instead of positionally. Actions 1 and 3 have identical field types (`Int`, `Bytes32`, `Int`), so a positional slip between those branches would have compiled silently.

Verification: `TestNttVectors.daml` gains the six trailing-byte rejection cases and changes exactly one existing line — the governance assertion now matches `"ntt governance: length"` instead of naming the action, since that text moved with the check. Everything else in that file, including the byte-for-byte `transceiver_message_1` reference vector shared with EVM, passes untouched, which is the evidence the codec itself is unchanged. `TestGet.daml` adds four unit tests for the primitives: bounds failure past end of input, leftover-byte rejection, `getLengthPrefixed` round-tripping against the encoder, and short-circuiting on the first failure.

Gates: `dpm build --all` clean; `dpm test` 165 scripts ok, 0 failed (rebased onto the current base, after #64/#65/#66/#68 merged).
