### PR TITLE
canton: commit the outbound sourceToken and identify the sending party in the wire message

### DIFF
--- a/canton/ntt/daml/Wormhole/Ntt/Manager.daml
+++ b/canton/ntt/daml/Wormhole/Ntt/Manager.daml
@@ -871,7 +871,6 @@ template NttManager
         ledgerCid             : Optional (ContractId LockedLedger)  -- required for lock/unlock
         recipientChain        : Int
         recipientAddress      : Bytes32
-        sourceToken           : Bytes32
         rawAmount             : Int      -- integer units at tokenDecimals
         nonce                 : Int
         consistencyLevel      : Int
@@ -965,13 +964,13 @@ template NttManager
         let ntt = NativeTokenTransfer with
               decimals = trimmed.decimals
               amount = trimmed.amount
-              sourceToken = normalizeHex sourceToken
+              sourceToken = tokenAddress
               recipientAddress = normalizeHex recipientAddress
               recipientChain
               additionalPayload = ""
             mm = NttManagerMessage with
               id = leftPadTo 32 (intToBytesN transceiver.sequence 8)
-              sender = managerAddress
+              sender = recipientAddressFor user
               payload = encodeNativeTokenTransfer ntt
             wm = WormholeTransceiverMessage with
               sourceManager = managerAddress

--- a/canton/test/daml/Test/TestFactoryAuthority.daml
+++ b/canton/test/daml/Test/TestFactoryAuthority.daml
@@ -499,7 +499,6 @@ testExternalMinterMaliciousFactoryFirewallsGg = do
       ledgerCid = None
       recipientChain = 2
       recipientAddress = b32 "ee"
-      sourceToken = b32 "dd"
       rawAmount = 100000000
       nonce = 0
       consistencyLevel = 0

--- a/canton/test/daml/Test/TestNtt.daml
+++ b/canton/test/daml/Test/TestNtt.daml
@@ -515,7 +515,6 @@ testTransceiverIsDeploymentBound = do
       ledgerCid = dA.ledgerCid
       recipientChain = 2
       recipientAddress = b32 "ee"
-      sourceToken = b32 "dd"
       rawAmount = 1000000
       nonce = 0
       consistencyLevel = 0
@@ -1200,7 +1199,6 @@ sendTransfer user d csId holdings =
     ledgerCid = d.ledgerCid
     recipientChain = 2
     recipientAddress = b32 "ee"
-    sourceToken = b32 "dd"
     rawAmount = 1000000
     nonce = 0
     consistencyLevel = 0
@@ -1252,7 +1250,6 @@ testTransferLockAccounting = do
       ledgerCid = Some ledgerCid
       recipientChain = 2
       recipientAddress = b32 "ee"
-      sourceToken = b32 "dd"
       rawAmount = 500000
       nonce = 1
       consistencyLevel = 0
@@ -1306,7 +1303,6 @@ testTransferTrimsToPeerDecimals = do
           ledgerCid = d'.ledgerCid
           recipientChain = chainId
           recipientAddress = b32 "ee"
-          sourceToken = b32 "dd"
           rawAmount
           nonce = 0
           consistencyLevel = 0
@@ -1514,7 +1510,6 @@ testTransferLockRejectsForgedCustodyPot = do
       ledgerCid = Some poisonedLedgerCid
       recipientChain = 2
       recipientAddress = b32 "ee"
-      sourceToken = b32 "dd"
       rawAmount = 1000000
       nonce = 0
       consistencyLevel = 0
@@ -1545,7 +1540,6 @@ testLockPendingSettlementRejected = do
       ledgerCid = d.ledgerCid
       recipientChain = 2
       recipientAddress = b32 "ee"
-      sourceToken = b32 "dd"
       rawAmount = 1000000
       nonce = 0
       consistencyLevel = 0
@@ -1682,7 +1676,6 @@ testTransferAdminToGg = do
       ledgerCid = Some ledgerCid
       recipientChain = 2
       recipientAddress = b32 "ee"
-      sourceToken = b32 "dd"
       rawAmount = 500000
       nonce = 1
       consistencyLevel = 0
@@ -2045,7 +2038,6 @@ testTransferArgumentChecks = do
       ledgerCid = d.ledgerCid
       recipientChain = 2
       recipientAddress = b32 "ee"
-      sourceToken = b32 "dd"
       rawAmount = 0
       nonce = 0
       consistencyLevel = 0
@@ -2214,7 +2206,6 @@ testNttSend = do
         ledgerCid = d'.ledgerCid
         recipientChain = 2
         recipientAddress = b32 "ee"
-        sourceToken = b32 "dd"
         rawAmount = 1000000
         nonce = 7
         consistencyLevel = 0
@@ -2230,6 +2221,15 @@ testNttSend = do
   feePay <- mintAndAllocate mockAdmin alice feeRecipient inst (feeToDecimal 1000)
   msg <- submitWithDiscs alice discs do doTransfer (Some feePay)
   msg.sequence === 2   -- deploy's TransceiverInit (0) and SetPeer's registration (1) precede this Transfer
+
+  -- The wire NativeTokenTransfer carries the deployment's own bridged token,
+  -- and the manager message's sender identifies alice, not the deployment.
+  let wm = decodeWormholeTransceiverMessage msg.payload
+      mm = decodeNttManagerMessage wm.managerPayload
+      ntt = decodeNativeTokenTransfer mm.payload
+  ntt.sourceToken === mgr.tokenAddress
+  mm.sender === recipientAddressFor alice
+  assert (mm.sender /= mgr.managerAddress)
 
   [(_, em)] <- query @Emitter gg
   em.sequence === 3
@@ -2306,7 +2306,6 @@ testNttTransferByDifferentUser = do
       ledgerCid = d'.ledgerCid
       recipientChain = 2
       recipientAddress = b32 "ee"
-      sourceToken = b32 "dd"
       rawAmount = 1000000
       nonce = 1
       consistencyLevel = 0
@@ -2349,7 +2348,6 @@ testNttTransferRequiresUserAuthority = do
         ledgerCid = d.ledgerCid
         recipientChain = 2
         recipientAddress = b32 "ee"
-        sourceToken = b32 "dd"
         rawAmount = 1000000
         nonce = 1
         consistencyLevel = 0

--- a/canton/test/daml/Test/TestNttCoin.daml
+++ b/canton/test/daml/Test/TestNttCoin.daml
@@ -113,7 +113,6 @@ testNttCoinEndToEndRoundTrip = do
       ledgerCid = None
       recipientChain = 2
       recipientAddress = b32 "ee"
-      sourceToken = b32 "dd"
       rawAmount = 1000000
       nonce = 0
       consistencyLevel = 0


### PR DESCRIPTION
Closes audit findings F10 and F6 — two outbound wire fields that diverged from the reference. Both are metadata (nothing in the protocol authorizes on either, and no inbound path reads them), so this is parity and trustworthiness rather than a fix.

**F10 — `sourceToken` is committed, not caller-supplied.** It was a `Transfer` choice argument, hex-normalized and forwarded, so a sender could advertise any source token. EVM hardcodes the manager's own token (`toWormholeFormat(token)`, `NttManager.sol:609`). The argument is now deleted and the value comes from the manager's stored `tokenAddress`, derived by `nttTokenAddressFor` at registration and preserved across `TransferAdmin`. It is already normalized at derivation, so no re-normalization is needed.

**F6 — `sender` identifies the originating party.** It was the deployment's own `managerAddress`, so every transfer out of a deployment reported the same sender; EVM sets the initiating account (`toWormholeFormat(sender)`, `NttManager.sol:551`). It is now `recipientAddressFor user`. That reuses the existing party-address derivation rather than introducing a second domain-separation tag, so a party has one address whether it appears as a sender or a recipient — the property an indexer or an attribution lookup would expect.

Note this is a **breaking change to the `Transfer` choice signature** (one fewer argument) and it **changes bytes that leave the chain**. Anything already parsing Canton-origin messages — the global accountant, indexers, integrator attribution — will see a real source token and a per-user sender where it previously saw a caller-chosen value and a constant.

Tests: `testNttSend` now decodes the published message through all three layers and asserts `ntt.sourceToken == mgr.tokenAddress`, `mm.sender == recipientAddressFor alice`, and that the sender is no longer the manager address. The byte-for-byte reference vectors in `TestNttVectors.daml` construct payload records directly and are untouched — they still pass, which is the check that the codec was not changed, only the callers.

Follow-up for `canton/playground-merged` (that branch only, queued): `Playground/Ops.daml` passes `sourceToken` into `Transfer` (`:454`) and builds its own copy of the message (`:432`), and the CLI has a `--source-token` flag on `guardian sign-transfer` — the flag stays meaningful there since it fabricates inbound VAAs, but the outbound path must drop the argument.

Gates: `dpm build --all` clean; `dpm test` 153 scripts ok, 0 failed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wormholelabs-xyz/codesmith/native-token-transfers/pr/68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788567264&installation_model_id=15502&pr_number=68&repository=wormholelabs-xyz%2Fnative-token-transfers&return_to=https%3A%2F%2Fgithub.com%2Fwormholelabs-xyz%2Fnative-token-transfers%2Fpull%2F68&signature=4ec39caca448d36d73565aa63ea135aee8841ca54430b29c5d315571803463ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->